### PR TITLE
fix: unblock E2E Tests workflow

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -503,10 +503,16 @@ func main() {
 		})
 	}
 
-	setupLog.Info("starting cluster discovery provider")
-	g.Go(func() error {
-		return ignoreCanceled(provider.Run(ctx, mgr))
-	})
+	// Providers that still implement the legacy Run(ctx, mgr) shape (e.g. the
+	// Milo provider) must be started by us. Providers that implement upstream's
+	// multicluster.ProviderRunnable interface (e.g. mcsingle) are started
+	// automatically by mgr.Start, so we skip them here.
+	if runner, ok := provider.(legacyRunnableProvider); ok {
+		setupLog.Info("starting cluster discovery provider")
+		g.Go(func() error {
+			return ignoreCanceled(runner.Run(ctx, mgr))
+		})
+	}
 
 	g.Go(func() error {
 		return ignoreCanceled(downstreamCluster.Start(ctx))
@@ -530,38 +536,27 @@ func main() {
 	}
 }
 
-type runnableProvider interface {
+// legacyRunnableProvider matches providers that still expose the pre-upstream
+// Run(ctx, mgr) shape (notably the Milo provider). Upstream multicluster-runtime
+// has moved to multicluster.ProviderRunnable (Start(ctx, Aware)), which the
+// manager starts automatically. Once Milo migrates this interface can be
+// removed along with the manual goroutine that drives it.
+type legacyRunnableProvider interface {
 	multicluster.Provider
 	Run(context.Context, mcmanager.Manager) error
-}
-
-// Needed until we contribute the patch in the following PR again (need to sign CLA):
-//
-//	See: https://github.com/kubernetes-sigs/multicluster-runtime/pull/18
-type wrappedSingleClusterProvider struct {
-	multicluster.Provider
-	cluster cluster.Cluster
-}
-
-func (p *wrappedSingleClusterProvider) Run(ctx context.Context, mgr mcmanager.Manager) error {
-	if err := mgr.Engage(ctx, "single", p.cluster); err != nil {
-		return err
-	}
-	return p.Provider.(runnableProvider).Run(ctx, mgr)
 }
 
 func initializeClusterDiscovery(
 	serverConfig config.NetworkServicesOperator,
 	deploymentCluster cluster.Cluster,
 	scheme *runtime.Scheme,
-) (runnables []manager.Runnable, provider runnableProvider, err error) {
+) (runnables []manager.Runnable, provider multicluster.Provider, err error) {
 	runnables = append(runnables, deploymentCluster)
 	switch serverConfig.Discovery.Mode {
 	case multiclusterproviders.ProviderSingle:
-		provider = &wrappedSingleClusterProvider{
-			Provider: mcsingle.New("single", deploymentCluster),
-			cluster:  deploymentCluster,
-		}
+		// mcsingle implements multicluster.ProviderRunnable; mgr.Start engages
+		// the cluster and blocks for us — no wrapper needed.
+		provider = mcsingle.New("single", deploymentCluster)
 
 	case multiclusterproviders.ProviderMilo:
 		discoveryRestConfig, err := serverConfig.Discovery.DiscoveryRestConfig()

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -433,6 +433,13 @@ func main() {
 		os.Exit(1)
 	}
 
+	if serverConfig.Gateway.EnableDNSIntegration {
+		if err := controller.AddDNSZoneDomainNameIndexer(ctx, mgr); err != nil {
+			setupLog.Error(err, "unable to add DNSZone indexer")
+			os.Exit(1)
+		}
+	}
+
 	if err := networkinggatewayv1webhooks.SetupGatewayWebhookWithManager(mgr, serverConfig); err != nil {
 		setupLog.Error(err, "unable to create webhook", "webhook", "Gateway")
 		os.Exit(1)

--- a/internal/controller/gateway_controller.go
+++ b/internal/controller/gateway_controller.go
@@ -475,9 +475,12 @@ func (r *GatewayReconciler) ensureListenerCertificates(
 
 	desiredCerts := make(map[string]bool)
 
-	// Only create Certificates for listeners with custom hostnames outside the
-	// wildcard scope. Wildcard-covered listeners use the shared TLS secret and
-	// don't need individual Certificates.
+	// Wildcard-covered listeners are covered by the shared TLS secret only when
+	// one is configured (DefaultListenerTLSSecretName). Otherwise they need a
+	// per-listener Certificate just like any other listener — the downstream
+	// listener already references a per-listener secret name via
+	// ensureDownstreamGateway, and nothing else creates that secret.
+	hasSharedSecret := r.Config.Gateway.HasDefaultListenerTLSSecret()
 	for _, l := range upstreamGateway.Spec.Listeners {
 		if l.TLS == nil || l.TLS.Options[certificateIssuerTLSOption] == "" || l.Hostname == nil {
 			continue
@@ -486,8 +489,7 @@ func (r *GatewayReconciler) ensureListenerCertificates(
 		if !slices.Contains(claimedHostnames, hostname) {
 			continue
 		}
-		// Skip hostnames covered by the wildcard — they use the shared secret.
-		if strings.HasSuffix(hostname, wildcardSuffix) || hostname == r.Config.Gateway.TargetDomain {
+		if hasSharedSecret && (strings.HasSuffix(hostname, wildcardSuffix) || hostname == r.Config.Gateway.TargetDomain) {
 			continue
 		}
 

--- a/internal/controller/gateway_controller.go
+++ b/internal/controller/gateway_controller.go
@@ -52,6 +52,12 @@ import (
 const gatewayControllerFinalizer = "gateway.networking.datumapis.com/gateway-controller"
 const gatewayControllerGCFinalizer = "gateway.networking.datumapis.com/gateway-controller-gc"
 const certificateIssuerTLSOption = "gateway.networking.datumapis.com/certificate-issuer"
+
+// autoIssuerSentinel is the placeholder value the defaulting webhook stamps
+// onto the operator-injected default-https listener via
+// listenerTLSOptions. It means "use whichever real issuer the user's other
+// TLS listener on this gateway specified" — see resolveAutoIssuer.
+const autoIssuerSentinel = "auto"
 const KindGateway = "Gateway"
 const KindHTTPRoute = "HTTPRoute"
 const KindService = "Service"
@@ -458,6 +464,33 @@ func listenerCertificateName(gatewayName string, listenerName gatewayv1.SectionN
 	return resourcename.GetValidDNS1123Name(fmt.Sprintf("%s-%s", gatewayName, listenerName))
 }
 
+// resolveAutoIssuer returns the first non-`auto` certificate-issuer value
+// found on any TLS listener of the gateway, mapped through ClusterIssuerMap.
+// Returns "" when no listener carries a real issuer.
+//
+// This restores the gateway-shim era semantic where the operator set a single
+// cert-manager.io/cluster-issuer annotation on the downstream Gateway from
+// the first TLS listener with an issuer (see the `if !HasAnnotation` guard
+// in pre-`feat: gateway controller certificates` code) and gateway-shim
+// minted Certificates for every TLS listener — including the auto-injected
+// default-https — using that one annotation.
+func (r *GatewayReconciler) resolveAutoIssuer(gateway *gatewayv1.Gateway) string {
+	for _, l := range gateway.Spec.Listeners {
+		if l.TLS == nil {
+			continue
+		}
+		issuer := string(l.TLS.Options[certificateIssuerTLSOption])
+		if issuer == "" || issuer == autoIssuerSentinel {
+			continue
+		}
+		if mapped := r.Config.Gateway.ClusterIssuerMap[issuer]; mapped != "" {
+			return mapped
+		}
+		return issuer
+	}
+	return ""
+}
+
 // ensureListenerCertificates creates, updates, or deletes cert-manager
 // Certificate resources for each listener that requires an individual TLS
 // certificate. Listeners whose hostnames fall under the wildcard target domain
@@ -481,6 +514,20 @@ func (r *GatewayReconciler) ensureListenerCertificates(
 	// listener already references a per-listener secret name via
 	// ensureDownstreamGateway, and nothing else creates that secret.
 	hasSharedSecret := r.Config.Gateway.HasDefaultListenerTLSSecret()
+
+	// The defaulting webhook stamps the operator-injected default-https
+	// listener with `certificate-issuer: auto` (the listenerTLSOptions
+	// default). Pre-`feat: gateway controller certificates`, the operator set
+	// a single cert-manager.io/cluster-issuer annotation on the downstream
+	// Gateway from the first listener with a real issuer, and gateway-shim
+	// minted Certificates for every TLS listener from that one annotation —
+	// so `auto` was implicitly resolved to whatever the user's other listener
+	// specified. With per-listener Certificate creation, that implicit
+	// resolution disappeared. Restore it: when a listener's issuer is `auto`,
+	// fall back to the first real issuer found on any TLS listener of this
+	// gateway, mapped through ClusterIssuerMap.
+	autoResolved := r.resolveAutoIssuer(upstreamGateway)
+
 	for _, l := range upstreamGateway.Spec.Listeners {
 		if l.TLS == nil || l.TLS.Options[certificateIssuerTLSOption] == "" || l.Hostname == nil {
 			continue
@@ -494,7 +541,16 @@ func (r *GatewayReconciler) ensureListenerCertificates(
 		}
 
 		clusterIssuerName := string(l.TLS.Options[certificateIssuerTLSOption])
-		if mapped := r.Config.Gateway.ClusterIssuerMap[clusterIssuerName]; mapped != "" {
+		if clusterIssuerName == autoIssuerSentinel {
+			if autoResolved == "" {
+				// No real issuer on this gateway to inherit from — match the
+				// pre-migration behavior of leaving the listener un-programmed
+				// rather than creating a Certificate with an unresolvable
+				// IssuerRef.
+				continue
+			}
+			clusterIssuerName = autoResolved
+		} else if mapped := r.Config.Gateway.ClusterIssuerMap[clusterIssuerName]; mapped != "" {
 			clusterIssuerName = mapped
 		}
 

--- a/internal/controller/indexers.go
+++ b/internal/controller/indexers.go
@@ -24,7 +24,6 @@ const (
 func AddIndexers(ctx context.Context, mgr mcmanager.Manager) error {
 	return errors.Join(
 		addNetworkContextControllerIndexers(ctx, mgr),
-		addDNSZoneDomainNameIndexer(ctx, mgr),
 	)
 }
 
@@ -99,7 +98,13 @@ func ownerIndexValue(kind, name string) string {
 	return fmt.Sprintf("%s:%s", kind, name)
 }
 
-func addDNSZoneDomainNameIndexer(ctx context.Context, mgr mcmanager.Manager) error {
+// AddDNSZoneDomainNameIndexer registers the DNSZone spec.domainName field
+// indexer used by the Gateway DNS controller. The DNSZone CRD lives in the
+// dns-operator project (dns.networking.miloapis.com/v1alpha1) and is only
+// installed in environments where DNS integration is enabled, so callers
+// must gate this on Gateway.EnableDNSIntegration to avoid a startup failure
+// when the CRD is absent.
+func AddDNSZoneDomainNameIndexer(ctx context.Context, mgr mcmanager.Manager) error {
 	if err := mgr.GetFieldIndexer().IndexField(ctx, &dnsv1alpha1.DNSZone{}, dnsZoneDomainNameIndex, func(o client.Object) []string {
 		zone := o.(*dnsv1alpha1.DNSZone)
 		if zone.Spec.DomainName == "" {

--- a/test/e2e/gateway/chainsaw-test.yaml
+++ b/test/e2e/gateway/chainsaw-test.yaml
@@ -339,7 +339,7 @@ spec:
             skipLogOutput: true
             cluster: nso-standard
             content: |
-              kubectl get gateway test-gateway -o json
+              kubectl -n $NAMESPACE get gateway test-gateway -o json
             outputs:
               - name: upstreamGatewayPostStatus
                 value: (json_parse($stdout))

--- a/test/e2e/gateway/chainsaw-test.yaml
+++ b/test/e2e/gateway/chainsaw-test.yaml
@@ -313,6 +313,39 @@ spec:
                     name: test-gateway
                 value: (@)
 
+        # The operator now derives the gateway's canonical hostname from a word
+        # dictionary + entropy seeded by the gateway UID (see internal/words),
+        # so the hostname can't be reconstructed inline by the test. Wait for
+        # the operator to publish the hostname on the upstream gateway's
+        # status.addresses, then capture it for use in the asserts below.
+        - assert:
+            timeout: 120s
+            cluster: nso-standard
+            resource:
+              apiVersion: gateway.networking.k8s.io/v1
+              kind: Gateway
+              metadata:
+                name: test-gateway
+              (status.addresses[?type == 'Hostname'] | length(@) >= `1`): true
+
+        - script:
+            skipCommandOutput: true
+            skipLogOutput: true
+            cluster: nso-standard
+            content: |
+              kubectl get gateway test-gateway -o json
+            outputs:
+              - name: upstreamGatewayPostStatus
+                value: (json_parse($stdout))
+              # Operator emits the bare canonical hostname first, followed by
+              # v4. and v6. variants — see internal/controller/gateway_controller.go.
+              - name: primaryHostname
+                value: ($upstreamGatewayPostStatus.status.addresses[?type == 'Hostname'].value | [0])
+              - name: v4IPFamilyHostname
+                value: (join('.', ['v4', $primaryHostname]))
+              - name: v6IPFamilyHostname
+                value: (join('.', ['v6', $primaryHostname]))
+
         # Ensure the downstream gateway was created as expected
         - assert:
             timeout: 120s
@@ -348,14 +381,14 @@ spec:
                 - allowedRoutes:
                     namespaces:
                       from: Same
-                  hostname: (join('.', [replace_all($upstreamGateway.metadata.uid, '-', ''), 'prism.e2e.env.datum.net']))
+                  hostname: ($primaryHostname)
                   name: default-http
                   port: 80
                   protocol: HTTP
                 - allowedRoutes:
                     namespaces:
                       from: Same
-                  hostname: (join('.', [replace_all($upstreamGateway.metadata.uid, '-', ''), 'prism.e2e.env.datum.net']))
+                  hostname: ($primaryHostname)
                   name: default-https
                   port: 443
                   protocol: HTTPS
@@ -422,13 +455,6 @@ spec:
         - assert:
             # timeout: 5s
             cluster: nso-infra
-            bindings:
-              - name: primaryHostname
-                value: (join('.', [replace_all($upstreamGateway.metadata.uid, '-', ''), 'prism.e2e.env.datum.net']))
-              - name: v4IPFamilyHostname
-                value: (join('.', ['v4', $primaryHostname]))
-              - name: v6IPFamilyHostname
-                value: (join('.', ['v6', $primaryHostname]))
             resource:
               apiVersion: externaldns.k8s.io/v1alpha1
               kind: DNSEndpoint
@@ -466,11 +492,11 @@ spec:
               status:
                 addresses:
                   - type: Hostname
-                    value: (join('.', [replace_all($upstreamGateway.metadata.uid, '-', ''), 'prism.e2e.env.datum.net']))
+                    value: ($primaryHostname)
                   - type: Hostname
-                    value: (join('.', ['v4', replace_all($upstreamGateway.metadata.uid, '-', ''), 'prism.e2e.env.datum.net']))
+                    value: ($v4IPFamilyHostname)
                   - type: Hostname
-                    value: (join('.', ['v6', replace_all($upstreamGateway.metadata.uid, '-', ''), 'prism.e2e.env.datum.net']))
+                    value: ($v6IPFamilyHostname)
                 listeners:
                   - attachedRoutes: 0
                     (conditions[?type == 'Programmed']):
@@ -780,7 +806,7 @@ spec:
                   - name: GATEWAY_SERVICE_NAMESPACE
                     value: ($gatewayService.metadata.namespace)
                   - name: PRIMARY_HOSTNAME
-                    value: (join('.', [replace_all($upstreamGateway.metadata.uid, '-', ''), 'prism.e2e.env.datum.net']))
+                    value: ($primaryHostname)
                   lifecycle:
                     postStart:
                       exec:

--- a/test/e2e/gateway/chainsaw-test.yaml
+++ b/test/e2e/gateway/chainsaw-test.yaml
@@ -326,7 +326,9 @@ spec:
               kind: Gateway
               metadata:
                 name: test-gateway
-              (status.addresses[?type == 'Hostname'] | length(@) >= `1`): true
+              status:
+                addresses:
+                  - type: Hostname
 
         - script:
             skipCommandOutput: true

--- a/test/e2e/gateway/chainsaw-test.yaml
+++ b/test/e2e/gateway/chainsaw-test.yaml
@@ -327,8 +327,12 @@ spec:
               metadata:
                 name: test-gateway
               status:
-                addresses:
-                  - type: Hostname
+                # JMESPath filter form: returns a list, length-matched against
+                # the expected; bare key + literal list would length-match the
+                # whole addresses slice and fail until the operator populates
+                # all 3 entries even though we already have what we need.
+                (addresses[?type == 'Hostname'] | [0]):
+                  type: Hostname
 
         - script:
             skipCommandOutput: true

--- a/test/e2e/gateway/chainsaw-test.yaml
+++ b/test/e2e/gateway/chainsaw-test.yaml
@@ -775,6 +775,12 @@ spec:
             outputs:
               - name: upstreamGateway
                 value: (json_parse($stdout))
+              # Re-derive in this step's scope; chainsaw bindings don't carry
+              # across steps, and the operator-published canonical hostname is
+              # word-derived from the gateway UID and can't be reconstructed
+              # inline.
+              - name: primaryHostname
+                value: ($upstreamGateway.status.addresses[?type == 'Hostname'].value | [0])
 
         - script:
             skipCommandOutput: true


### PR DESCRIPTION
## Summary

Fixed the e2e tests and brought them up to date. 

**Operator (`cmd/main.go`, `internal/controller/`):**

- Gate the `DNSZone` field indexer on `Gateway.EnableDNSIntegration`. Unconditional registration crashed startup in clusters without the dns-operator CRDs (e.g. e2e), which cascaded into webhook timeouts on every `Domain` operation.
- Drop the `wrappedSingleClusterProvider` shim. Upstream `multicluster-runtime` migrated `single.Provider` to `multicluster.ProviderRunnable`; the type assertion in the shim panicked at startup. The Milo provider hasn't migrated yet, so its `Run(ctx, mgr)` shape is preserved behind a guarded `legacyRunnableProvider` interface.
- In `ensureListenerCertificates`, gate the wildcard-hostname skip on `HasDefaultListenerTLSSecret`. With no shared secret configured, wildcard listeners (including the auto-injected `default-https`) need per-listener `Certificate` resources — `ensureDownstreamGateway` was already pointing them at per-listener secret names with nothing to back them.
- Resolve the `auto` `certificate-issuer` sentinel to the first real issuer found on any TLS listener of the gateway (mapped through `ClusterIssuerMap`). Restores the gateway-shim era semantic that was lost when per-listener `Certificate` creation replaced the gateway-level annotation in `feat: gateway controller certificates`. Without this, the auto-injected `default-https` listener got a `Certificate` with `IssuerRef.Name = "auto"` and cert-manager had nothing to issue against.

**E2E test (`test/e2e/gateway/chainsaw-test.yaml`):**

- Capture the canonical gateway hostname at runtime from `status.addresses` (it's now word-derived from the gateway UID — `<word>-<word>-<5char>.<targetDomain>` — and can't be reconstructed inline). Used in place of every `replace_all($upstreamGateway.metadata.uid, '-', '')` site in the listener / DNSEndpoint / status assertions.
- Use the chainsaw filter idiom `(addresses[?type == 'Hostname'] | [0])` to wait for the slice to be populated; bare-key list assertions length-match against the full slice.
- Pass `-n $NAMESPACE` on the `kubectl get gateway` capture; chainsaw scripts don't pick up the auto-applied namespace the way `assert` resources do.
- Re-derive `$primaryHostname` in the connectivity-test step. Chainsaw bindings are step-scoped.

Ref: #116