### PR TITLE
feat: remove location role from network admin

### DIFF
--- a/config/iam/roles/networking-admin.yaml
+++ b/config/iam/roles/networking-admin.yaml
@@ -10,7 +10,6 @@ spec:
   inheritedRoles:
     - name: networking.datumapis.com-viewer
     - name: networking.datumapis.com-gateway-admin
-    - name: networking.datumapis.com-location-admin
     - name: networking.datumapis.com-domain-admin
   includedPermissions:
     - networking.datumapis.com/networks.create


### PR DESCRIPTION
We're not using the location role for now since compute is being deferred. We can remove this role for now.