### PR TITLE
fix: watch Challenges instead of Certificates for ACME HTTP-01 solver

### DIFF
--- a/internal/controller/gateway_downstream_certificate_solver_controller_test.go
+++ b/internal/controller/gateway_downstream_certificate_solver_controller_test.go
@@ -45,118 +45,147 @@ func TestGatewayDownstreamCertificateSolverReconciler(t *testing.T) {
 		},
 	}
 
-	certNotReadyStatus := map[string]any{
-		"conditions": []any{
-			map[string]any{
-				"type":   "Ready",
-				"status": "False",
-			},
-		},
-	}
-
 	testGateway := newGateway(operatorConfig, testNamespace.Name, "test-gateway")
 
 	tests := []struct {
 		name            string
-		certificate     *unstructured.Unstructured
+		challenge       *unstructured.Unstructured
 		existingObjects []client.Object
 		assert          func(t *testing.T, cl client.Client, result ctrl.Result)
 	}{
 		{
-			name: "Certificate Ready",
-			certificate: newUnstructuredGVK(certificateGVK, "test-cert-ready", testNamespace.Name, func(u *unstructured.Unstructured) {
-				status := map[string]any{
-					"conditions": []any{
-						map[string]any{
-							"type":   "Ready",
-							"status": "True",
-						},
-					},
-				}
-				if err := unstructured.SetNestedMap(u.Object, status, "status"); err != nil {
-					t.Fatalf("failed to set status: %v", err)
-				}
+			name: "Challenge not found",
+			challenge: newUnstructuredGVK(challengeGVK, "nonexistent-challenge", testNamespace.Name, func(u *unstructured.Unstructured) {
+				// This challenge won't be added to the client, simulating deletion
 			}),
 			assert: func(t *testing.T, cl client.Client, result ctrl.Result) {
-				// Expect no requeue
+				// Expect no requeue when challenge is not found
+				assert.Equal(t, ctrl.Result{}, result)
+			},
+		},
+		{
+			name: "Challenge with no owning Order",
+			challenge: newUnstructuredGVK(challengeGVK, "orphan-challenge", testNamespace.Name, func(u *unstructured.Unstructured) {
+				spec := map[string]any{
+					"key":   "test-key",
+					"token": "test-token",
+				}
+				if err := unstructured.SetNestedMap(u.Object, spec, "spec"); err != nil {
+					t.Fatalf("failed to set spec: %v", err)
+				}
+				// No owner reference set
+			}),
+			existingObjects: []client.Object{},
+			assert: func(t *testing.T, cl client.Client, result ctrl.Result) {
+				// Expect no requeue - challenge has no owner
 				assert.Equal(t, ctrl.Result{}, result)
 			},
 		},
 		{
 			name: "Irrelevant issuer",
-			certificate: newUnstructuredGVK(certificateGVK, "test-cert-irrelevant-issuer", testNamespace.Name, func(u *unstructured.Unstructured) {
-				if err := unstructured.SetNestedMap(u.Object, certNotReadyStatus, "status"); err != nil {
-					t.Fatalf("failed to set status: %v", err)
+			challenge: func() *unstructured.Unstructured {
+				order := newUnstructuredGVK(orderGVK, "test-order-irrelevant", testNamespace.Name, func(u *unstructured.Unstructured) {
+					u.SetAnnotations(map[string]string{
+						certManagerCertificateNameAnnotation: "test-cert-irrelevant-issuer",
+					})
+				})
+
+				challenge := newUnstructuredGVK(challengeGVK, "test-challenge-irrelevant", testNamespace.Name, func(u *unstructured.Unstructured) {
+					spec := map[string]any{
+						"key":   "test-key",
+						"token": "test-token",
+					}
+					if err := unstructured.SetNestedMap(u.Object, spec, "spec"); err != nil {
+						t.Fatalf("failed to set spec on Challenge: %v", err)
+					}
+				})
+
+				if err := controllerutil.SetControllerReference(order, challenge, testScheme); err != nil {
+					t.Fatalf("failed to set owner reference on Challenge: %v", err)
 				}
 
-				spec := map[string]any{
-					"issuerRef": map[string]any{
-						"kind": "ClusterIssuer",
-						"name": "some-other-issuer",
-					},
-				}
-				if err := unstructured.SetNestedMap(u.Object, spec, "spec"); err != nil {
-					t.Fatalf("failed to set spec: %v", err)
-				}
-			}),
+				return challenge
+			}(),
+			existingObjects: func() []client.Object {
+				order := newUnstructuredGVK(orderGVK, "test-order-irrelevant", testNamespace.Name, func(u *unstructured.Unstructured) {
+					u.SetAnnotations(map[string]string{
+						certManagerCertificateNameAnnotation: "test-cert-irrelevant-issuer",
+					})
+				})
+
+				certificate := newUnstructuredGVK(certificateGVK, "test-cert-irrelevant-issuer", testNamespace.Name, func(u *unstructured.Unstructured) {
+					spec := map[string]any{
+						"issuerRef": map[string]any{
+							"kind": "ClusterIssuer",
+							"name": "some-other-issuer",
+						},
+					}
+					if err := unstructured.SetNestedMap(u.Object, spec, "spec"); err != nil {
+						t.Fatalf("failed to set spec: %v", err)
+					}
+
+					if err := controllerutil.SetControllerReference(testGateway, u, testScheme); err != nil {
+						t.Fatalf("failed to set owner reference: %v", err)
+					}
+				})
+
+				return []client.Object{order, certificate, testGateway}
+			}(),
 			assert: func(t *testing.T, cl client.Client, result ctrl.Result) {
-				// Expect no requeue
+				// Expect no requeue - issuer not in configured list
 				assert.Equal(t, ctrl.Result{}, result)
 			},
 		},
 		{
 			name: "HTTPRouteFilter and HTTPRoute created",
-			certificate: newUnstructuredGVK(certificateGVK, "test-cert-create-route", testNamespace.Name, func(u *unstructured.Unstructured) {
-				if err := unstructured.SetNestedMap(u.Object, certNotReadyStatus, "status"); err != nil {
-					t.Fatalf("failed to set status: %v", err)
-				}
-
-				spec := map[string]any{
-					"issuerRef": map[string]any{
-						"kind": "ClusterIssuer",
-						"name": "test-issuer",
-					},
-				}
-				if err := unstructured.SetNestedMap(u.Object, spec, "spec"); err != nil {
-					t.Fatalf("failed to set spec: %v", err)
-				}
-
-				if err := controllerutil.SetControllerReference(testGateway, u, testScheme); err != nil {
-					t.Fatalf("failed to set owner reference: %v", err)
-				}
-			}),
-			existingObjects: append(
-				[]client.Object{testGateway},
-				func() []client.Object {
-					var objs []client.Object
-					order := newUnstructuredGVK(orderGVK, "test-order", testNamespace.Name, func(u *unstructured.Unstructured) {
-						u.SetAnnotations(map[string]string{
-							certManagerCertificateNameAnnotation: "test-cert-create-route",
-						})
+			challenge: func() *unstructured.Unstructured {
+				order := newUnstructuredGVK(orderGVK, "test-order", testNamespace.Name, func(u *unstructured.Unstructured) {
+					u.SetAnnotations(map[string]string{
+						certManagerCertificateNameAnnotation: "test-cert-create-route",
 					})
+				})
 
-					objs = append(objs, order)
+				challenge := newUnstructuredGVK(challengeGVK, "test-challenge", testNamespace.Name, func(u *unstructured.Unstructured) {
+					spec := map[string]any{
+						"key":   "test-key",
+						"token": "test-token",
+					}
+					if err := unstructured.SetNestedMap(u.Object, spec, "spec"); err != nil {
+						t.Fatalf("failed to set spec on Challenge: %v", err)
+					}
+				})
 
-					challenge := newUnstructuredGVK(challengeGVK, "test-challenge", testNamespace.Name, func(u *unstructured.Unstructured) {
-						// Set spec.key and spec.token
-						spec := map[string]any{
-							"key":   "test-key",
-							"token": "test-token",
-						}
-						if err := unstructured.SetNestedMap(u.Object, spec, "spec"); err != nil {
-							t.Fatalf("failed to set spec on Challenge: %v", err)
-						}
+				if err := controllerutil.SetControllerReference(order, challenge, testScheme); err != nil {
+					t.Fatalf("failed to set owner reference on Challenge: %v", err)
+				}
+
+				return challenge
+			}(),
+			existingObjects: func() []client.Object {
+				order := newUnstructuredGVK(orderGVK, "test-order", testNamespace.Name, func(u *unstructured.Unstructured) {
+					u.SetAnnotations(map[string]string{
+						certManagerCertificateNameAnnotation: "test-cert-create-route",
 					})
+				})
 
-					if err := controllerutil.SetControllerReference(order, challenge, testScheme); err != nil {
-						t.Fatalf("failed to set owner reference on Challenge: %v", err)
+				certificate := newUnstructuredGVK(certificateGVK, "test-cert-create-route", testNamespace.Name, func(u *unstructured.Unstructured) {
+					spec := map[string]any{
+						"issuerRef": map[string]any{
+							"kind": "ClusterIssuer",
+							"name": "test-issuer",
+						},
+					}
+					if err := unstructured.SetNestedMap(u.Object, spec, "spec"); err != nil {
+						t.Fatalf("failed to set spec: %v", err)
 					}
 
-					objs = append(objs, challenge)
+					if err := controllerutil.SetControllerReference(testGateway, u, testScheme); err != nil {
+						t.Fatalf("failed to set owner reference: %v", err)
+					}
+				})
 
-					return objs
-				}()...,
-			),
+				return []client.Object{order, certificate, testGateway}
+			}(),
 			assert: func(t *testing.T, cl client.Client, result ctrl.Result) {
 				// Expect no requeue
 				assert.Equal(t, ctrl.Result{}, result)
@@ -202,16 +231,131 @@ func TestGatewayDownstreamCertificateSolverReconciler(t *testing.T) {
 				assert.True(t, found, "expected HTTPRoute to have a rule matching the challenge path")
 			},
 		},
+		{
+			name: "HTTPRouteFilter and HTTPRoute created for renewal (certificate already Ready)",
+			challenge: func() *unstructured.Unstructured {
+				order := newUnstructuredGVK(orderGVK, "test-order-renewal", testNamespace.Name, func(u *unstructured.Unstructured) {
+					u.SetAnnotations(map[string]string{
+						certManagerCertificateNameAnnotation: "test-cert-renewal",
+					})
+				})
+
+				challenge := newUnstructuredGVK(challengeGVK, "test-challenge-renewal", testNamespace.Name, func(u *unstructured.Unstructured) {
+					spec := map[string]any{
+						"key":   "renewal-key",
+						"token": "renewal-token",
+					}
+					if err := unstructured.SetNestedMap(u.Object, spec, "spec"); err != nil {
+						t.Fatalf("failed to set spec on Challenge: %v", err)
+					}
+				})
+
+				if err := controllerutil.SetControllerReference(order, challenge, testScheme); err != nil {
+					t.Fatalf("failed to set owner reference on Challenge: %v", err)
+				}
+
+				return challenge
+			}(),
+			existingObjects: func() []client.Object {
+				order := newUnstructuredGVK(orderGVK, "test-order-renewal", testNamespace.Name, func(u *unstructured.Unstructured) {
+					u.SetAnnotations(map[string]string{
+						certManagerCertificateNameAnnotation: "test-cert-renewal",
+					})
+				})
+
+				// Certificate is Ready (simulating renewal scenario)
+				certificate := newUnstructuredGVK(certificateGVK, "test-cert-renewal", testNamespace.Name, func(u *unstructured.Unstructured) {
+					spec := map[string]any{
+						"issuerRef": map[string]any{
+							"kind": "ClusterIssuer",
+							"name": "test-issuer",
+						},
+					}
+					if err := unstructured.SetNestedMap(u.Object, spec, "spec"); err != nil {
+						t.Fatalf("failed to set spec: %v", err)
+					}
+
+					// Set Ready=True to simulate a renewal scenario where the cert is still valid
+					status := map[string]any{
+						"conditions": []any{
+							map[string]any{
+								"type":   "Ready",
+								"status": "True",
+							},
+						},
+					}
+					if err := unstructured.SetNestedMap(u.Object, status, "status"); err != nil {
+						t.Fatalf("failed to set status: %v", err)
+					}
+
+					if err := controllerutil.SetControllerReference(testGateway, u, testScheme); err != nil {
+						t.Fatalf("failed to set owner reference: %v", err)
+					}
+				})
+
+				return []client.Object{order, certificate, testGateway}
+			}(),
+			assert: func(t *testing.T, cl client.Client, result ctrl.Result) {
+				// Expect no requeue
+				assert.Equal(t, ctrl.Result{}, result)
+
+				// Check that HTTPRouteFilter and HTTPRoute were created even though
+				// the certificate is already Ready (this is the key renewal fix)
+				httpRouteFilter := &envoygatewayv1alpha1.HTTPRouteFilter{}
+				err := cl.Get(context.Background(), client.ObjectKey{
+					Namespace: "test",
+					Name:      "test-challenge-renewal",
+				}, httpRouteFilter)
+				assert.NoError(t, err, "expected HTTPRouteFilter to be created for renewal")
+
+				owner := metav1.GetControllerOf(httpRouteFilter)
+				assert.NotNil(t, owner, "expected HTTPRouteFilter to have an owner")
+				assert.Equal(t, "test-challenge-renewal", owner.Name, "expected HTTPRouteFilter to be owned by the challenge")
+
+				// Confirm that the filter's direct response body matches the renewal key
+				assert.Equal(t, "renewal-key", ptr.Deref(httpRouteFilter.Spec.DirectResponse.Body.Inline, ""), "expected HTTPRouteFilter direct response body to match renewal challenge key")
+
+				httpRoute := &gatewayv1.HTTPRoute{}
+				err = cl.Get(context.Background(), client.ObjectKey{
+					Namespace: "test",
+					Name:      "test-challenge-renewal",
+				}, httpRoute)
+				assert.NoError(t, err, "expected HTTPRoute to be created for renewal")
+
+				owner = metav1.GetControllerOf(httpRoute)
+				assert.NotNil(t, owner, "expected HTTPRoute to have an owner")
+				assert.Equal(t, "test-challenge-renewal", owner.Name, "expected HTTPRoute to be owned by the challenge")
+
+				// Confirm that the HTTPRoute has a rule that matches the expected path
+				found := false
+				for _, rule := range httpRoute.Spec.Rules {
+					for _, path := range rule.Matches {
+						if path.Path != nil && ptr.Deref(path.Path.Value, "") == "/.well-known/acme-challenge/renewal-token" {
+							found = true
+							break
+						}
+					}
+				}
+
+				assert.True(t, found, "expected HTTPRoute to have a rule matching the renewal challenge path")
+			},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			objects := []client.Object{testNamespace}
+
+			// Only add challenge to client if it's not the "not found" test case
+			if tt.name != "Challenge not found" {
+				objects = append(objects, tt.challenge)
+			}
+
+			objects = append(objects, tt.existingObjects...)
+
 			fakeDownstreamClient := fake.NewClientBuilder().
 				WithScheme(testScheme).
-				WithObjects(tt.certificate, testNamespace).
-				WithObjects(tt.existingObjects...).
-				WithStatusSubresource(tt.certificate).
-				WithStatusSubresource(tt.existingObjects...).
+				WithObjects(objects...).
 				Build()
 
 			ctx := context.Background()
@@ -224,7 +368,7 @@ func TestGatewayDownstreamCertificateSolverReconciler(t *testing.T) {
 			result, err := reconciler.Reconcile(
 				ctx,
 				ctrl.Request{
-					NamespacedName: client.ObjectKeyFromObject(tt.certificate),
+					NamespacedName: client.ObjectKeyFromObject(tt.challenge),
 				},
 			)
 			if assert.NoError(t, err) {


### PR DESCRIPTION
The downstream certificate solver controller was watching Certificate resources and exiting early when a certificate had `Ready=True status`. This caused certificate renewals to fail because cert-manager creates new Order and Challenge resources for renewals while the existing certificate is still marked as Ready.

By watching Challenge resources directly, the controller now correctly handles both initial certificate issuance and renewals. When a Challenge is created (for either scenario), the controller:

1. Finds the owning Order via controller reference
2. Gets the Certificate name from the Order's annotation
3. Validates the Certificate uses a configured ClusterIssuer
4. Verifies the Certificate is owned by a Gateway
5. Creates the HTTPRoute and HTTPRouteFilter for the ACME challenge

This approach is also more efficient since reconciliation only occurs when there is actual work to do (a Challenge exists), rather than on every Certificate status change.

---

Closes #109 