### PR TITLE
fix: missing rbac role

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -65,6 +65,14 @@ rules:
   - patch
   - update
 - apiGroups:
+  - dns.networking.miloapis.com
+  resources:
+  - dnszones
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - externaldns.k8s.io
   resources:
   - dnsendpoints


### PR DESCRIPTION
Adds missing role that should have been auto generated but wasn't. This role is used by the domain controller to automatically verify datum managed dns zones