### PR TITLE
fix: Map valid protocols to ports and only create downstream listeners for upstream protocols

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -274,14 +274,14 @@ type GatewayConfig struct {
 	// ValidPortNumbers is a list of port numbers that are permitted on gateway
 	// listeners.
 	//
-	// Defaults to [80, 443]
+	// +default=[80,443]
 	ValidPortNumbers []int `json:"validPortNumbers,omitempty"`
 
 	// ValidProtocolTypes is a list of protocol types that are permitted on
 	// gateway listeners.
 	//
-	// Defaults to [HTTP, HTTPS]
-	ValidProtocolTypes []gatewayv1.ProtocolType `json:"validProtocolTypes,omitempty"`
+	// +default={"80": ["HTTP"], "443": ["HTTPS"]}
+	ValidProtocolTypes map[int][]gatewayv1.ProtocolType `json:"validProtocolTypes,omitempty"`
 
 	// CustomHostnameAllowList is a list of allowed hostname suffixes for specific
 	// clusters. Hostnames on gateways in a cluster must be a subdomain of one of
@@ -322,17 +322,6 @@ func SetDefaults_GatewayConfig(obj *GatewayConfig) {
 		obj.IPFamilies = []networkingv1alpha.IPFamily{
 			networkingv1alpha.IPv4Protocol,
 			networkingv1alpha.IPv6Protocol,
-		}
-	}
-
-	if len(obj.ValidPortNumbers) == 0 {
-		obj.ValidPortNumbers = []int{80, 443}
-	}
-
-	if len(obj.ValidProtocolTypes) == 0 {
-		obj.ValidProtocolTypes = []gatewayv1.ProtocolType{
-			gatewayv1.HTTPProtocolType,
-			gatewayv1.HTTPSProtocolType,
 		}
 	}
 }

--- a/internal/config/zz_generated.deepcopy.go
+++ b/internal/config/zz_generated.deepcopy.go
@@ -101,8 +101,19 @@ func (in *GatewayConfig) DeepCopyInto(out *GatewayConfig) {
 	}
 	if in.ValidProtocolTypes != nil {
 		in, out := &in.ValidProtocolTypes, &out.ValidProtocolTypes
-		*out = make([]apisv1.ProtocolType, len(*in))
-		copy(*out, *in)
+		*out = make(map[int][]apisv1.ProtocolType, len(*in))
+		for key, val := range *in {
+			var outVal []apisv1.ProtocolType
+			if val == nil {
+				(*out)[key] = nil
+			} else {
+				inVal := (*in)[key]
+				in, out := &inVal, &outVal
+				*out = make([]apisv1.ProtocolType, len(*in))
+				copy(*out, *in)
+			}
+			(*out)[key] = outVal
+		}
 	}
 	if in.CustomHostnameAllowList != nil {
 		in, out := &in.CustomHostnameAllowList, &out.CustomHostnameAllowList

--- a/internal/config/zz_generated.defaults.go
+++ b/internal/config/zz_generated.defaults.go
@@ -24,6 +24,16 @@ func SetObjectDefaults_NetworkServicesOperator(in *NetworkServicesOperator) {
 	SetDefaults_TLSConfig(&in.MetricsServer.TLS)
 	SetDefaults_TLSConfig(&in.WebhookServer.TLS)
 	SetDefaults_GatewayConfig(&in.Gateway)
+	if in.Gateway.ValidPortNumbers == nil {
+		if err := json.Unmarshal([]byte(`[80,443]`), &in.Gateway.ValidPortNumbers); err != nil {
+			panic(err)
+		}
+	}
+	if in.Gateway.ValidProtocolTypes == nil {
+		if err := json.Unmarshal([]byte(`{"80": ["HTTP"], "443": ["HTTPS"]}`), &in.Gateway.ValidProtocolTypes); err != nil {
+			panic(err)
+		}
+	}
 	if in.HTTPProxy.GatewayClassName == "" {
 		in.HTTPProxy.GatewayClassName = "datum-external-global-proxy"
 	}

--- a/internal/validation/gateway_validation_test.go
+++ b/internal/validation/gateway_validation_test.go
@@ -14,6 +14,11 @@ import (
 
 func TestValidateGateway(t *testing.T) {
 
+	defaultValidProtocolTypes := map[int][]gatewayv1.ProtocolType{
+		HTTPPort:  []gatewayv1.ProtocolType{gatewayv1.HTTPProtocolType},
+		HTTPSPort: []gatewayv1.ProtocolType{gatewayv1.HTTPSProtocolType},
+	}
+
 	scenarios := map[string]struct {
 		gateway        *gatewayv1.Gateway
 		opts           GatewayValidationOptions
@@ -45,7 +50,7 @@ func TestValidateGateway(t *testing.T) {
 			},
 			opts: GatewayValidationOptions{
 				ValidPortNumbers:   []int{80, 443},
-				ValidProtocolTypes: []gatewayv1.ProtocolType{gatewayv1.HTTPProtocolType, gatewayv1.HTTPSProtocolType},
+				ValidProtocolTypes: defaultValidProtocolTypes,
 			},
 			expectedErrors: field.ErrorList{
 				field.Invalid(field.NewPath("spec", "listeners").Index(0).Child("hostname"), "example.com", "hostnames are not permitted"),
@@ -67,7 +72,7 @@ func TestValidateGateway(t *testing.T) {
 			},
 			opts: GatewayValidationOptions{
 				ValidPortNumbers:   []int{80, 443},
-				ValidProtocolTypes: []gatewayv1.ProtocolType{gatewayv1.HTTPProtocolType, gatewayv1.HTTPSProtocolType},
+				ValidProtocolTypes: defaultValidProtocolTypes,
 				CustomHostnameAllowList: []config.CustomHostnameAllowListEntry{
 					{
 						ClusterName: "other-cluster",
@@ -96,7 +101,7 @@ func TestValidateGateway(t *testing.T) {
 			},
 			opts: GatewayValidationOptions{
 				ValidPortNumbers:   []int{80, 443},
-				ValidProtocolTypes: []gatewayv1.ProtocolType{gatewayv1.HTTPProtocolType, gatewayv1.HTTPSProtocolType},
+				ValidProtocolTypes: defaultValidProtocolTypes,
 				CustomHostnameAllowList: []config.CustomHostnameAllowListEntry{
 					{
 						ClusterName: "cluster-a",
@@ -125,7 +130,7 @@ func TestValidateGateway(t *testing.T) {
 			},
 			opts: GatewayValidationOptions{
 				ValidPortNumbers:   []int{80, 443},
-				ValidProtocolTypes: []gatewayv1.ProtocolType{gatewayv1.HTTPProtocolType, gatewayv1.HTTPSProtocolType},
+				ValidProtocolTypes: defaultValidProtocolTypes,
 				CustomHostnameAllowList: []config.CustomHostnameAllowListEntry{
 					{
 						ClusterName: "cluster-a",
@@ -152,7 +157,7 @@ func TestValidateGateway(t *testing.T) {
 			},
 			opts: GatewayValidationOptions{
 				ValidPortNumbers:   []int{80, 443},
-				ValidProtocolTypes: []gatewayv1.ProtocolType{gatewayv1.HTTPProtocolType, gatewayv1.HTTPSProtocolType},
+				ValidProtocolTypes: defaultValidProtocolTypes,
 				CustomHostnameAllowList: []config.CustomHostnameAllowListEntry{
 					{
 						ClusterName: "cluster-a",
@@ -179,7 +184,7 @@ func TestValidateGateway(t *testing.T) {
 			},
 			opts: GatewayValidationOptions{
 				ValidPortNumbers:   []int{80, 443},
-				ValidProtocolTypes: []gatewayv1.ProtocolType{gatewayv1.HTTPProtocolType, gatewayv1.HTTPSProtocolType},
+				ValidProtocolTypes: defaultValidProtocolTypes,
 				CustomHostnameAllowList: []config.CustomHostnameAllowListEntry{
 					{
 						ClusterName: "cluster-a",
@@ -208,7 +213,7 @@ func TestValidateGateway(t *testing.T) {
 			},
 			opts: GatewayValidationOptions{
 				ValidPortNumbers:   []int{80, 443},
-				ValidProtocolTypes: []gatewayv1.ProtocolType{gatewayv1.HTTPProtocolType, gatewayv1.HTTPSProtocolType},
+				ValidProtocolTypes: defaultValidProtocolTypes,
 				CustomHostnameAllowList: []config.CustomHostnameAllowListEntry{
 					{
 						ClusterName: "cluster-a",
@@ -237,7 +242,7 @@ func TestValidateGateway(t *testing.T) {
 			},
 			opts: GatewayValidationOptions{
 				ValidPortNumbers:   []int{80, 443},
-				ValidProtocolTypes: []gatewayv1.ProtocolType{gatewayv1.HTTPProtocolType, gatewayv1.HTTPSProtocolType},
+				ValidProtocolTypes: defaultValidProtocolTypes,
 				CustomHostnameAllowList: []config.CustomHostnameAllowListEntry{
 					{
 						ClusterName: "cluster-a",
@@ -264,7 +269,7 @@ func TestValidateGateway(t *testing.T) {
 			},
 			opts: GatewayValidationOptions{
 				ValidPortNumbers:   []int{80, 443},
-				ValidProtocolTypes: []gatewayv1.ProtocolType{gatewayv1.HTTPProtocolType, gatewayv1.HTTPSProtocolType},
+				ValidProtocolTypes: defaultValidProtocolTypes,
 				CustomHostnameAllowList: []config.CustomHostnameAllowListEntry{
 					{
 						ClusterName: "cluster-a",
@@ -293,7 +298,7 @@ func TestValidateGateway(t *testing.T) {
 			},
 			opts: GatewayValidationOptions{
 				ValidPortNumbers:   []int{80, 443},
-				ValidProtocolTypes: []gatewayv1.ProtocolType{gatewayv1.HTTPProtocolType, gatewayv1.HTTPSProtocolType},
+				ValidProtocolTypes: defaultValidProtocolTypes,
 				CustomHostnameAllowList: []config.CustomHostnameAllowListEntry{
 					{
 						ClusterName: "cluster-a",
@@ -319,7 +324,7 @@ func TestValidateGateway(t *testing.T) {
 			},
 			opts: GatewayValidationOptions{
 				ValidPortNumbers:   []int{80, 443},
-				ValidProtocolTypes: []gatewayv1.ProtocolType{gatewayv1.HTTPProtocolType, gatewayv1.HTTPSProtocolType},
+				ValidProtocolTypes: defaultValidProtocolTypes,
 			},
 			expectedErrors: field.ErrorList{
 				field.NotSupported(field.NewPath("spec", "listeners").Index(0).Child("port"), 8080, []string{"80", "443"}),
@@ -340,7 +345,7 @@ func TestValidateGateway(t *testing.T) {
 			},
 			opts: GatewayValidationOptions{
 				ValidPortNumbers:   []int{80, 443},
-				ValidProtocolTypes: []gatewayv1.ProtocolType{gatewayv1.HTTPProtocolType, gatewayv1.HTTPSProtocolType},
+				ValidProtocolTypes: defaultValidProtocolTypes,
 			},
 			expectedErrors: field.ErrorList{
 				field.NotSupported(field.NewPath("spec", "listeners").Index(0).Child("protocol"), gatewayv1.TCPProtocolType, []gatewayv1.ProtocolType{gatewayv1.HTTPProtocolType, gatewayv1.HTTPSProtocolType}),
@@ -364,9 +369,10 @@ func TestValidateGateway(t *testing.T) {
 			},
 			opts: GatewayValidationOptions{
 				ValidPortNumbers:   []int{80, 443},
-				ValidProtocolTypes: []gatewayv1.ProtocolType{gatewayv1.HTTPProtocolType, gatewayv1.HTTPSProtocolType},
+				ValidProtocolTypes: defaultValidProtocolTypes,
 			},
 			expectedErrors: field.ErrorList{
+				field.Required(field.NewPath("spec", "listeners").Index(0).Child("tls", "options"), ""),
 				field.Invalid(field.NewPath("spec", "listeners").Index(0).Child("tls", "mode"), gatewayv1.TLSModePassthrough, "mode must be set to Terminate"),
 			},
 		},
@@ -393,9 +399,10 @@ func TestValidateGateway(t *testing.T) {
 			},
 			opts: GatewayValidationOptions{
 				ValidPortNumbers:   []int{80, 443},
-				ValidProtocolTypes: []gatewayv1.ProtocolType{gatewayv1.HTTPProtocolType, gatewayv1.HTTPSProtocolType},
+				ValidProtocolTypes: defaultValidProtocolTypes,
 			},
 			expectedErrors: field.ErrorList{
+				field.Required(field.NewPath("spec", "listeners").Index(0).Child("tls", "options"), ""),
 				field.Forbidden(field.NewPath("spec", "listeners").Index(0).Child("tls", "certificateRefs"), ""),
 			},
 		},
@@ -419,7 +426,7 @@ func TestValidateGateway(t *testing.T) {
 			},
 			opts: GatewayValidationOptions{
 				ValidPortNumbers:   []int{80, 443},
-				ValidProtocolTypes: []gatewayv1.ProtocolType{gatewayv1.HTTPProtocolType, gatewayv1.HTTPSProtocolType},
+				ValidProtocolTypes: defaultValidProtocolTypes,
 			},
 			expectedErrors: field.ErrorList{
 				field.NotSupported(field.NewPath("spec", "listeners").Index(0).Child("allowedRoutes", "namespaces", "from"), gatewayv1.NamespacesFromAll, []gatewayv1.FromNamespaces{gatewayv1.NamespacesFromSame}),
@@ -447,7 +454,7 @@ func TestValidateGateway(t *testing.T) {
 			},
 			opts: GatewayValidationOptions{
 				ValidPortNumbers:   []int{80, 443},
-				ValidProtocolTypes: []gatewayv1.ProtocolType{gatewayv1.HTTPProtocolType, gatewayv1.HTTPSProtocolType},
+				ValidProtocolTypes: defaultValidProtocolTypes,
 			},
 			expectedErrors: field.ErrorList{
 				field.TooMany(field.NewPath("spec", "listeners").Index(0).Child("allowedRoutes", "kinds"), 1, 0),
@@ -474,7 +481,7 @@ func TestValidateGateway(t *testing.T) {
 			},
 			opts: GatewayValidationOptions{
 				ValidPortNumbers:   []int{80, 443},
-				ValidProtocolTypes: []gatewayv1.ProtocolType{gatewayv1.HTTPProtocolType, gatewayv1.HTTPSProtocolType},
+				ValidProtocolTypes: defaultValidProtocolTypes,
 			},
 			expectedErrors: field.ErrorList{
 				field.TooMany(field.NewPath("spec", "addresses"), 1, 0),
@@ -500,7 +507,7 @@ func TestValidateGateway(t *testing.T) {
 			},
 			opts: GatewayValidationOptions{
 				ValidPortNumbers:   []int{80, 443},
-				ValidProtocolTypes: []gatewayv1.ProtocolType{gatewayv1.HTTPProtocolType, gatewayv1.HTTPSProtocolType},
+				ValidProtocolTypes: defaultValidProtocolTypes,
 			},
 			expectedErrors: field.ErrorList{
 				field.Forbidden(field.NewPath("spec", "infrastructure"), "infrastructure is not permitted"),
@@ -526,7 +533,7 @@ func TestValidateGateway(t *testing.T) {
 			},
 			opts: GatewayValidationOptions{
 				ValidPortNumbers:   []int{80, 443},
-				ValidProtocolTypes: []gatewayv1.ProtocolType{gatewayv1.HTTPProtocolType, gatewayv1.HTTPSProtocolType},
+				ValidProtocolTypes: defaultValidProtocolTypes,
 			},
 			expectedErrors: field.ErrorList{
 				field.Forbidden(field.NewPath("spec", "backendTLS"), "backendTLS is not permitted"),
@@ -538,9 +545,9 @@ func TestValidateGateway(t *testing.T) {
 					GatewayClassName: "test-gateway-class",
 					Listeners: []gatewayv1.Listener{
 						{
-							Name:     "http",
-							Protocol: gatewayv1.HTTPProtocolType,
-							Port:     80,
+							Name:     "https",
+							Protocol: gatewayv1.HTTPSProtocolType,
+							Port:     443,
 							TLS: &gatewayv1.GatewayTLSConfig{
 								Options: map[gatewayv1.AnnotationKey]gatewayv1.AnnotationValue{
 									"test-option": "test-value",
@@ -553,7 +560,7 @@ func TestValidateGateway(t *testing.T) {
 			},
 			opts: GatewayValidationOptions{
 				ValidPortNumbers:   []int{80, 443},
-				ValidProtocolTypes: []gatewayv1.ProtocolType{gatewayv1.HTTPProtocolType, gatewayv1.HTTPSProtocolType},
+				ValidProtocolTypes: defaultValidProtocolTypes,
 			},
 			expectedErrors: field.ErrorList{
 				field.Forbidden(field.NewPath("spec", "listeners").Index(0).Child("tls", "frontendValidation"), ""),
@@ -566,9 +573,9 @@ func TestValidateGateway(t *testing.T) {
 					GatewayClassName: "test-gateway-class",
 					Listeners: []gatewayv1.Listener{
 						{
-							Name:     "http",
-							Protocol: gatewayv1.HTTPProtocolType,
-							Port:     80,
+							Name:     "https",
+							Protocol: gatewayv1.HTTPSProtocolType,
+							Port:     443,
 							TLS: &gatewayv1.GatewayTLSConfig{
 								Options: map[gatewayv1.AnnotationKey]gatewayv1.AnnotationValue{
 									"test-option": "invalid-value",
@@ -580,7 +587,7 @@ func TestValidateGateway(t *testing.T) {
 			},
 			opts: GatewayValidationOptions{
 				ValidPortNumbers:   []int{80, 443},
-				ValidProtocolTypes: []gatewayv1.ProtocolType{gatewayv1.HTTPProtocolType, gatewayv1.HTTPSProtocolType},
+				ValidProtocolTypes: defaultValidProtocolTypes,
 				PermittedTLSOptions: map[string][]string{
 					"test-option": {"test-value"},
 				},
@@ -609,7 +616,7 @@ func TestValidateGateway(t *testing.T) {
 			},
 			opts: GatewayValidationOptions{
 				ValidPortNumbers:   []int{80, 443},
-				ValidProtocolTypes: []gatewayv1.ProtocolType{gatewayv1.HTTPProtocolType, gatewayv1.HTTPSProtocolType},
+				ValidProtocolTypes: defaultValidProtocolTypes,
 				PermittedTLSOptions: map[string][]string{
 					"test-option": {"valid-value"},
 				},

--- a/internal/validation/gateway_validation_test.go
+++ b/internal/validation/gateway_validation_test.go
@@ -15,8 +15,8 @@ import (
 func TestValidateGateway(t *testing.T) {
 
 	defaultValidProtocolTypes := map[int][]gatewayv1.ProtocolType{
-		HTTPPort:  []gatewayv1.ProtocolType{gatewayv1.HTTPProtocolType},
-		HTTPSPort: []gatewayv1.ProtocolType{gatewayv1.HTTPSProtocolType},
+		HTTPPort:  {gatewayv1.HTTPProtocolType},
+		HTTPSPort: {gatewayv1.HTTPSProtocolType},
 	}
 
 	scenarios := map[string]struct {


### PR DESCRIPTION
While working through identifying what alerts are needed for gateways / proxies, I found that the downstream gateway was being programmed with TLS listeners when the upstream gateway did not request them. Due to how the TLS options work, this resulted in the downstream gateway not receiving the cert-manager annotation, and certs not being provisioned for the TLS listeners. This led to a series being present in the alert query I was developing to let the team know when cert provisioning may be failing.

With these changes, the downstream gateway is now only programmed with an HTTP listener for prism addresses when an HTTP listener is present in the upstream gateway, and the same for HTTPS listeners.

I've also adjusted validation to require that TLS options are provided for HTTPS listeners, as otherwise they'd never be valid since there's currently no way to provide a custom cert to reference.