### PR TITLE
feat: make status.connectionDetails.publicKey.id selectable

### DIFF
--- a/api/v1alpha1/connector_types.go
+++ b/api/v1alpha1/connector_types.go
@@ -171,6 +171,7 @@ const ConnectorNameAnnotation = "networking.datum.org/connector-name"
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:selectablefield:JSONPath=".status.connectionDetails.publicKey.id"
 
 // Connector is the Schema for the connectors API.
 type Connector struct {

--- a/config/crd/bases/networking.datumapis.com_connectors.yaml
+++ b/config/crd/bases/networking.datumapis.com_connectors.yaml
@@ -298,6 +298,8 @@ spec:
         required:
         - spec
         type: object
+    selectableFields:
+    - jsonPath: .status.connectionDetails.publicKey.id
     served: true
     storage: true
     subresources:


### PR DESCRIPTION
* added a new field to be selectable so clients can request a field selector when listing for status.connectionDetails.publicKey.id 
* desktop clients will use this to figure out which connectors belong to that desktop
