### PR TITLE
fix: wait for TLS certificates before enabling WAF

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -48,6 +48,14 @@ rules:
   - list
   - watch
 - apiGroups:
+  - cert-manager.io
+  resources:
+  - certificates
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - coordination.k8s.io
   resources:
   - leases


### PR DESCRIPTION
When a **TrafficProtectionPolicy** targets a Gateway with HTTPS listeners, the **EnvoyPatchPolicy** uses JSONPath selectors to patch the route configuration. However, if the TLS certificate isn't ready yet, Envoy Gateway won't materialize the `filter_chains` for the HTTPS listener, causing the JSONPath selectors to fail with "**ResourceNotFound**" errors.

This resulted in EnvoyPatchPolicies stuck in a non-programmed state with errors like:
> Unable to find xds resources: type.googleapis.com/envoy.config.route.v3.RouteConfiguration/ns-.../gateway/https

The fix adds certificate readiness verification before creating **EnvoyPatchPolicies.** When certificates are pending, the reconciler:
- Sets `Accepted=False` with reason **WaitingForCertificates**
- Lists the pending certificate names in the status message

A watch on downstream **Certificate** resources triggers immediate reconciliation when certificates become ready, ensuring minimal delay once TLS is provisioned.

> [!NOTE]
>
> This is a mitigation. 
>
> Ideally, WAF should be enabled on HTTP listeners independently of HTTPS certificate provisioning status. Future work should decouple HTTP and HTTPS listener patching so traffic protection can be applied to HTTP listeners immediately while waiting for certificates.