### PR TITLE
Add metric series to track custom hostnames defined on HTTPProxies and Gateways.

### DIFF
--- a/config/resource-metrics/gateways.yaml
+++ b/config/resource-metrics/gateways.yaml
@@ -51,6 +51,16 @@ spec:
             labelsFromPath:
               type: ["type"]
             valueFrom: ["status"]
+      - name: "custom_hostname"
+        help: "Custom hostname defined on the gateway"
+        errorLogV: 10
+        each:
+          type: Info
+          info:
+            path: [spec,listeners]
+            labelsFromPath:
+              hostname: [hostname]
+
     - groupVersionKind:
         group: gateway.networking.k8s.io
         kind: "HTTPRoute"

--- a/config/resource-metrics/httpproxies.yaml
+++ b/config/resource-metrics/httpproxies.yaml
@@ -52,3 +52,12 @@ spec:
               reason: [reason]
               status: [status]
             valueFrom: [status]
+      - name: "custom_hostname"
+        help: "Custom hostname defined on the proxy"
+        errorLogV: 10
+        each:
+          type: Info
+          info:
+            path: [spec,hostnames]
+            labelsFromPath:
+              hostname: []


### PR DESCRIPTION
This change results in the addition of two new metric series:

- `datum_cloud_networking_http_proxy_custom_hostname`
- `datum_cloud_networking_gateway_custom_hostname`

Each series will have a `hostname` label populated with the hostname.