### PR TITLE
Program downstream gateways to use a separate secret for each listener certificate

### DIFF
--- a/internal/util/resourcename/resourcename.go
+++ b/internal/util/resourcename/resourcename.go
@@ -1,0 +1,44 @@
+package resourcename
+
+import (
+	"crypto/md5"
+	"fmt"
+
+	validation "k8s.io/apimachinery/pkg/util/validation"
+)
+
+// GetValidDNS1123Name returns a name compliant with Kubernetes DNS-1123
+// subdomain length (253).
+// It truncates and appends an MD5 hash if the input name is too long.
+func GetValidDNS1123Name(name string) string {
+	return optionalTruncateAndHash(name, validation.DNS1123SubdomainMaxLength)
+}
+
+// GetValidDNS1035Name returns a name compliant with Kubernetes DNS-1035
+// label length (63).
+// It truncates and appends an MD5 hash if the input name is too long.
+func GetValidDNS1035Name(name string) string {
+	return optionalTruncateAndHash(name, validation.DNS1035LabelMaxLength)
+}
+
+// optionalTruncateAndHash ensures a name fits maxLength. If longer, it
+// truncates the name and appends an MD5 hash of the original name. Panics if
+// maxLength is too small for the hash suffix (33 chars).
+func optionalTruncateAndHash(name string, maxLength int) string {
+	if len(name) <= maxLength {
+		return name
+	}
+
+	hash := md5.Sum([]byte(name))
+
+	prefixLen := maxLength - 33
+	if prefixLen <= 0 {
+		panic(fmt.Sprintf("maxLength is too small: %d", maxLength))
+	}
+
+	if len(name) > prefixLen {
+		name = name[0:prefixLen]
+	}
+
+	return fmt.Sprintf("%s-%x", name, hash)
+}

--- a/internal/util/resourcename/resourcename_test.go
+++ b/internal/util/resourcename/resourcename_test.go
@@ -1,0 +1,48 @@
+package resourcename
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestOptionalTruncateAndHash(t *testing.T) {
+	tests := []struct {
+		name  string
+		fn    func(string) string
+		input string
+		want  string
+	}{
+		{
+			name:  "DNS1123 no truncation",
+			fn:    GetValidDNS1123Name,
+			input: "short",
+			want:  "short",
+		},
+		{
+			name:  "DNS1123 truncation",
+			fn:    GetValidDNS1123Name,
+			input: "long" + strings.Repeat("a", 253),
+			want:  "long" + strings.Repeat("a", 253-33-4) + "-ac7d16f7520c0ebcf3269a2d2dbda4da",
+		},
+		{
+			name:  "DNS1035 no truncation",
+			fn:    GetValidDNS1035Name,
+			input: "short",
+			want:  "short",
+		},
+		{
+			name:  "DNS1035 truncation",
+			fn:    GetValidDNS1035Name,
+			input: "long" + strings.Repeat("a", 63),
+			want:  "long" + strings.Repeat("a", 63-33-4) + "-95b923195bff3e889498eca200310834",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.fn(tt.input); got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/test/e2e/gateway/chainsaw-test.yaml
+++ b/test/e2e/gateway/chainsaw-test.yaml
@@ -329,7 +329,7 @@ spec:
                     certificateRefs:
                     - group: ""
                       kind: Secret
-                      name: test-gateway
+                      name: test-gateway-https-test-e2e
                     mode: Terminate
                 - allowedRoutes:
                     namespaces:
@@ -349,7 +349,7 @@ spec:
                     certificateRefs:
                     - group: ""
                       kind: Secret
-                      name: test-gateway
+                      name: test-gateway-https-0
                     mode: Terminate
                 - allowedRoutes:
                     namespaces:
@@ -369,7 +369,7 @@ spec:
                     certificateRefs:
                     - group: ""
                       kind: Secret
-                      name: test-gateway
+                      name: test-gateway-https-1
                     mode: Terminate
                 - allowedRoutes:
                     namespaces:
@@ -389,7 +389,7 @@ spec:
                     certificateRefs:
                     - group: ""
                       kind: Secret
-                      name: test-gateway
+                      name: test-gateway-https-2
                     mode: Terminate
               status:
                 conditions:


### PR DESCRIPTION
@scotwells pointed out that cert-manager will correctly create a `Certificate` for each unique secret referenced by a `CertificateRef` on gateway listeners, and only include the hostname defined on that listener. This will address the OverlappingTLSConfig issue observed when evaluating the latest release of Envoy Gateway - details can be found at https://github.com/envoyproxy/gateway/issues/2675.

As part of this, I've introduced a utility that provides helpers for obtaining resource names for various length limits. If an input name exceeds the length limit, it will be truncated and suffixed with a hash of the full name. This is done for ease of development - in this particular scenario, a Gateway's name can be up to 253 characters, as can the listener's name.

I also made a minor tweak to finalize logic to prevent attempting to remove a finalizer that doesn't exist, which usually leads to object not found errors as the resource has already been removed.