### PR TITLE
Ensure cmctl is installed before installing cert-manager.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -146,7 +146,7 @@ load-image-operator: docker-build kind
 	$(KIND) load docker-image $(IMG)
 
 .PHONY: cert-manager
-cert-manager:
+cert-manager: cmctl
 	kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v${CERTMANAGER_VERSION}/cert-manager.yaml
 	$(CMCTL) check api --wait=5m
 


### PR DESCRIPTION
This should fix the broken e2e build: https://github.com/datum-cloud/network-services-operator/actions/runs/13859236352/job/38783266430