### PR TITLE
bugfix: allow exact matches on gateway hostname

### DIFF
--- a/internal/validation/gateway_validation.go
+++ b/internal/validation/gateway_validation.go
@@ -55,7 +55,8 @@ func validateListeners(listeners []gatewayv1.Listener, fldPath *field.Path, opts
 				hostnameStr := string(*l.Hostname)
 				validHostname := false
 				for _, suffix := range allowedSuffixes {
-					if strings.HasSuffix(hostnameStr, "."+suffix) {
+					// Allow exact matches or suffix matches
+					if suffix == hostnameStr || strings.HasSuffix(hostnameStr, "."+suffix) {
 						validHostname = true
 						break
 					}

--- a/internal/validation/gateway_validation_test.go
+++ b/internal/validation/gateway_validation_test.go
@@ -161,9 +161,7 @@ func TestValidateGateway(t *testing.T) {
 				},
 				ClusterName: "cluster-a",
 			},
-			expectedErrors: field.ErrorList{
-				field.Invalid(field.NewPath("spec", "listeners").Index(0).Child("hostname"), "example.com", "hostname does not match any allowed suffixes: [example.com another.org]"),
-			},
+			expectedErrors: field.ErrorList{},
 		},
 		"custom hostname: invalid, not a subdomain": {
 			gateway: &gatewayv1.Gateway{


### PR DESCRIPTION
Allow exact matching on custom hostnames. Needed this to allow creating a gateway that served the domain `milo-os.com`. 