### PR TITLE
Fix bug with transitioning proxy target domain.

### DIFF
--- a/internal/controller/gateway_controller_test.go
+++ b/internal/controller/gateway_controller_test.go
@@ -685,6 +685,27 @@ func TestEnsureHostnamesClaimed(t *testing.T) {
 				assert.NoError(t, cl.Get(ctx, domainObjectKey, &networkingv1alpha.Domain{}), "expected to find a domain, but encountered an errro")
 			},
 		},
+		{
+			name: "hostname matches address",
+			upstreamGateway: newGateway(testConfig, upstreamNamespace.Name, "test", func(g *gatewayv1.Gateway) {
+				g.Spec.Listeners = []gatewayv1.Listener{
+					{
+						Name:     gatewayv1.SectionName(SchemeHTTP),
+						Port:     DefaultHTTPPort,
+						Protocol: gatewayv1.HTTPProtocolType,
+						Hostname: ptr.To(gatewayv1.Hostname("example.com")),
+					},
+				}
+				g.Status.Addresses = []gatewayv1.GatewayStatusAddress{
+					{
+						Type:  ptr.To(gatewayv1.HostnameAddressType),
+						Value: "example.com",
+					},
+				}
+			}),
+			expectedVerifiedHostnames: []string{"example.com"},
+			expectedClaimedHostnames:  []string{"example.com"},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
If an existing Gateway exists with a DNS address provisioned to a previous target domain, it will attempt to verify ownership of the previous domain, and will remove the hostname from being programmed in the downstream gateway resource.

To address this, consider any value in the Gateway's Address of type HostnameAddressType as verified.