### PR TITLE
Move the webhook kustomization to be a Component so it can be included via Flux Kustomizations.

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -16,6 +16,7 @@ namePrefix: network-services-operator-
 
 components:
 - ../resource-metrics
+- ../webhook
 
 resources:
 - ../crd
@@ -23,7 +24,6 @@ resources:
 - ../manager
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
-- ../webhook
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
 #- ../certmanager
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.

--- a/config/dev/kustomization.yaml
+++ b/config/dev/kustomization.yaml
@@ -3,8 +3,10 @@ namePrefix: network-services-operator-
 
 resources:
   - ../upstream_resources
-  - ../webhook
   - ../certmanager
+
+components:
+  - ../webhook
 
 replacements:
   - source: # Add cert-manager annotation to ValidatingWebhookConfiguration, MutatingWebhookConfiguration and CRDs

--- a/config/e2e/kustomization.yaml
+++ b/config/e2e/kustomization.yaml
@@ -6,10 +6,10 @@ resources:
   - ../rbac
   - ../manager
   - ../certmanager
-  - ../webhook
 
 components:
   - ../rbac_deployment
+  - ../webhook
 
 configMapGenerator:
   - name: config

--- a/config/webhook/kustomization.yaml
+++ b/config/webhook/kustomization.yaml
@@ -1,3 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
 resources:
 - manifests.yaml
 - service.yaml


### PR DESCRIPTION
This is required in order to install webhooks into the core control plane.