### PR TITLE
Install Gateway API and Envoy Gateway API CRDs via direct manifests 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -185,23 +185,23 @@ endif
 
 .PHONY: install
 install: manifests kustomize ## Install CRDs into the K8s cluster specified in ~/.kube/config.
-	$(KUSTOMIZE) build --enable-helm config/dev | $(KUBECTL) apply -f -
+	$(KUSTOMIZE) build config/dev | $(KUBECTL) apply -f -
 
 .PHONY: uninstall
 uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
-	$(KUSTOMIZE) build --enable-helm config/crd | $(KUBECTL) delete --ignore-not-found=$(ignore-not-found) -f -
+	$(KUSTOMIZE) build config/crd | $(KUBECTL) delete --ignore-not-found=$(ignore-not-found) -f -
 
 .PHONY: deploy
 deploy: set-image-controller ## Deploy controller to the K8s cluster specified in ~/.kube/config.
-	$(KUSTOMIZE) build --enable-helm config/default | $(KUBECTL) apply -f -
+	$(KUSTOMIZE) build config/default | $(KUBECTL) apply -f -
 
 .PHONY: deploy-e2e
 deploy-e2e: set-image-controller
-	$(KUSTOMIZE) build --enable-helm config/e2e | $(KUBECTL) apply -f -
+	$(KUSTOMIZE) build config/e2e | $(KUBECTL) apply -f -
 
 .PHONY: undeploy
 undeploy: kustomize ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
-	$(KUSTOMIZE) build --enable-helm config/default | $(KUBECTL) delete --ignore-not-found=$(ignore-not-found) -f -
+	$(KUSTOMIZE) build config/default | $(KUBECTL) delete --ignore-not-found=$(ignore-not-found) -f -
 
 
 

--- a/config/crd/gateway/kustomization.yaml
+++ b/config/crd/gateway/kustomization.yaml
@@ -1,21 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-
-helmCharts:
-- name: gateway-crds-helm
-  repo: oci://docker.io/envoyproxy
-  # IMPORTANT - When upgrading the helm chart, ensure there's no undesired CRDs
-  # added in the new version. If there are, remove them in the patches below.
-  version: v1.5.0
-  releaseName: gateway
-  namespace: kube-system
-  valuesInline:
-    crds:
-      gatewayAPI:
-        enabled: true
-        channel: standard
-      envoyGateway:
-        enabled: true
+resources:
+  - github.com/kubernetes-sigs/gateway-api/config/crd/?ref=v1.3.0
+  - https://github.com/envoyproxy/gateway/releases/download/v1.5.1/envoy-gateway-crds.yaml
 
 patches:
   # Drop resources that shouldn't be added to upstream control planes yet


### PR DESCRIPTION
This is required for use in Flux Kustomization, as it does not support helm chart expansion.