### PR TITLE
Publish multi-arch (amd64 + arm64) container images

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -16,9 +16,10 @@ jobs:
       contents: read
       packages: write
       attestations: write
-    uses: datum-cloud/actions/.github/workflows/publish-docker.yaml@v1.5.1
+    uses: datum-cloud/actions/.github/workflows/publish-docker.yaml@v1.13.1
     with:
       image-name: network-services-operator
+      platforms: linux/amd64,linux/arm64
     secrets: inherit
 
   publish-kustomize-bundles:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,11 @@
 # Build the manager binary
-FROM golang:1.24 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.24 AS builder
 ARG TARGETOS
 ARG TARGETARCH
+ARG VERSION=dev
+ARG GIT_COMMIT=unknown
+ARG GIT_TREE_STATE=unknown
+ARG BUILD_DATE=unknown
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -21,7 +25,13 @@ COPY internal/ internal/
 # was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
 # the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
-RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager cmd/main.go
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build \
+    -ldflags "-s -w \
+      -X main.version=${VERSION} \
+      -X main.gitCommit=${GIT_COMMIT} \
+      -X main.gitTreeState=${GIT_TREE_STATE} \
+      -X main.buildDate=${BUILD_DATE}" \
+    -o manager cmd/main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -54,6 +54,11 @@ var (
 	scheme   = runtime.NewScheme()
 	setupLog = ctrl.Log.WithName("setup")
 	codecs   = serializer.NewCodecFactory(scheme, serializer.EnableStrict)
+
+	version      = "dev"
+	gitCommit    = "unknown"
+	gitTreeState = "unknown"
+	buildDate    = "unknown"
 )
 
 func init() {
@@ -139,6 +144,13 @@ func main() {
 	flag.Parse()
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+
+	setupLog.Info("starting network-services-operator",
+		"version", version,
+		"gitCommit", gitCommit,
+		"gitTreeState", gitTreeState,
+		"buildDate", buildDate,
+	)
 
 	var serverConfig config.NetworkServicesOperator
 	var configData []byte


### PR DESCRIPTION
## Summary

- Our published container images today are amd64-only, which means developers on Apple Silicon (and any arm64 environment) cannot pull and run them without emulation. This PR switches the publish workflow to build and push both `linux/amd64` and `linux/arm64` images.
- The Dockerfile was unintentionally forcing QEMU emulation whenever arm64 was requested. It's now pinned to the runner's native architecture and cross-compiles the Go binary, which is the standard fast path for pure-Go projects and keeps CI times low.
- Local multi-arch build wall-clock after the fix: ~49 seconds (cold-ish, on an M-series laptop). Prior QEMU-based arm64 builds were 15+ minutes.
- Also threads `version` / `gitCommit` / `gitTreeState` / `buildDate` into the manager binary via `-ldflags -X` so published images carry build metadata and log it at startup.

## Test plan

- [ ] CI publish workflow runs green on this PR
- [ ] `docker buildx imagetools inspect ghcr.io/datum-cloud/network-services-operator:<tag>` shows both `linux/amd64` and `linux/arm64`
- [ ] Pulling and running the image on an Apple Silicon machine works without emulation warnings

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>