### PR TITLE
Add resource metrics

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -18,6 +18,7 @@ resources:
 - ../crd
 - ../rbac
 - ../manager
+- ../resource-metrics
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
 #- ../webhook

--- a/config/resource-metrics/general.yaml
+++ b/config/resource-metrics/general.yaml
@@ -1,0 +1,20 @@
+kind: CustomResourceStateMetrics
+spec:
+  resources:
+    # Creates a generic metric for all resources
+    - groupVersionKind:
+        group: networking.datumapis.com
+        kind: "*"
+        version: "*"
+      metricNamePrefix: "datum_cloud_resource"
+      labelsFromPath:
+        namespace: [metadata, namespace]
+        name: [metadata, name]
+      metrics:
+        - name: "info"
+          help: "Information about the resource"
+          each:
+            type: Info
+            info:
+              labelsFromPath:
+                uid: [metadata, uid]

--- a/config/resource-metrics/kustomization.yaml
+++ b/config/resource-metrics/kustomization.yaml
@@ -4,6 +4,7 @@ kind: Kustomization
 configMapGenerator:
   - name: network-services-metrics
     files:
+      - general.yaml
       - network-bindings.yaml
       - network-contexts.yaml
       - network-policies.yaml

--- a/config/resource-metrics/kustomization.yaml
+++ b/config/resource-metrics/kustomization.yaml
@@ -1,0 +1,16 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+configMapGenerator:
+  - name: network-services-metrics
+    files:
+      - network-bindings.yaml
+      - network-contexts.yaml
+      - network-policies.yaml
+      - networks.yaml
+      - subnet-claims.yaml
+      - subnets.yaml
+      - locations.yaml
+    options:
+      labels:
+        telemetry.datumapis.com/resource-metrics-config: "true"

--- a/config/resource-metrics/locations.yaml
+++ b/config/resource-metrics/locations.yaml
@@ -5,7 +5,7 @@ spec:
         group: networking.datumapis.com
         kind: Location
         version: v1alpha
-      metricNamePrefix: "location"
+      metricNamePrefix: "datum_cloud_location"
       labelsFromPath:
         namespace: [metadata, namespace]
         name: [metadata, name]

--- a/config/resource-metrics/locations.yaml
+++ b/config/resource-metrics/locations.yaml
@@ -1,0 +1,30 @@
+kind: CustomResourceStateMetrics
+spec:
+  resources:
+    - groupVersionKind:
+        group: networking.datumapis.com
+        kind: Location
+        version: v1alpha
+      metricNamePrefix: "location"
+      labelsFromPath:
+        namespace: [metadata, namespace]
+        name: [metadata, name]
+      metrics:
+        - name: "info"
+          help: "Information about location"
+          each:
+            type: Info
+            info:
+              labelsFromPath:
+                uid: [metadata, uid]
+        - name: "status_condition"
+          help: "The current status conditions of the location"
+          each:
+            type: Gauge
+            gauge:
+              path: [status, conditions]
+              labelsFromPath:
+                condition: [type]
+                reason: [reason]
+                status: [status]
+              valueFrom: [status]

--- a/config/resource-metrics/network-bindings.yaml
+++ b/config/resource-metrics/network-bindings.yaml
@@ -1,0 +1,32 @@
+kind: CustomResourceStateMetrics
+spec:
+  resources:
+    - groupVersionKind:
+        group: networking.datumapis.com
+        kind: NetworkBinding
+        version: v1alpha
+      metricNamePrefix: "network_binding"
+      labelsFromPath:
+        namespace: [metadata, namespace]
+        name: [metadata, name]
+        network_name: [spec, network, name]
+        network_namespace: [spec, network, namespace]
+      metrics:
+        - name: "info"
+          help: "Information about network binding"
+          each:
+            type: Info
+            info:
+              labelsFromPath:
+                uid: [metadata, uid]
+        - name: "status_condition"
+          help: "The current status conditions of the network binding"
+          each:
+            type: Gauge
+            gauge:
+              path: [status, conditions]
+              labelsFromPath:
+                condition: [type]
+                reason: [reason]
+                status: [status]
+              valueFrom: [status]

--- a/config/resource-metrics/network-bindings.yaml
+++ b/config/resource-metrics/network-bindings.yaml
@@ -5,7 +5,7 @@ spec:
         group: networking.datumapis.com
         kind: NetworkBinding
         version: v1alpha
-      metricNamePrefix: "network_binding"
+      metricNamePrefix: "datum_cloud_network_binding"
       labelsFromPath:
         namespace: [metadata, namespace]
         name: [metadata, name]

--- a/config/resource-metrics/network-contexts.yaml
+++ b/config/resource-metrics/network-contexts.yaml
@@ -1,0 +1,30 @@
+kind: CustomResourceStateMetrics
+spec:
+  resources:
+    - groupVersionKind:
+        group: networking.datumapis.com
+        kind: NetworkContext
+        version: v1alpha
+      metricNamePrefix: "network_context"
+      labelsFromPath:
+        namespace: [metadata, namespace]
+        name: [metadata, name]
+      metrics:
+        - name: "info"
+          help: "Information about network context"
+          each:
+            type: Info
+            info:
+              labelsFromPath:
+                uid: [metadata, uid]
+        - name: "status_condition"
+          help: "The current status conditions of the network context"
+          each:
+            type: Gauge
+            gauge:
+              path: [status, conditions]
+              labelsFromPath:
+                condition: [type]
+                reason: [reason]
+                status: [status]
+              valueFrom: [status]

--- a/config/resource-metrics/network-contexts.yaml
+++ b/config/resource-metrics/network-contexts.yaml
@@ -5,7 +5,7 @@ spec:
         group: networking.datumapis.com
         kind: NetworkContext
         version: v1alpha
-      metricNamePrefix: "network_context"
+      metricNamePrefix: "datum_cloud_network_context"
       labelsFromPath:
         namespace: [metadata, namespace]
         name: [metadata, name]

--- a/config/resource-metrics/network-policies.yaml
+++ b/config/resource-metrics/network-policies.yaml
@@ -1,0 +1,30 @@
+kind: CustomResourceStateMetrics
+spec:
+  resources:
+    - groupVersionKind:
+        group: networking.datumapis.com
+        kind: NetworkPolicy
+        version: v1alpha
+      metricNamePrefix: "network_policy"
+      labelsFromPath:
+        namespace: [metadata, namespace]
+        name: [metadata, name]
+      metrics:
+        - name: "info"
+          help: "Information about network policy"
+          each:
+            type: Info
+            info:
+              labelsFromPath:
+                uid: [metadata, uid]
+        - name: "status_condition"
+          help: "The current status conditions of the network policy"
+          each:
+            type: Gauge
+            gauge:
+              path: [status, conditions]
+              labelsFromPath:
+                condition: [type]
+                reason: [reason]
+                status: [status]
+              valueFrom: [status]

--- a/config/resource-metrics/network-policies.yaml
+++ b/config/resource-metrics/network-policies.yaml
@@ -5,7 +5,7 @@ spec:
         group: networking.datumapis.com
         kind: NetworkPolicy
         version: v1alpha
-      metricNamePrefix: "network_policy"
+      metricNamePrefix: "datum_cloud_network_policy"
       labelsFromPath:
         namespace: [metadata, namespace]
         name: [metadata, name]

--- a/config/resource-metrics/networks.yaml
+++ b/config/resource-metrics/networks.yaml
@@ -1,0 +1,30 @@
+kind: CustomResourceStateMetrics
+spec:
+  resources:
+    - groupVersionKind:
+        group: networking.datumapis.com
+        kind: Network
+        version: v1alpha
+      metricNamePrefix: "network"
+      labelsFromPath:
+        namespace: [metadata, namespace]
+        name: [metadata, name]
+      metrics:
+        - name: "info"
+          help: "Information about network"
+          each:
+            type: Info
+            info:
+              labelsFromPath:
+                uid: [metadata, uid]
+        - name: "status_condition"
+          help: "The current status conditions of the network"
+          each:
+            type: Gauge
+            gauge:
+              path: [status, conditions]
+              labelsFromPath:
+                condition: [type]
+                reason: [reason]
+                status: [status]
+              valueFrom: [status]

--- a/config/resource-metrics/networks.yaml
+++ b/config/resource-metrics/networks.yaml
@@ -5,7 +5,7 @@ spec:
         group: networking.datumapis.com
         kind: Network
         version: v1alpha
-      metricNamePrefix: "network"
+      metricNamePrefix: "datum_cloud_network"
       labelsFromPath:
         namespace: [metadata, namespace]
         name: [metadata, name]

--- a/config/resource-metrics/subnet-claims.yaml
+++ b/config/resource-metrics/subnet-claims.yaml
@@ -5,7 +5,7 @@ spec:
         group: networking.datumapis.com
         kind: SubnetClaim
         version: v1alpha
-      metricNamePrefix: "subnet_claim"
+      metricNamePrefix: "datum_cloud_subnet_claim"
       labelsFromPath:
         namespace: [metadata, namespace]
         name: [metadata, name]

--- a/config/resource-metrics/subnet-claims.yaml
+++ b/config/resource-metrics/subnet-claims.yaml
@@ -1,0 +1,35 @@
+kind: CustomResourceStateMetrics
+spec:
+  resources:
+    - groupVersionKind:
+        group: networking.datumapis.com
+        kind: SubnetClaim
+        version: v1alpha
+      metricNamePrefix: "subnet_claim"
+      labelsFromPath:
+        namespace: [metadata, namespace]
+        name: [metadata, name]
+        network_name: [spec, network, name]
+        network_namespace: [spec, network, namespace]
+      metrics:
+        - name: "info"
+          help: "Information about subnet claim"
+          each:
+            type: Info
+            info:
+              labelsFromPath:
+                uid: [metadata, uid]
+                cloud_datum_net_network_context: [metadata, labels, cloud_datum_net_network_context]
+                gcp_topology_datum_net_project: [metadata, labels, gcp_topology_datum_net_project]
+                gcp_topology_datum_net_region: [metadata, labels, gcp_topology_datum_net_region]
+        - name: "status_condition"
+          help: "The current status conditions of the subnet claim"
+          each:
+            type: Gauge
+            gauge:
+              path: [status, conditions]
+              labelsFromPath:
+                condition: [type]
+                reason: [reason]
+                status: [status]
+              valueFrom: [status]

--- a/config/resource-metrics/subnets.yaml
+++ b/config/resource-metrics/subnets.yaml
@@ -5,7 +5,7 @@ spec:
         group: networking.datumapis.com
         kind: Subnet
         version: v1alpha
-      metricNamePrefix: "subnet"
+      metricNamePrefix: "datum_cloud_subnet"
       labelsFromPath:
         namespace: [metadata, namespace]
         name: [metadata, name]

--- a/config/resource-metrics/subnets.yaml
+++ b/config/resource-metrics/subnets.yaml
@@ -1,0 +1,32 @@
+kind: CustomResourceStateMetrics
+spec:
+  resources:
+    - groupVersionKind:
+        group: networking.datumapis.com
+        kind: Subnet
+        version: v1alpha
+      metricNamePrefix: "subnet"
+      labelsFromPath:
+        namespace: [metadata, namespace]
+        name: [metadata, name]
+        network_name: [spec, network, name]
+        network_namespace: [spec, network, namespace]
+      metrics:
+        - name: "info"
+          help: "Information about subnet"
+          each:
+            type: Info
+            info:
+              labelsFromPath:
+                uid: [metadata, uid]
+        - name: "status_condition"
+          help: "The current status conditions of the subnet"
+          each:
+            type: Gauge
+            gauge:
+              path: [status, conditions]
+              labelsFromPath:
+                condition: [type]
+                reason: [reason]
+                status: [status]
+              valueFrom: [status]


### PR DESCRIPTION
This adds new configuration files to the kustomize deployment of the operator to install ConfigMaps that contain the kube-state-metrics configuration required to collect metrics for the custom resources managed by this operator.