### PR TITLE
feat: Add HTTPRoute parentRef sectionName support and improved downstream resource GC

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -219,13 +219,21 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err := controller.AddIndexers(ctx, mgr); err != nil {
-		setupLog.Error(err, "unable to add indexers")
+	if err := (&controller.GatewayDownstreamGCReconciler{
+		Config:            serverConfig,
+		DownstreamCluster: downstreamCluster,
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "GatewayDownstreamGC")
 		os.Exit(1)
 	}
 
 	if err := (&controller.DomainReconciler{}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Domain")
+		os.Exit(1)
+	}
+
+	if err := controller.AddIndexers(ctx, mgr); err != nil {
+		setupLog.Error(err, "unable to add indexers")
 		os.Exit(1)
 	}
 

--- a/internal/controller/gateway_downstream_gc_controller.go
+++ b/internal/controller/gateway_downstream_gc_controller.go
@@ -1,0 +1,198 @@
+package controller
+
+import (
+	"context"
+	"fmt"
+
+	discoveryv1 "k8s.io/api/discovery/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+	"sigs.k8s.io/controller-runtime/pkg/cluster"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	mcbuilder "sigs.k8s.io/multicluster-runtime/pkg/builder"
+	mchandler "sigs.k8s.io/multicluster-runtime/pkg/handler"
+	mcmanager "sigs.k8s.io/multicluster-runtime/pkg/manager"
+	mcreconcile "sigs.k8s.io/multicluster-runtime/pkg/reconcile"
+
+	"go.datum.net/network-services-operator/internal/config"
+	downstreamclient "go.datum.net/network-services-operator/internal/downstreamclient"
+)
+
+// GatewayDownstreamGCReconciler reconciles a Gateway object
+type GatewayDownstreamGCReconciler struct {
+	mgr    mcmanager.Manager
+	Config config.NetworkServicesOperator
+
+	DownstreamCluster cluster.Cluster
+}
+
+type GVKRequest struct {
+	mcreconcile.Request
+	GVK schema.GroupVersionKind
+}
+
+// Cluster returns the name of the cluster that the request belongs to.
+func (r GVKRequest) Cluster() string {
+	return r.ClusterName
+}
+
+// WithCluster sets the name of the cluster that the request belongs to.
+func (r GVKRequest) WithCluster(name string) GVKRequest {
+	r.ClusterName = name
+	return r
+}
+
+func (r *GatewayDownstreamGCReconciler) Reconcile(ctx context.Context, req GVKRequest) (ctrl.Result, error) {
+	logger := log.FromContext(ctx).WithValues(
+		"gvk",
+		req.GVK.String(),
+		"cluster",
+		req.ClusterName,
+		"namespace",
+		req.Namespace, "name",
+		req.Name,
+	)
+
+	cl, err := r.mgr.GetCluster(ctx, req.ClusterName)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	var obj unstructured.Unstructured
+	obj.SetGroupVersionKind(req.GVK)
+	if err := cl.GetClient().Get(ctx, req.NamespacedName, &obj); err != nil {
+		if apierrors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, err
+	}
+
+	// Only process objects that are being deleted and have the gateway finalizer.
+	if dt := obj.GetDeletionTimestamp(); dt.IsZero() || !controllerutil.ContainsFinalizer(&obj, gatewayControllerGCFinalizer) {
+		return ctrl.Result{}, nil
+	}
+
+	logger.Info("garbage collecting downstream resources")
+
+	downstreamStrategy := downstreamclient.NewMappedNamespaceResourceStrategy(req.ClusterName, cl.GetClient(), r.DownstreamCluster.GetClient())
+
+	if err := downstreamStrategy.DeleteAnchorForObject(ctx, &obj); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed deleting anchor: %w", err)
+	}
+
+	// When an HTTPRoute is deleted, ensure that the downstream EndpointSlices are
+	// deleted as well. They're currently logically owned by the route as a result
+	// of duplicating the upstream EndpointSlice.
+
+	if req.GVK.Group == gatewayv1.GroupName && req.GVK.Kind == "HTTPRoute" {
+		httpRoute := &gatewayv1.HTTPRoute{}
+		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.Object, httpRoute); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to convert unstructured httproute: %w", err)
+		}
+
+		downstreamObjectMeta, err := downstreamStrategy.ObjectMetaFromUpstreamObject(ctx, httpRoute)
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed getting downstream object metadata: %w", err)
+		}
+
+		logger.Info("looking for endpointslices", "downstream_namespace", downstreamObjectMeta.Namespace)
+
+		for ruleIdx, rule := range httpRoute.Spec.Rules {
+			for backendRefIdx, backendRef := range rule.BackendRefs {
+				if ptr.Deref(backendRef.Group, "") != discoveryv1.GroupName ||
+					ptr.Deref(backendRef.Kind, "") != "EndpointSlice" {
+					continue
+				}
+
+				resourceName := fmt.Sprintf("route-%s-rule-%d-backendref-%d", httpRoute.UID, ruleIdx, backendRefIdx)
+
+				endpointSlice := &discoveryv1.EndpointSlice{}
+				if err := r.DownstreamCluster.GetClient().Get(ctx, client.ObjectKey{
+					Namespace: string(ptr.Deref(backendRef.Namespace, gatewayv1.Namespace(downstreamObjectMeta.Namespace))),
+					Name:      resourceName,
+				}, endpointSlice); err != nil {
+					if apierrors.IsNotFound(err) {
+						logger.Info("endpointslice not found", "namespace", downstreamObjectMeta.Namespace, resourceName)
+						// Nothing to do
+						continue
+					}
+					return ctrl.Result{}, fmt.Errorf("failed fetching endpointslice: %w", err)
+				}
+
+				logger.Info("deleting endpointslice", "namespace", downstreamObjectMeta.Namespace, "name", resourceName)
+
+				if dt := endpointSlice.GetDeletionTimestamp(); dt == nil {
+					if err := r.DownstreamCluster.GetClient().Delete(ctx, endpointSlice); err != nil {
+						return ctrl.Result{}, fmt.Errorf("failed to delete endpointslice: %w", err)
+					}
+				}
+			}
+		}
+	}
+
+	if controllerutil.RemoveFinalizer(&obj, gatewayControllerGCFinalizer) {
+		if err := cl.GetClient().Update(ctx, &obj); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to remove finalizer: %w", err)
+		}
+	}
+
+	return ctrl.Result{}, nil
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *GatewayDownstreamGCReconciler) SetupWithManager(mgr mcmanager.Manager) error {
+	r.mgr = mgr
+
+	return mcbuilder.TypedControllerManagedBy[GVKRequest](mgr).
+		Watches(&gatewayv1.HTTPRoute{}, TypedEnqueueRequestForObjectWithGVK(&gatewayv1.HTTPRoute{})).
+		Watches(&discoveryv1.EndpointSlice{}, TypedEnqueueRequestForObjectWithGVK(&discoveryv1.EndpointSlice{})).
+		Named("gateway_downstream_resources").
+		Complete(r)
+}
+
+func TypedEnqueueRequestForObjectWithGVK(
+	obj client.Object,
+) mchandler.TypedEventHandlerFunc[client.Object, GVKRequest] {
+	return func(clusterName string, cl cluster.Cluster) handler.TypedEventHandler[client.Object, GVKRequest] {
+		return handler.TypedEnqueueRequestsFromMapFunc(func(ctx context.Context, obj client.Object) []GVKRequest {
+			// Only reconcile objects that are being deleted
+			if dt := obj.GetDeletionTimestamp(); dt.IsZero() {
+				return nil
+			}
+
+			logger := log.FromContext(ctx)
+
+			gvk, err := apiutil.GVKForObject(obj, cl.GetScheme())
+			if err != nil {
+				logger.Error(fmt.Errorf("failed to get GVK in TypedEnqueueRequestForObjectWithGVK: %w", err), "cluster", clusterName, clusterName)
+				return nil
+			}
+
+			return []GVKRequest{
+				{
+					GVK: gvk,
+					Request: mcreconcile.Request{
+						ClusterName: clusterName,
+						Request: reconcile.Request{
+							NamespacedName: types.NamespacedName{
+								Namespace: obj.GetNamespace(),
+								Name:      obj.GetName(),
+							},
+						},
+					},
+				},
+			}
+		})
+	}
+}

--- a/internal/controller/gateway_downstream_gc_controller_test.go
+++ b/internal/controller/gateway_downstream_gc_controller_test.go
@@ -1,0 +1,116 @@
+package controller
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/uuid"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	mcreconcile "sigs.k8s.io/multicluster-runtime/pkg/reconcile"
+)
+
+func TestHTTPRouteGC(t *testing.T) {
+
+	testScheme := runtime.NewScheme()
+	assert.NoError(t, scheme.AddToScheme(testScheme))
+	assert.NoError(t, gatewayv1.Install(testScheme))
+	assert.NoError(t, discoveryv1.AddToScheme(testScheme))
+
+	upstreamNamespace := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test",
+			UID:  uuid.NewUUID(),
+		},
+	}
+
+	upstreamHTTPRouteUID := uuid.NewUUID()
+
+	downstreamNamespaceName := fmt.Sprintf("ns-%s", upstreamNamespace.UID)
+
+	downstreamEndpointSlice := &discoveryv1.EndpointSlice{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: downstreamNamespaceName,
+			Name:      fmt.Sprintf("route-%s-rule-%d-backendref-%d", upstreamHTTPRouteUID, 0, 0),
+		},
+	}
+
+	upstreamHTTPRoute := &gatewayv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "test",
+			Name:      "test",
+			UID:       upstreamHTTPRouteUID,
+			Finalizers: []string{
+				gatewayControllerGCFinalizer,
+			},
+			DeletionTimestamp: ptr.To(metav1.Now()),
+		},
+		Spec: gatewayv1.HTTPRouteSpec{
+			Rules: []gatewayv1.HTTPRouteRule{
+				{
+					BackendRefs: []gatewayv1.HTTPBackendRef{
+						{
+							BackendRef: gatewayv1.BackendRef{
+								BackendObjectReference: gatewayv1.BackendObjectReference{
+									Group: ptr.To(gatewayv1.Group(discoveryv1.GroupName)),
+									Kind:  ptr.To(gatewayv1.Kind("EndpointSlice")),
+									Name:  gatewayv1.ObjectName(downstreamEndpointSlice.Name),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	fakeUpstreamClient := fake.NewClientBuilder().
+		WithScheme(testScheme).
+		WithObjects(upstreamHTTPRoute, upstreamNamespace).
+		Build()
+
+	fakeDownstreamClient := fake.NewClientBuilder().
+		WithScheme(testScheme).
+		WithObjects(downstreamEndpointSlice).
+		Build()
+
+	ctx := context.Background()
+
+	mgr := &fakeMockManager{cl: fakeUpstreamClient}
+
+	reconciler := &GatewayDownstreamGCReconciler{
+		mgr:               mgr,
+		DownstreamCluster: &fakeCluster{cl: fakeDownstreamClient},
+	}
+
+	_, err := reconciler.Reconcile(
+		ctx,
+		GVKRequest{
+			GVK: gatewayv1.SchemeGroupVersion.WithKind("HTTPRoute"),
+			Request: mcreconcile.Request{
+				ClusterName: "test",
+				Request: reconcile.Request{
+					NamespacedName: client.ObjectKeyFromObject(upstreamHTTPRoute),
+				},
+			},
+		},
+	)
+	assert.NoError(t, err, "reconcile failed")
+
+	err = fakeUpstreamClient.Get(ctx, client.ObjectKeyFromObject(upstreamHTTPRoute), &gatewayv1.HTTPRoute{})
+	assert.True(t, apierrors.IsNotFound(err))
+
+	err = fakeDownstreamClient.Get(ctx, client.ObjectKeyFromObject(downstreamEndpointSlice), &discoveryv1.EndpointSlice{})
+	assert.True(t, apierrors.IsNotFound(err))
+}

--- a/internal/controller/httpproxy_controller_test.go
+++ b/internal/controller/httpproxy_controller_test.go
@@ -27,7 +27,7 @@ import (
 	"go.datum.net/network-services-operator/internal/config"
 )
 
-func TestHTTPPRoxyCollectDesiredResources(t *testing.T) {
+func TestHTTPProxyCollectDesiredResources(t *testing.T) {
 
 	operatorConfig := config.NetworkServicesOperator{
 		HTTPProxy: config.HTTPProxyConfig{

--- a/internal/validation/httproute_validation_test.go
+++ b/internal/validation/httproute_validation_test.go
@@ -252,11 +252,10 @@ func TestValidateHTTPRoute(t *testing.T) {
 					CommonRouteSpec: gatewayv1.CommonRouteSpec{
 						ParentRefs: []gatewayv1.ParentReference{
 							{
-								Group:       ptr.To(gatewayv1.Group("invalid.group")),
-								Kind:        ptr.To(gatewayv1.Kind("InvalidKind")),
-								Namespace:   ptr.To(gatewayv1.Namespace("invalid-namespace")),
-								SectionName: ptr.To(gatewayv1.SectionName("invalid-section-name")),
-								Port:        ptr.To(gatewayv1.PortNumber(80)),
+								Group:     ptr.To(gatewayv1.Group("invalid.group")),
+								Kind:      ptr.To(gatewayv1.Kind("InvalidKind")),
+								Namespace: ptr.To(gatewayv1.Namespace("invalid-namespace")),
+								Port:      ptr.To(gatewayv1.PortNumber(80)),
 							},
 						},
 					},
@@ -266,7 +265,6 @@ func TestValidateHTTPRoute(t *testing.T) {
 				field.Invalid(field.NewPath("spec", "parentRefs").Index(0).Child("group"), "invalid.group", ""),
 				field.Invalid(field.NewPath("spec", "parentRefs").Index(0).Child("kind"), "InvalidKind", ""),
 				field.Invalid(field.NewPath("spec", "parentRefs").Index(0).Child("namespace"), "invalid-namespace", ""),
-				field.Forbidden(field.NewPath("spec", "parentRefs").Index(0).Child("sectionName"), ""),
 				field.Forbidden(field.NewPath("spec", "parentRefs").Index(0).Child("port"), ""),
 			},
 		},


### PR DESCRIPTION
## Summary

### HTTPRoute ParentRef SectionName support

The restriction on using a `SectionName` in an HTTPRoute ParentRef has been lifted. This existed initially as a result of expected downstream Gateway programming complications and was never removed. This allows for [HTTP-to-HTTPS redirects](https://gateway-api.sigs.k8s.io/guides/http-redirect-rewrite/#http-to-https-redirects) to be programmed by attaching routes with request rewrite filters to only the port 80 listener.

If an HTTPRoute has a ParentRef and a SectionName that is not in the parent Gateway, it will not be attached to a resource.

### Garbage collection

While testing these changes, gaps in downstream resource GC were found. To address this, I've built a fairly general downstream resource GC controller that can be used to ensure downstream anchor resources are deleted when an upstream resource is deleted, avoiding the need for more complicated resource tracking in the gateway controller. Currently there's some specific handling for downstream resources of HTTPRoutes - I think over time we can adjust this controller to be provided with a map of GVK to finalizer functions to avoid this.