### PR TITLE
fix: wait for https listener before applying envoypatchpolicy

### DIFF
--- a/internal/controller/httpproxy_controller.go
+++ b/internal/controller/httpproxy_controller.go
@@ -880,15 +880,20 @@ func (r *HTTPProxyReconciler) reconcileConnectorEnvoyPatchPolicy(
 		return nil, false, nil
 	}
 
-	// Wait for the Gateway to be Programmed before creating the EnvoyPatchPolicy.
-	// This ensures the RouteConfiguration exists in Envoy's xDS, so the patch
-	// can be applied immediately rather than waiting for Envoy Gateway to retry.
+	// Wait for the Gateway and default HTTPS listener to be Programmed before
+	// creating the EnvoyPatchPolicy. This ensures the target RouteConfiguration
+	// exists in Envoy's xDS, so the patch can be applied immediately rather than
+	// waiting for Envoy Gateway to retry.
 	gatewayProgrammed := apimeta.IsStatusConditionTrue(
 		gateway.Status.Conditions,
 		string(gatewayv1.GatewayConditionProgrammed),
 	)
-	if !gatewayProgrammed {
-		// Gateway not yet programmed; requeue will happen when Gateway status changes.
+	defaultHTTPSListenerProgrammed := gatewayListenerProgrammed(
+		gateway.Status.Listeners,
+		gatewayutil.DefaultHTTPSListenerName,
+	)
+	if !gatewayProgrammed || !defaultHTTPSListenerProgrammed {
+		// Gateway/listener not yet programmed; requeue will happen when status changes.
 		return nil, true, nil
 	}
 
@@ -981,6 +986,16 @@ func cleanupConnectorOfflineHTTPRouteFilter(ctx context.Context, cl client.Clien
 		return err
 	}
 	return cl.Delete(ctx, &filter)
+}
+
+func gatewayListenerProgrammed(listeners []gatewayv1.ListenerStatus, listenerName gatewayv1.SectionName) bool {
+	for _, listener := range listeners {
+		if listener.Name != listenerName {
+			continue
+		}
+		return apimeta.IsStatusConditionTrue(listener.Conditions, string(gatewayv1.ListenerConditionProgrammed))
+	}
+	return false
 }
 
 func downstreamPatchPolicyReady(policy *envoygatewayv1alpha1.EnvoyPatchPolicy, gatewayClassName string) (bool, string) {

--- a/internal/controller/httpproxy_controller_test.go
+++ b/internal/controller/httpproxy_controller_test.go
@@ -460,7 +460,67 @@ func TestHTTPProxyReconcile(t *testing.T) {
 				},
 			},
 			postCreateGatewayStatus: func(g *gatewayv1.Gateway) {
-				// EnvoyPatchPolicy is only created after Gateway is Programmed
+				setGatewayProgrammedWithDefaultHTTPSListener(g)
+			},
+			expectedError: false,
+			expectedConditions: []metav1.Condition{
+				{
+					Type:   networkingv1alpha.HTTPProxyConditionAccepted,
+					Status: metav1.ConditionTrue,
+					Reason: networkingv1alpha.HTTPProxyReasonAccepted,
+				},
+				{
+					Type:   networkingv1alpha.HTTPProxyConditionProgrammed,
+					Status: metav1.ConditionFalse,
+					Reason: networkingv1alpha.HTTPProxyReasonPending,
+				},
+			},
+			assert: func(t *testContext, cl client.Client, httpProxy *networkingv1alpha.HTTPProxy) {
+				var patchList envoygatewayv1alpha1.EnvoyPatchPolicyList
+				err := t.downstreamClient.List(context.Background(), &patchList)
+				assert.NoError(t, err)
+				assert.Len(t, patchList.Items, 1)
+				assert.Equal(t, fmt.Sprintf("connector-%s", httpProxy.Name), patchList.Items[0].Name)
+			},
+		},
+		{
+			name:              "connector backend waits for default-https listener programmed",
+			httpProxy:         connectorHTTPProxy,
+			downstreamObjects: connectorDownstreamObjects(connectorHTTPProxy),
+			namespaceUID:      string(connectorNamespaceUID),
+			existingObjects: []client.Object{
+				&networkingv1alpha1.Connector{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "connector-1",
+						Namespace: "test",
+					},
+					Status: networkingv1alpha1.ConnectorStatus{
+						Conditions: []metav1.Condition{
+							{
+								Type:   networkingv1alpha1.ConnectorConditionReady,
+								Status: metav1.ConditionTrue,
+								Reason: networkingv1alpha1.ConnectorReasonReady,
+							},
+						},
+						ConnectionDetails: &networkingv1alpha1.ConnectorConnectionDetails{
+							Type: networkingv1alpha1.PublicKeyConnectorConnectionType,
+							PublicKey: &networkingv1alpha1.ConnectorConnectionDetailsPublicKey{
+								Id:            "node-123",
+								DiscoveryMode: networkingv1alpha1.DNSPublicKeyDiscoveryMode,
+								HomeRelay:     "https://relay.example.test",
+								Addresses: []networkingv1alpha1.PublicKeyConnectorAddress{
+									{
+										Address: "127.0.0.1",
+										Port:    80,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			postCreateGatewayStatus: func(g *gatewayv1.Gateway) {
+				// Gateway-level Programmed is not enough without default-https listener Programmed.
 				apimeta.SetStatusCondition(&g.Status.Conditions, metav1.Condition{
 					Type:               string(gatewayv1.GatewayConditionProgrammed),
 					Status:             metav1.ConditionTrue,
@@ -485,8 +545,7 @@ func TestHTTPProxyReconcile(t *testing.T) {
 				var patchList envoygatewayv1alpha1.EnvoyPatchPolicyList
 				err := t.downstreamClient.List(context.Background(), &patchList)
 				assert.NoError(t, err)
-				assert.Len(t, patchList.Items, 1)
-				assert.Equal(t, fmt.Sprintf("connector-%s", httpProxy.Name), patchList.Items[0].Name)
+				assert.Len(t, patchList.Items, 0)
 			},
 		},
 		{
@@ -512,12 +571,7 @@ func TestHTTPProxyReconcile(t *testing.T) {
 				},
 			},
 			postCreateGatewayStatus: func(g *gatewayv1.Gateway) {
-				apimeta.SetStatusCondition(&g.Status.Conditions, metav1.Condition{
-					Type:               string(gatewayv1.GatewayConditionProgrammed),
-					Status:             metav1.ConditionTrue,
-					ObservedGeneration: g.Generation,
-					Reason:             string(gatewayv1.GatewayReasonProgrammed),
-				})
+				setGatewayProgrammedWithDefaultHTTPSListener(g)
 			},
 			expectedError: false,
 			expectedConditions: []metav1.Condition{
@@ -600,13 +654,7 @@ func TestHTTPProxyReconcile(t *testing.T) {
 				},
 			},
 			postCreateGatewayStatus: func(g *gatewayv1.Gateway) {
-				// EnvoyPatchPolicy is only created after Gateway is Programmed
-				apimeta.SetStatusCondition(&g.Status.Conditions, metav1.Condition{
-					Type:               string(gatewayv1.GatewayConditionProgrammed),
-					Status:             metav1.ConditionTrue,
-					ObservedGeneration: g.Generation,
-					Reason:             string(gatewayv1.GatewayReasonProgrammed),
-				})
+				setGatewayProgrammedWithDefaultHTTPSListener(g)
 			},
 			expectedError: false,
 			expectedConditions: []metav1.Condition{
@@ -1506,6 +1554,35 @@ func TestHTTPProxyFinalizerCleanup(t *testing.T) {
 	} else {
 		assert.True(t, apierrors.IsNotFound(err))
 	}
+}
+
+func setGatewayProgrammedWithDefaultHTTPSListener(g *gatewayv1.Gateway) {
+	apimeta.SetStatusCondition(&g.Status.Conditions, metav1.Condition{
+		Type:               string(gatewayv1.GatewayConditionProgrammed),
+		Status:             metav1.ConditionTrue,
+		ObservedGeneration: g.Generation,
+		Reason:             string(gatewayv1.GatewayReasonProgrammed),
+	})
+
+	defaultHTTPSListenerStatus := gatewayv1.ListenerStatus{
+		Name: gatewayutil.DefaultHTTPSListenerName,
+		Conditions: []metav1.Condition{
+			{
+				Type:               string(gatewayv1.ListenerConditionProgrammed),
+				Status:             metav1.ConditionTrue,
+				ObservedGeneration: g.Generation,
+				Reason:             string(gatewayv1.ListenerReasonProgrammed),
+			},
+		},
+	}
+
+	for i := range g.Status.Listeners {
+		if g.Status.Listeners[i].Name == gatewayutil.DefaultHTTPSListenerName {
+			g.Status.Listeners[i] = defaultHTTPSListenerStatus
+			return
+		}
+	}
+	g.Status.Listeners = append(g.Status.Listeners, defaultHTTPSListenerStatus)
 }
 
 func newHTTPProxy(opts ...func(*networkingv1alpha.HTTPProxy)) *networkingv1alpha.HTTPProxy {


### PR DESCRIPTION
* if an envoypatchpolicy is applied too soon before its https listener is programmed, it causes all future patchpolicies to stall and puts envoy in a deadlock state.
* this fix makes httpproxy-connector patches and trafficprotectionpolicy patches wait to apply until after the httpslistener is programmed

Ref: https://github.com/datum-cloud/engineering/issues/178