### PR TITLE
Allow management of secrets in the downstream control plane.

### DIFF
--- a/config/rbac_downstream/role.yaml
+++ b/config/rbac_downstream/role.yaml
@@ -44,6 +44,7 @@ rules:
   - ""
   resources:
   - configmaps
+  - secrets
   verbs:
   - get
   - list


### PR DESCRIPTION
In the future, I'd like to see if we can find an approach that only allows management of secrets in downstream namespaces that represent upstream project namespaces.