### PR TITLE
fix: prevent TPP stale cleanup from deleting connector EPPs

### DIFF
--- a/internal/controller/connector_routing_compiler.go
+++ b/internal/controller/connector_routing_compiler.go
@@ -356,6 +356,50 @@ func buildConnectorConnectRoutes(
 	return connectRoutes
 }
 
+// buildConnectorOfflineEnvoyPatches returns xDS patches for when a connector is
+// not ready. A direct_response CONNECT route is inserted at the front of each
+// HTTPS RouteConfiguration so that in-flight tunnel requests receive a clean
+// 503 instead of a connection error. Using patches instead of deleting the EPP
+// avoids the EG watchable-deduplication race that leaves EPP status null after
+// a delete+create cycle.
+func buildConnectorOfflineEnvoyPatches(
+	downstreamNamespace string,
+	gateway *gatewayv1.Gateway,
+	httpProxy *networkingv1alpha.HTTPProxy,
+) ([]envoygatewayv1alpha1.EnvoyJSONPatchConfig, error) {
+	route := map[string]any{
+		"name": fmt.Sprintf("connector-offline-%s", httpProxy.Name),
+		"match": map[string]any{
+			"connect_matcher": map[string]any{},
+		},
+		"direct_response": map[string]any{
+			"status": 503,
+			"body": map[string]any{
+				"inline_string": "Tunnel not online",
+			},
+		},
+	}
+
+	routeValue, err := json.Marshal(route)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal offline CONNECT route: %w", err)
+	}
+
+	patches := make([]envoygatewayv1alpha1.EnvoyJSONPatchConfig, 0)
+	for _, routeConfigName := range gatewayHTTPSRouteConfigNames(downstreamNamespace, gateway) {
+		patches = append(patches, envoygatewayv1alpha1.EnvoyJSONPatchConfig{
+			Type: "type.googleapis.com/envoy.config.route.v3.RouteConfiguration",
+			Name: routeConfigName,
+			Operation: envoygatewayv1alpha1.JSONPatchOperation{
+				Op:    envoygatewayv1alpha1.JSONPatchOperationType("add"),
+				Path:  ptr.To("/virtual_hosts/0/routes/0"),
+				Value: &apiextensionsv1.JSON{Raw: routeValue},
+			},
+		})
+	}
+	return patches, nil
+}
+
 func connectorRouteJSONPath(
 	downstreamNamespace string,
 	gateway *gatewayv1.Gateway,

--- a/internal/controller/httpproxy_controller.go
+++ b/internal/controller/httpproxy_controller.go
@@ -1343,39 +1343,9 @@ func (r *HTTPProxyReconciler) reconcileConnectorEnvoyPatchPolicy(
 		return nil, false, err
 	}
 
-	connectorBackends, err := collectConnectorBackends(ctx, upstreamClient, httpProxy)
-	if err != nil {
-		return nil, false, err
-	}
-
-	policyName := fmt.Sprintf("connector-%s", httpProxy.Name)
-	policyKey := client.ObjectKey{Namespace: downstreamNamespaceName, Name: policyName}
-	downstreamClient := downstreamStrategy.GetClient()
-
-	if len(connectorBackends) == 0 {
-		var existing envoygatewayv1alpha1.EnvoyPatchPolicy
-		if err := downstreamClient.Get(ctx, policyKey, &existing); err != nil {
-			if apierrors.IsNotFound(err) {
-				if err := downstreamStrategy.DeleteAnchorForObject(ctx, httpProxy); err != nil {
-					return nil, false, err
-				}
-				return nil, false, nil
-			}
-			return nil, false, err
-		}
-		if err := downstreamClient.Delete(ctx, &existing); err != nil {
-			return nil, false, err
-		}
-		if err := downstreamStrategy.DeleteAnchorForObject(ctx, httpProxy); err != nil {
-			return nil, false, err
-		}
-		return nil, false, nil
-	}
-
 	// Wait for the Gateway and default HTTPS listener to be Programmed before
-	// creating the EnvoyPatchPolicy. This ensures the target RouteConfiguration
-	// exists in Envoy's xDS, so the patch can be applied immediately rather than
-	// waiting for Envoy Gateway to retry.
+	// creating or updating the EnvoyPatchPolicy. This ensures the target
+	// RouteConfiguration exists in Envoy's xDS so patches apply immediately.
 	gatewayProgrammed := apimeta.IsStatusConditionTrue(
 		gateway.Status.Conditions,
 		string(gatewayv1.GatewayConditionProgrammed),
@@ -1393,15 +1363,35 @@ func (r *HTTPProxyReconciler) reconcileConnectorEnvoyPatchPolicy(
 		return nil, true, fmt.Errorf("downstreamGatewayClassName is required for connector patching")
 	}
 
-	jsonPatches, err := buildConnectorEnvoyPatches(
-		downstreamNamespaceName,
-		r.Config.Gateway.ConnectorTunnelListenerName(),
-		gateway,
-		httpProxy,
-		connectorBackends,
-	)
+	connectorBackends, err := collectConnectorBackends(ctx, upstreamClient, httpProxy)
 	if err != nil {
-		return nil, true, err
+		return nil, false, err
+	}
+
+	policyName := fmt.Sprintf("connector-%s", httpProxy.Name)
+	downstreamClient := downstreamStrategy.GetClient()
+
+	// Build patches for either the online or offline state. The EPP is always
+	// kept alive (never deleted when the connector is offline) so that EG never
+	// hits a delete+create cycle that can leave EPP status permanently null due
+	// to the watchable deduplication race in Envoy Gateway.
+	var jsonPatches []envoygatewayv1alpha1.EnvoyJSONPatchConfig
+	connectorOnline := len(connectorBackends) > 0
+	if !connectorOnline {
+		// Connector offline: insert a direct_response CONNECT route so clients
+		// receive a clean 503 "Tunnel not ready" instead of a connection error.
+		jsonPatches, err = buildConnectorOfflineEnvoyPatches(downstreamNamespaceName, gateway, httpProxy)
+	} else {
+		jsonPatches, err = buildConnectorEnvoyPatches(
+			downstreamNamespaceName,
+			r.Config.Gateway.ConnectorTunnelListenerName(),
+			gateway,
+			httpProxy,
+			connectorBackends,
+		)
+	}
+	if err != nil {
+		return nil, connectorOnline, err
 	}
 
 	policy := envoygatewayv1alpha1.EnvoyPatchPolicy{
@@ -1426,9 +1416,9 @@ func (r *HTTPProxyReconciler) reconcileConnectorEnvoyPatchPolicy(
 		return nil
 	})
 	if err != nil {
-		return nil, true, err
+		return nil, connectorOnline, err
 	}
-	return &policy, true, nil
+	return &policy, connectorOnline, nil
 }
 
 func (r *HTTPProxyReconciler) cleanupConnectorEnvoyPatchPolicy(

--- a/internal/controller/httpproxy_controller.go
+++ b/internal/controller/httpproxy_controller.go
@@ -1343,6 +1343,31 @@ func (r *HTTPProxyReconciler) reconcileConnectorEnvoyPatchPolicy(
 		return nil, false, err
 	}
 
+	policyName := fmt.Sprintf("connector-%s", httpProxy.Name)
+	policyKey := client.ObjectKey{Namespace: downstreamNamespaceName, Name: policyName}
+	downstreamClient := downstreamStrategy.GetClient()
+
+	// If the HTTPProxy has no connector backends in its spec at all (i.e. the
+	// connector was removed, not just temporarily offline), delete the EPP and
+	// return. This is distinct from the connector being defined but not-ready,
+	// where we keep the EPP alive with offline patches.
+	//
+	// The anchor ConfigMap is intentionally NOT deleted here — it is tied to the
+	// HTTPProxy lifetime, not to whether a connector backend is configured. It
+	// will be cleaned up in cleanupConnectorEnvoyPatchPolicy when the HTTPProxy
+	// is deleted. Deleting the anchor here would cascade-GC any other downstream
+	// resources that share the same anchor as an owner.
+	if !httpProxyHasConnectorBackends(httpProxy) {
+		var existing envoygatewayv1alpha1.EnvoyPatchPolicy
+		if err := downstreamClient.Get(ctx, policyKey, &existing); err != nil {
+			if apierrors.IsNotFound(err) {
+				return nil, false, nil
+			}
+			return nil, false, err
+		}
+		return nil, false, downstreamClient.Delete(ctx, &existing)
+	}
+
 	// Wait for the Gateway and default HTTPS listener to be Programmed before
 	// creating or updating the EnvoyPatchPolicy. This ensures the target
 	// RouteConfiguration exists in Envoy's xDS so patches apply immediately.
@@ -1363,23 +1388,20 @@ func (r *HTTPProxyReconciler) reconcileConnectorEnvoyPatchPolicy(
 		return nil, true, fmt.Errorf("downstreamGatewayClassName is required for connector patching")
 	}
 
+	// Collect connector backends that are currently ready. If none are ready the
+	// connector is offline and we keep the EPP alive with a direct_response route
+	// so EG never hits a delete+create cycle (which causes the watchable
+	// deduplication race that leaves EPP status permanently null).
 	connectorBackends, err := collectConnectorBackends(ctx, upstreamClient, httpProxy)
 	if err != nil {
 		return nil, false, err
 	}
 
-	policyName := fmt.Sprintf("connector-%s", httpProxy.Name)
-	downstreamClient := downstreamStrategy.GetClient()
-
-	// Build patches for either the online or offline state. The EPP is always
-	// kept alive (never deleted when the connector is offline) so that EG never
-	// hits a delete+create cycle that can leave EPP status permanently null due
-	// to the watchable deduplication race in Envoy Gateway.
 	var jsonPatches []envoygatewayv1alpha1.EnvoyJSONPatchConfig
 	connectorOnline := len(connectorBackends) > 0
 	if !connectorOnline {
 		// Connector offline: insert a direct_response CONNECT route so clients
-		// receive a clean 503 "Tunnel not ready" instead of a connection error.
+		// receive a clean 503 "Tunnel not online" instead of a connection error.
 		jsonPatches, err = buildConnectorOfflineEnvoyPatches(downstreamNamespaceName, gateway, httpProxy)
 	} else {
 		jsonPatches, err = buildConnectorEnvoyPatches(
@@ -1611,6 +1633,21 @@ func buildConnectorOfflineHTTPRouteFilter(httpProxy *networkingv1alpha.HTTPProxy
 			},
 		},
 	}
+}
+
+// httpProxyHasConnectorBackends returns true if any backend in the HTTPProxy
+// spec references a connector, regardless of the connector's readiness state.
+// Used to distinguish "connector removed from spec" (→ delete EPP) from
+// "connector defined but offline" (→ update EPP with offline patches).
+func httpProxyHasConnectorBackends(httpProxy *networkingv1alpha.HTTPProxy) bool {
+	for _, rule := range httpProxy.Spec.Rules {
+		for _, backend := range rule.Backends {
+			if backend.Connector != nil {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func connectorReady(ctx context.Context, cl client.Client, namespace, name string) (bool, error) {

--- a/internal/controller/httpproxy_controller_test.go
+++ b/internal/controller/httpproxy_controller_test.go
@@ -602,10 +602,22 @@ func TestHTTPProxyReconcile(t *testing.T) {
 			assert: func(t *testContext, cl client.Client, httpProxy *networkingv1alpha.HTTPProxy) {
 				ctx := context.Background()
 
+				// Connector is offline but still in the spec: EPP should exist with
+				// an offline direct_response CONNECT route rather than being deleted.
 				var patchList envoygatewayv1alpha1.EnvoyPatchPolicyList
 				err := t.downstreamClient.List(ctx, &patchList)
 				assert.NoError(t, err)
-				assert.Len(t, patchList.Items, 0)
+				if assert.Len(t, patchList.Items, 1) {
+					patches := patchList.Items[0].Spec.JSONPatches
+					if assert.Len(t, patches, 1) {
+						assert.Equal(t, "type.googleapis.com/envoy.config.route.v3.RouteConfiguration", string(patches[0].Type))
+						assert.Equal(t, "add", string(patches[0].Operation.Op))
+						raw := string(patches[0].Operation.Value.Raw)
+						assert.Contains(t, raw, "direct_response")
+						assert.Contains(t, raw, "connect_matcher")
+						assert.Contains(t, raw, "Tunnel not online")
+					}
+				}
 
 				httpRouteFilter := &envoygatewayv1alpha1.HTTPRouteFilter{}
 				filterKey := client.ObjectKey{Namespace: httpProxy.Namespace, Name: connectorOfflineFilterName(httpProxy)}

--- a/internal/controller/trafficprotectionpolicy_controller.go
+++ b/internal/controller/trafficprotectionpolicy_controller.go
@@ -63,6 +63,13 @@ const (
 	// The stale-cleanup loop uses this prefix to skip EPPs owned by other
 	// controllers (e.g. the HTTPProxy connector controller uses "connector-<name>").
 	tppEnvoyPatchPolicyPrefix = "tpp-"
+
+	// tppManagedLabel is stamped onto every EnvoyPatchPolicy created or updated
+	// by this controller. Once all existing EPPs have been reconciled and carry
+	// this label, the stale-cleanup loop can switch to a label-selector List
+	// instead of the current prefix check, removing the naming-convention
+	// dependency entirely.
+	tppManagedLabel = "networking.datumapis.com/managed-by-tpp-controller"
 )
 
 // certificateReadinessResult contains the result of checking certificate readiness
@@ -176,6 +183,10 @@ func (r *TrafficProtectionPolicyReconciler) Reconcile(ctx context.Context, req N
 		}}
 
 		result, err := controllerutil.CreateOrUpdate(ctx, downstreamStrategy.GetClient(), &policy, func() error {
+			if policy.Labels == nil {
+				policy.Labels = make(map[string]string)
+			}
+			policy.Labels[tppManagedLabel] = "true"
 			policy.Spec = desiredPolicy.Spec
 			return nil
 		})
@@ -190,6 +201,9 @@ func (r *TrafficProtectionPolicyReconciler) Reconcile(ctx context.Context, req N
 	// "connector-<name>" from the HTTPProxy controller). Filtering by prefix
 	// avoids a label dependency and correctly handles deleted gateways whose EPP
 	// would be missed if we only iterated upstreamGateways.
+	// TODO: once all existing EPPs carry tppManagedLabel (stamped above on every
+	// CreateOrUpdate), switch this List to use a label selector and drop the
+	// prefix check.
 	var existingPolicies envoygatewayv1alpha1.EnvoyPatchPolicyList
 	if err := downstreamStrategy.GetClient().List(
 		ctx,

--- a/internal/controller/trafficprotectionpolicy_controller.go
+++ b/internal/controller/trafficprotectionpolicy_controller.go
@@ -57,6 +57,12 @@ const (
 	// PolicyReasonWaitingForListenersProgrammed indicates that the policy is waiting
 	// for HTTPS listeners to be Programmed=True before EnvoyPatchPolicies can be created.
 	PolicyReasonWaitingForListenersProgrammed gatewayv1alpha2.PolicyConditionReason = "WaitingForListenersProgrammed"
+
+	// tppEnvoyPatchPolicyPrefix is the name prefix for all EnvoyPatchPolicies
+	// written by the TrafficProtectionPolicy controller ("tpp-<gateway-name>").
+	// The stale-cleanup loop uses this prefix to skip EPPs owned by other
+	// controllers (e.g. the HTTPProxy connector controller uses "connector-<name>").
+	tppEnvoyPatchPolicyPrefix = "tpp-"
 )
 
 // certificateReadinessResult contains the result of checking certificate readiness
@@ -179,21 +185,28 @@ func (r *TrafficProtectionPolicyReconciler) Reconcile(ctx context.Context, req N
 		logger.Info("applied envoypatchpolicy to downstream cluster", "namespace", policy.Namespace, "name", policy.Name, "result", result)
 	}
 
+	// Clean up stale EPPs. All EPPs written by this controller are named
+	// "tpp-<gateway-name>"; other controllers use different prefixes (e.g.
+	// "connector-<name>" from the HTTPProxy controller). Filtering by prefix
+	// avoids a label dependency and correctly handles deleted gateways whose EPP
+	// would be missed if we only iterated upstreamGateways.
 	var existingPolicies envoygatewayv1alpha1.EnvoyPatchPolicyList
 	if err := downstreamStrategy.GetClient().List(
 		ctx,
 		&existingPolicies,
 		client.InNamespace(downstreamNamespaceName),
 	); err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to list managed envoypatchpolicies: %w", err)
+		return ctrl.Result{}, fmt.Errorf("failed to list envoypatchpolicies: %w", err)
 	}
 
 	for i := range existingPolicies.Items {
 		existing := &existingPolicies.Items[i]
+		if !strings.HasPrefix(existing.Name, tppEnvoyPatchPolicyPrefix) {
+			continue
+		}
 		if _, ok := desiredPolicyNames[existing.Name]; ok {
 			continue
 		}
-
 		if err := downstreamStrategy.GetClient().Delete(ctx, existing); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to delete stale envoypatchpolicy %s/%s: %w", existing.Namespace, existing.Name, err)
 		}
@@ -1142,7 +1155,7 @@ func (r *TrafficProtectionPolicyReconciler) getDesiredEnvoyPatchPolicies(
 			continue
 		}
 
-		policyName := fmt.Sprintf("tpp-%s", attachmentsForGateway[0].Gateway.Name)
+		policyName := tppEnvoyPatchPolicyPrefix + attachmentsForGateway[0].Gateway.Name
 		desiredPolicies = append(desiredPolicies, &envoygatewayv1alpha1.EnvoyPatchPolicy{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: downstreamNamespaceName,

--- a/internal/controller/trafficprotectionpolicy_controller_test.go
+++ b/internal/controller/trafficprotectionpolicy_controller_test.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -8,6 +9,8 @@ import (
 	"github.com/davecgh/go-spew/spew"
 	envoygatewayv1alpha1 "github.com/envoyproxy/gateway/api/v1alpha1"
 	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -759,7 +762,7 @@ func TestGetDesiredEnvoyPatchPolicies(t *testing.T) {
 
 			var patchPolicy *envoygatewayv1alpha1.EnvoyPatchPolicy
 			for _, p := range patchPolicies {
-				if p.Name == fmt.Sprintf("tpp-%s", attachment.Gateway.Name) {
+				if p.Name == tppEnvoyPatchPolicyPrefix+attachment.Gateway.Name {
 					patchPolicy = p
 					break
 				}
@@ -1458,4 +1461,84 @@ func newTestScheme() *runtime.Scheme {
 	_ = gatewayv1.Install(testScheme)
 	_ = networkingv1alpha.AddToScheme(testScheme)
 	return testScheme
+}
+
+// TestTPPReconcileStaleCleanupPreservesConnectorEPPs is a regression test for the
+// bug where the TPP stale-cleanup loop deleted connector-* EnvoyPatchPolicies that
+// belong to the HTTPProxy controller. The stale cleanup must only delete EPPs whose
+// names carry the "tpp-" prefix (written by this controller); it must leave EPPs
+// with any other prefix untouched.
+func TestTPPReconcileStaleCleanupPreservesConnectorEPPs(t *testing.T) {
+	// Upstream scheme: core (Namespace) + Gateway API + networking CRDs
+	upstreamScheme := runtime.NewScheme()
+	assert.NoError(t, scheme.AddToScheme(upstreamScheme))
+	assert.NoError(t, gatewayv1.Install(upstreamScheme))
+	assert.NoError(t, networkingv1alpha.AddToScheme(upstreamScheme))
+
+	// Downstream scheme: only needs EnvoyPatchPolicy for this test
+	downstreamScheme := runtime.NewScheme()
+	assert.NoError(t, envoygatewayv1alpha1.AddToScheme(downstreamScheme))
+
+	const (
+		upstreamNS   = "default"
+		nsUID        = "test-ns-uid"
+		downstreamNS = "ns-" + nsUID
+	)
+
+	// The upstream namespace must exist so that GetDownstreamNamespaceNameForUpstreamNamespace
+	// can derive "ns-<uid>" from its UID.
+	upstreamNamespace := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: upstreamNS,
+			UID:  nsUID,
+		},
+	}
+	fakeUpstreamClient := fake.NewClientBuilder().
+		WithScheme(upstreamScheme).
+		WithObjects(upstreamNamespace).
+		Build()
+
+	// Pre-populate the downstream cluster with two EPPs:
+	//   connector-tunnel-foo – owned by the HTTPProxy controller (must survive)
+	//   tpp-stale-gw         – an orphaned TPP EPP (must be deleted)
+	connectorEPP := &envoygatewayv1alpha1.EnvoyPatchPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "connector-tunnel-foo", Namespace: downstreamNS},
+	}
+	staleTppEPP := &envoygatewayv1alpha1.EnvoyPatchPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "tpp-stale-gw", Namespace: downstreamNS},
+	}
+	fakeDownstreamClient := fake.NewClientBuilder().
+		WithScheme(downstreamScheme).
+		WithObjects(connectorEPP, staleTppEPP).
+		Build()
+
+	reconciler := &TrafficProtectionPolicyReconciler{
+		mgr:               &fakeMockManager{cl: fakeUpstreamClient},
+		DownstreamCluster: &fakeCluster{cl: fakeDownstreamClient},
+		Config: config.NetworkServicesOperator{
+			Gateway: config.GatewayConfig{
+				// Required by ensureHTTPCorazaListenerFilter; value doesn't matter here.
+				DownstreamGatewayNamespace: "envoy-gateway-system",
+			},
+		},
+	}
+
+	ctx := context.Background()
+	_, err := reconciler.Reconcile(ctx, NamespaceReconcileRequest{
+		Namespace:   upstreamNS,
+		ClusterName: "test-cluster",
+	})
+	assert.NoError(t, err)
+
+	// connector-tunnel-foo must still exist – the stale cleanup must skip it.
+	got := &envoygatewayv1alpha1.EnvoyPatchPolicy{}
+	assert.NoError(t,
+		fakeDownstreamClient.Get(ctx, client.ObjectKey{Name: "connector-tunnel-foo", Namespace: downstreamNS}, got),
+		"connector EPP must not be deleted by TPP stale cleanup",
+	)
+
+	// tpp-stale-gw must have been removed – the stale cleanup must delete it.
+	stale := &envoygatewayv1alpha1.EnvoyPatchPolicy{}
+	err = fakeDownstreamClient.Get(ctx, client.ObjectKey{Name: "tpp-stale-gw", Namespace: downstreamNS}, stale)
+	assert.True(t, apierrors.IsNotFound(err), "stale tpp EPP must be deleted by stale cleanup")
 }


### PR DESCRIPTION
Closes datum-cloud/infra#2196

## Root Cause

Confirmed via NSO pod logs on the `bpkrd` pod at `02:14:00Z`:

```
"deleted stale envoypatchpolicy from downstream cluster"
{"controller": "trafficprotectionpolicy", "name": "connector-tunnel-ttqpb"}
```

The `TrafficProtectionPolicy` stale-cleanup loop listed **all** `EnvoyPatchPolicies` in the downstream namespace and deleted any not in its desired set. Whenever a Gateway or HTTPRoute change triggered a TPP reconcile (e.g. on NSO pod failover), it silently deleted `connector-<name>` EPPs that belong to the HTTPProxy controller.

This delete+create cycle then triggered Envoy Gateway's watchable deduplication bug: the recreated EPP has the same name and `generation=1` as the previous one, so EG's in-memory map suppresses the status write → EPP status stays null permanently.

## Fix

Scope the stale-cleanup loop to names with the `"tpp-"` prefix. All EPPs written by the TPP controller are named `tpp-<gateway-name>`; the HTTPProxy controller uses `connector-<name>`. The prefix guard is O(1) per item, requires no label dependencies, and correctly handles deleted gateways whose orphaned EPP would be missed if we only iterated the live gateway list.

## Changes

- Add `tppEnvoyPatchPolicyPrefix = "tpp-"` constant
- Skip EPPs in stale-cleanup loop that don't carry the `"tpp-"` prefix
- Use the constant at the naming site in `getDesiredEnvoyPatchPolicies`
- Regression test: TPP reconcile with no active TPPs deletes stale `tpp-*` EPPs but leaves `connector-*` EPPs untouched

## Previous commits (still included)

The earlier commits on this branch keep the connector EPP alive when a connector goes offline (replacing delete with a `direct_response 503` spec), which eliminates a separate source of delete+create cycles. Both fixes are complementary.

## Test plan

- [x] Deploy with a connector-backed HTTPProxy; trigger a TPP reconcile (e.g. create/delete a Gateway in the same namespace) — confirm `connector-*` EPP is not deleted
- [x] Take the connector offline — confirm EPP spec switches to `direct_response` route and EPP status remains set
- [x] Bring connector back online — confirm EPP spec switches back and status remains `Accepted+Programmed`
- [x] Confirm CONNECT requests return `503 "Tunnel not online"` while connector is offline