### PR TITLE
Remove constraint that required backendRefs for all rules

### DIFF
--- a/internal/validation/httproute_validation.go
+++ b/internal/validation/httproute_validation.go
@@ -123,10 +123,6 @@ func validateHTTPRouteFilter(filter gatewayv1.HTTPRouteFilter, fldPath *field.Pa
 func validateHTTPRouteRuleBackendRefs(route *gatewayv1.HTTPRoute, rule gatewayv1.HTTPRouteRule, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	if len(rule.BackendRefs) == 0 {
-		allErrs = append(allErrs, field.Required(fldPath, "HTTPRoute rule must have at least one backend ref"))
-	}
-
 	for i, backendRef := range rule.BackendRefs {
 		allErrs = append(allErrs, validateHTTPBackendRef(route, backendRef, fldPath.Index(i))...)
 	}

--- a/internal/validation/httproute_validation_test.go
+++ b/internal/validation/httproute_validation_test.go
@@ -178,28 +178,6 @@ func TestValidateHTTPRoute(t *testing.T) {
 			},
 			expectedErrors: field.ErrorList{},
 		},
-		"invalid httproute with no backend refs": {
-			route: &gatewayv1.HTTPRoute{
-				Spec: gatewayv1.HTTPRouteSpec{
-					Rules: []gatewayv1.HTTPRouteRule{
-						{
-							Matches: []gatewayv1.HTTPRouteMatch{
-								{
-									Path: &gatewayv1.HTTPPathMatch{
-										Type:  ptr.To(gatewayv1.PathMatchType("PathPrefix")),
-										Value: ptr.To("/test"),
-									},
-								},
-							},
-							BackendRefs: []gatewayv1.HTTPBackendRef{},
-						},
-					},
-				},
-			},
-			expectedErrors: field.ErrorList{
-				field.Required(field.NewPath("spec", "rules").Index(0).Child("backendRefs"), ""),
-			},
-		},
 		"invalid httproute with invalid backend ref kind": {
 			route: &gatewayv1.HTTPRoute{
 				Spec: gatewayv1.HTTPRouteSpec{


### PR DESCRIPTION
The `backendRefs` field is specifically not permitted when using filters such as RequestRedirect. When originally writing validation, it looks like I was too restrictive.

See https://github.com/kubernetes-sigs/gateway-api/blob/344f8de09c63f03077743df802888d22e78712fe/apis/v1/httproute_types.go#L131-L135

The spec doesn't seem to define what to expect when no backends are defined on a rule, but we'll make sure to test and see if we get a 503 or a 404.

See https://github.com/kubernetes-sigs/gateway-api/blob/344f8de09c63f03077743df802888d22e78712fe/apis/v1/httproute_types.go#L252-L290
