### PR TITLE
Add network and network context controllers to manage status conditions and teardown logic.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ go.work.sum
 .env
 
 bin/
+config/**/charts

--- a/api/v1alpha/networkbinding_types.go
+++ b/api/v1alpha/networkbinding_types.go
@@ -63,12 +63,17 @@ const (
 // +kubebuilder:subresource:status
 
 // NetworkBinding is the Schema for the networkbindings API
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
+// +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].status`
+// +kubebuilder:printcolumn:name="Reason",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].reason`
 type NetworkBinding struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// +kubebuilder:validation:Required
-	Spec   NetworkBindingSpec   `json:"spec,omitempty"`
+	Spec NetworkBindingSpec `json:"spec,omitempty"`
+
+	// +kubebuilder:default={conditions:{{type:"Ready",status:"Unknown",reason:"Pending", message:"Waiting for controller", lastTransitionTime: "1970-01-01T00:00:00Z"}}}
 	Status NetworkBindingStatus `json:"status,omitempty"`
 }
 

--- a/api/v1alpha/networkcontext_types.go
+++ b/api/v1alpha/networkcontext_types.go
@@ -26,19 +26,41 @@ type NetworkContextStatus struct {
 }
 
 const (
-	// NetworkContextReady indicates that the network context is ready for use.
+	// NetworkContextReady indicates whether or not the network context is ready for use.
 	NetworkContextReady = "Ready"
+
+	// NetworkContextProgrammed indicates whether or not the network context has been programmed.
+	NetworkContextProgrammed = "Programmed"
+)
+
+const (
+	// NetworkContextProgrammedReasonNotProgrammed indicates that the network context is not ready because it has not been programmed.
+	NetworkContextProgrammedReasonNotProgrammed = "NotProgrammed"
+
+	// NetworkContextProgrammedReasonProgramming indicates that the network context is being programmed.
+	NetworkContextProgrammedReasonProgrammingInProgress = "ProgrammingInProgress"
+
+	// NetworkContextProgrammedReasonProgrammed indicates that the network context has been programmed.
+	NetworkContextProgrammedReasonProgrammed = "Programmed"
+
+	// NetworkContextReadyReasonReady indicates that the network context is ready for use.
+	NetworkContextReadyReasonReady = "Ready"
 )
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 
 // NetworkContext is the Schema for the networkcontexts API
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
+// +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].status`
+// +kubebuilder:printcolumn:name="Reason",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].reason`
 type NetworkContext struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec   NetworkContextSpec   `json:"spec,omitempty"`
+	Spec NetworkContextSpec `json:"spec,omitempty"`
+
+	// +kubebuilder:default={conditions:{{type:"Programmed",status:"Unknown",reason:"Pending", message:"Waiting for controller", lastTransitionTime: "1970-01-01T00:00:00Z"},{type:"Ready",status:"Unknown",reason:"Pending", message:"Waiting for controller", lastTransitionTime: "1970-01-01T00:00:00Z"}}}
 	Status NetworkContextStatus `json:"status,omitempty"`
 }
 

--- a/api/v1alpha/subnet_types.go
+++ b/api/v1alpha/subnet_types.go
@@ -51,15 +51,47 @@ type SubnetStatus struct {
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 
+const (
+	// SubnetAllocated indicates that the subnet has been allocated a prefix
+	SubnetAllocated = "Allocated"
+
+	// SubnetProgrammed indicates that the subnet has been programmed
+	SubnetProgrammed = "Programmed"
+
+	// SubnetReady indicates that the subnet is ready to use
+	SubnetReady = "Ready"
+)
+
+const (
+	// SubnetProgrammedReasonNotProgrammed indicates that the subnet has not been programmed
+	SubnetProgrammedReasonNotProgrammed = "NotProgrammed"
+
+	// SubnetProgrammedReasonProgrammingInProgress indicates that the subnet is being programmed.
+	SubnetProgrammedReasonProgrammingInProgress = "ProgrammingInProgress"
+
+	// SubnetProgrammedReasonProgrammed indicates that the subnet has been programmed
+	SubnetProgrammedReasonProgrammed = "Programmed"
+
+	// SubnetReadyReasonReady indicates that the subnet is ready to use
+	SubnetReadyReasonReady = "Ready"
+)
+
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 
 // Subnet is the Schema for the subnets API
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
+// +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].status`
+// +kubebuilder:printcolumn:name="Reason",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].reason`
+// +kubebuilder:printcolumn:name="Start Address",type=string,JSONPath=`.status.startAddress`
+// +kubebuilder:printcolumn:name="Prefix Length",type=string,JSONPath=`.status.prefixLength`
 type Subnet struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec   SubnetSpec   `json:"spec,omitempty"`
+	Spec SubnetSpec `json:"spec,omitempty"`
+
+	// +kubebuilder:default={conditions:{{type:"Allocated",status:"Unknown",reason:"Pending", message:"Waiting for controller", lastTransitionTime: "1970-01-01T00:00:00Z"},{type:"Programmed",status:"Unknown",reason:"Pending", message:"Waiting for controller", lastTransitionTime: "1970-01-01T00:00:00Z"},{type:"Ready",status:"Unknown",reason:"Pending", message:"Waiting for controller", lastTransitionTime: "1970-01-01T00:00:00Z"}}}
 	Status SubnetStatus `json:"status,omitempty"`
 }
 

--- a/api/v1alpha/subnetclaim_types.go
+++ b/api/v1alpha/subnetclaim_types.go
@@ -58,11 +58,16 @@ type SubnetClaimStatus struct {
 // +kubebuilder:subresource:status
 
 // SubnetClaim is the Schema for the subnetclaims API
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
+// +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].status`
+// +kubebuilder:printcolumn:name="Reason",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].reason`
 type SubnetClaim struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec   SubnetClaimSpec   `json:"spec,omitempty"`
+	Spec SubnetClaimSpec `json:"spec,omitempty"`
+
+	// +kubebuilder:default={conditions:{{type:"Allocated",status:"Unknown",reason:"Pending", message:"Waiting for controller", lastTransitionTime: "1970-01-01T00:00:00Z"},{type:"Programmed",status:"Unknown",reason:"Pending", message:"Waiting for controller", lastTransitionTime: "1970-01-01T00:00:00Z"},{type:"Ready",status:"Unknown",reason:"Pending", message:"Waiting for controller", lastTransitionTime: "1970-01-01T00:00:00Z"}}}
 	Status SubnetClaimStatus `json:"status,omitempty"`
 }
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -219,6 +219,11 @@ func main() {
 		os.Exit(1)
 	}
 
+	if err = controller.AddIndexers(ctx, mgr); err != nil {
+		setupLog.Error(err, "unable to add indexers")
+		os.Exit(1)
+	}
+
 	validationOpts := validation.GatewayValidationOptions{
 		ControllerName:          serverConfig.Gateway.ControllerName,
 		PermittedTLSOptions:     serverConfig.Gateway.PermittedTLSOptions,

--- a/config/crd/bases/networking.datumapis.com_networkbindings.yaml
+++ b/config/crd/bases/networking.datumapis.com_networkbindings.yaml
@@ -14,7 +14,17 @@ spec:
     singular: networkbinding
   scope: Namespaced
   versions:
-  - name: v1alpha
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].reason
+      name: Reason
+      type: string
+    name: v1alpha
     schema:
       openAPIV3Schema:
         description: NetworkBinding is the Schema for the networkbindings API
@@ -72,6 +82,13 @@ spec:
             - network
             type: object
           status:
+            default:
+              conditions:
+              - lastTransitionTime: "1970-01-01T00:00:00Z"
+                message: Waiting for controller
+                reason: Pending
+                status: Unknown
+                type: Ready
             description: NetworkBindingStatus defines the observed state of NetworkBinding
             properties:
               conditions:

--- a/config/crd/bases/networking.datumapis.com_networkcontexts.yaml
+++ b/config/crd/bases/networking.datumapis.com_networkcontexts.yaml
@@ -14,7 +14,17 @@ spec:
     singular: networkcontext
   scope: Namespaced
   versions:
-  - name: v1alpha
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].reason
+      name: Reason
+      type: string
+    name: v1alpha
     schema:
       openAPIV3Schema:
         description: NetworkContext is the Schema for the networkcontexts API
@@ -66,6 +76,18 @@ spec:
             - network
             type: object
           status:
+            default:
+              conditions:
+              - lastTransitionTime: "1970-01-01T00:00:00Z"
+                message: Waiting for controller
+                reason: Pending
+                status: Unknown
+                type: Programmed
+              - lastTransitionTime: "1970-01-01T00:00:00Z"
+                message: Waiting for controller
+                reason: Pending
+                status: Unknown
+                type: Ready
             description: NetworkContextStatus defines the observed state of NetworkContext
             properties:
               conditions:

--- a/config/crd/bases/networking.datumapis.com_subnetclaims.yaml
+++ b/config/crd/bases/networking.datumapis.com_subnetclaims.yaml
@@ -14,7 +14,17 @@ spec:
     singular: subnetclaim
   scope: Namespaced
   versions:
-  - name: v1alpha
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].reason
+      name: Reason
+      type: string
+    name: v1alpha
     schema:
       openAPIV3Schema:
         description: SubnetClaim is the Schema for the subnetclaims API
@@ -84,6 +94,23 @@ spec:
             - subnetClass
             type: object
           status:
+            default:
+              conditions:
+              - lastTransitionTime: "1970-01-01T00:00:00Z"
+                message: Waiting for controller
+                reason: Pending
+                status: Unknown
+                type: Allocated
+              - lastTransitionTime: "1970-01-01T00:00:00Z"
+                message: Waiting for controller
+                reason: Pending
+                status: Unknown
+                type: Programmed
+              - lastTransitionTime: "1970-01-01T00:00:00Z"
+                message: Waiting for controller
+                reason: Pending
+                status: Unknown
+                type: Ready
             description: SubnetClaimStatus defines the observed state of SubnetClaim
             properties:
               conditions:

--- a/config/crd/bases/networking.datumapis.com_subnets.yaml
+++ b/config/crd/bases/networking.datumapis.com_subnets.yaml
@@ -14,7 +14,23 @@ spec:
     singular: subnet
   scope: Namespaced
   versions:
-  - name: v1alpha
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].reason
+      name: Reason
+      type: string
+    - jsonPath: .status.startAddress
+      name: Start Address
+      type: string
+    - jsonPath: .status.prefixLength
+      name: Prefix Length
+      type: string
+    name: v1alpha
     schema:
       openAPIV3Schema:
         description: Subnet is the Schema for the subnets API
@@ -86,6 +102,23 @@ spec:
             - subnetClass
             type: object
           status:
+            default:
+              conditions:
+              - lastTransitionTime: "1970-01-01T00:00:00Z"
+                message: Waiting for controller
+                reason: Pending
+                status: Unknown
+                type: Allocated
+              - lastTransitionTime: "1970-01-01T00:00:00Z"
+                message: Waiting for controller
+                reason: Pending
+                status: Unknown
+                type: Programmed
+              - lastTransitionTime: "1970-01-01T00:00:00Z"
+                message: Waiting for controller
+                reason: Pending
+                status: Unknown
+                type: Ready
             description: SubnetStatus defines the observed state of a Subnet
             properties:
               conditions:

--- a/config/dev/config.yaml
+++ b/config/dev/config.yaml
@@ -4,6 +4,7 @@ metricsServer:
   bindAddress: "0"
 
 webhookServer:
+  port: 9444
   tls:
     secretRef:
       name: network-services-operator-webhook-server-cert

--- a/config/dev/webhook_patch.yaml
+++ b/config/dev/webhook_patch.yaml
@@ -59,7 +59,7 @@ apiVersion: builtin
 kind: PrefixSuffixTransformer
 metadata:
   name: hostPrefix
-prefix: "https://host.docker.internal:9443"
+prefix: "https://host.docker.internal:9444"
 fieldSpecs:
   - kind: ValidatingWebhookConfiguration
     path: webhooks/clientConfig/url

--- a/internal/controller/indexers.go
+++ b/internal/controller/indexers.go
@@ -1,0 +1,42 @@
+package controller
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	mcmanager "sigs.k8s.io/multicluster-runtime/pkg/manager"
+
+	networkingv1alpha "go.datum.net/network-services-operator/api/v1alpha"
+)
+
+const (
+	networkContextControllerNetworkUIDIndex = "networkContextControllerNetworkUIDIndex"
+)
+
+func AddIndexers(ctx context.Context, mgr mcmanager.Manager) error {
+	return errors.Join(
+		addNetworkContextControllerIndexers(ctx, mgr),
+	)
+}
+
+func addNetworkContextControllerIndexers(ctx context.Context, mgr mcmanager.Manager) error {
+	if err := mgr.GetFieldIndexer().IndexField(ctx, &networkingv1alpha.NetworkContext{}, networkContextControllerNetworkUIDIndex, networkContextControllerNetworkUIDIndexFunc); err != nil {
+		return fmt.Errorf("failed to add network context controller indexer %q: %w", networkContextControllerNetworkUIDIndex, err)
+	}
+
+	return nil
+}
+
+func networkContextControllerNetworkUIDIndexFunc(o client.Object) []string {
+
+	if networkRef := metav1.GetControllerOf(o); networkRef != nil {
+		return []string{
+			string(networkRef.UID),
+		}
+	}
+
+	return nil
+}

--- a/internal/controller/network_controller.go
+++ b/internal/controller/network_controller.go
@@ -4,48 +4,140 @@ package controller
 
 import (
 	"context"
+	"errors"
+	"fmt"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/finalizer"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	mcbuilder "sigs.k8s.io/multicluster-runtime/pkg/builder"
+	mccontext "sigs.k8s.io/multicluster-runtime/pkg/context"
 	mcmanager "sigs.k8s.io/multicluster-runtime/pkg/manager"
 	mcreconcile "sigs.k8s.io/multicluster-runtime/pkg/reconcile"
 
 	networkingv1alpha "go.datum.net/network-services-operator/api/v1alpha"
 )
 
+const networkControllerFinalizer = "networking.datumapis.com/network-controller"
+
 // NetworkReconciler reconciles a Network object
 type NetworkReconciler struct {
-	mgr mcmanager.Manager
+	mgr        mcmanager.Manager
+	finalizers finalizer.Finalizers
 }
 
 // +kubebuilder:rbac:groups=networking.datumapis.com,resources=networks,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=networking.datumapis.com,resources=networks/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=networking.datumapis.com,resources=networks/finalizers,verbs=update
 
-// Reconcile is part of the main kubernetes reconciliation loop which aims to
-// move the current state of the cluster closer to the desired state.
-// TODO(user): Modify the Reconcile function to compare the state specified by
-// the Network object against the actual cluster state, and then
-// perform operations to make the cluster state reflect the state specified by
-// the user.
-//
-// For more details, check Reconcile and its Result here:
-// - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.19.1/pkg/reconcile
 func (r *NetworkReconciler) Reconcile(ctx context.Context, req mcreconcile.Request) (ctrl.Result, error) {
-	logger := log.FromContext(ctx, "cluster", req.ClusterName)
+	logger := log.FromContext(ctx)
+
+	cl, err := r.mgr.GetCluster(ctx, req.ClusterName)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	ctx = mccontext.WithCluster(ctx, req.ClusterName)
+
+	var network networkingv1alpha.Network
+	if err := cl.GetClient().Get(ctx, req.NamespacedName, &network); err != nil {
+		if apierrors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, err
+	}
 
 	logger.Info("reconciling network")
 	defer logger.Info("reconcile complete")
 
+	finalizationResult, err := r.finalizers.Finalize(ctx, &network)
+	if err != nil {
+		if v, ok := err.(kerrors.Aggregate); ok && v.Is(errNetworkContextsExist) {
+			// Don't produce an error in this case and let the watch on network contexts
+			// result in another reconcile schedule.
+			logger.Info("network still has network contexts, waiting until removal")
+			return ctrl.Result{}, nil
+		} else {
+			return ctrl.Result{}, fmt.Errorf("failed to finalize: %w", err)
+		}
+	}
+	if finalizationResult.Updated {
+		if err = cl.GetClient().Update(ctx, &network); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to update based on finalization result: %w", err)
+		}
+		return ctrl.Result{}, nil
+	}
+
+	if !network.DeletionTimestamp.IsZero() {
+		return ctrl.Result{}, nil
+	}
+
 	return ctrl.Result{}, nil
+}
+
+var errNetworkContextsExist = errors.New("network contexts exist")
+
+func (r *NetworkReconciler) Finalize(ctx context.Context, obj client.Object) (finalizer.Result, error) {
+	logger := log.FromContext(ctx)
+	logger.Info("finalizing network")
+
+	clusterName, ok := mccontext.ClusterFrom(ctx)
+	if !ok {
+		return finalizer.Result{}, fmt.Errorf("cluster name not found in context")
+	}
+
+	cl, err := r.mgr.GetCluster(ctx, clusterName)
+	if err != nil {
+		return finalizer.Result{}, err
+	}
+
+	listOpts := client.MatchingFields{
+		networkContextControllerNetworkUIDIndex: string(obj.GetUID()),
+	}
+	var networkContexts networkingv1alpha.NetworkContextList
+	if err := cl.GetClient().List(ctx, &networkContexts, listOpts); err != nil {
+		return finalizer.Result{}, err
+	}
+
+	if len(networkContexts.Items) == 0 {
+		log.FromContext(ctx).Info("network contexts have been removed")
+		return finalizer.Result{}, nil
+	}
+
+	// All deployments need to be deleted before the workload may be deleted
+	for _, networkContext := range networkContexts.Items {
+		if networkContext.DeletionTimestamp.IsZero() {
+			logger.Info("deleting network context", "network context", networkContext.Name)
+			// Deletion will result in another reconcile of the workload, where we
+			// will remove the finalizers.
+			if err := cl.GetClient().Delete(ctx, &networkContext); client.IgnoreNotFound(err) != nil {
+				return finalizer.Result{}, fmt.Errorf("failed deleting network context: %w", err)
+			}
+		}
+	}
+
+	// Really don't like using errors for communication here. I think we'd need
+	// to move away from the finalizer helper to ensure we can wait on child
+	// resources to be gone before allowing the finalizer to be removed.
+	return finalizer.Result{}, errNetworkContextsExist
 }
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *NetworkReconciler) SetupWithManager(mgr mcmanager.Manager) error {
 	r.mgr = mgr
+
+	r.finalizers = finalizer.NewFinalizers()
+	if err := r.finalizers.Register(networkControllerFinalizer, r); err != nil {
+		return fmt.Errorf("failed to register finalizer: %w", err)
+	}
+
 	return mcbuilder.ControllerManagedBy(mgr).
 		For(&networkingv1alpha.Network{}, mcbuilder.WithEngageWithLocalCluster(false)).
+		Owns(&networkingv1alpha.NetworkContext{}, mcbuilder.WithEngageWithLocalCluster(false)).
 		Named("network").
 		Complete(r)
 }


### PR DESCRIPTION
Also added default status conditions via kubebuilder markers, new expected conditions and reasons, as well as printer columns.

Enhancement: https://github.com/datum-cloud/enhancements/issues/28

Related work:

- https://github.com/datum-cloud/infra-provider-gcp/pull/29
- https://github.com/datum-cloud/workload-operator/pull/51