### PR TITLE
fix(gateway): respect ClusterIssuerMap[auto] before inter-listener fallback

### DIFF
--- a/internal/controller/gateway_controller.go
+++ b/internal/controller/gateway_controller.go
@@ -540,7 +540,15 @@ func (r *GatewayReconciler) ensureListenerCertificates(
 			continue
 		}
 
+		// Apply ClusterIssuerMap translation first — this is the admin-level
+		// override (e.g. mapping the `auto` sentinel to a real ClusterIssuer
+		// name). Only fall back to the gateway-shim era inter-listener
+		// resolution when the sentinel survives mapping unchanged, i.e. when
+		// the admin hasn't provided a translation.
 		clusterIssuerName := string(l.TLS.Options[certificateIssuerTLSOption])
+		if mapped := r.Config.Gateway.ClusterIssuerMap[clusterIssuerName]; mapped != "" {
+			clusterIssuerName = mapped
+		}
 		if clusterIssuerName == autoIssuerSentinel {
 			if autoResolved == "" {
 				// No real issuer on this gateway to inherit from — match the
@@ -550,8 +558,6 @@ func (r *GatewayReconciler) ensureListenerCertificates(
 				continue
 			}
 			clusterIssuerName = autoResolved
-		} else if mapped := r.Config.Gateway.ClusterIssuerMap[clusterIssuerName]; mapped != "" {
-			clusterIssuerName = mapped
 		}
 
 		certName := listenerCertificateName(upstreamGateway.Name, l.Name)

--- a/internal/controller/gateway_controller_test.go
+++ b/internal/controller/gateway_controller_test.go
@@ -319,6 +319,7 @@ func TestEnsureDownstreamGatewayWildcardCert(t *testing.T) {
 	tests := []struct {
 		name                      string
 		defaultTLSSecretName      string
+		configMutator             func(*config.GatewayConfig)
 		upstreamGateway           *gatewayv1.Gateway
 		existingUpstreamObjects   []client.Object
 		existingDownstreamObjects []client.Object
@@ -536,6 +537,69 @@ func TestEnsureDownstreamGatewayWildcardCert(t *testing.T) {
 				)
 			},
 		},
+		{
+			// Regression: ClusterIssuerMap[auto] must be applied before the
+			// inter-listener `auto` fallback. In deployments where every TLS
+			// listener carries `certificate-issuer: auto` (e.g. staging maps
+			// auto -> datum-gateway-http), the cert reconciler must still
+			// create a per-listener Certificate referencing the mapped issuer.
+			// Skipping the listener under those conditions surfaced as
+			// "Certificate not found in downstream cluster" on HTTPProxy.
+			name:                 "auto issuer translated via ClusterIssuerMap creates per-listener cert",
+			defaultTLSSecretName: defaultTLSSecretName,
+			configMutator: func(g *config.GatewayConfig) {
+				g.ClusterIssuerMap = map[string]string{
+					autoIssuerSentinel: "real-issuer",
+				}
+				g.ListenerTLSOptions = map[gatewayv1.AnnotationKey]gatewayv1.AnnotationValue{
+					gatewayv1.AnnotationKey(certificateIssuerTLSOption): autoIssuerSentinel,
+				}
+			},
+			upstreamGateway: newGateway(config.NetworkServicesOperator{Gateway: baseConfig}, upstreamNamespace.Name, "test-gw", func(g *gatewayv1.Gateway) {
+				g.Spec.Listeners = append(g.Spec.Listeners,
+					gatewayv1.Listener{
+						Name:     "https-hostname-0",
+						Protocol: gatewayv1.HTTPSProtocolType,
+						Port:     DefaultHTTPSPort,
+						Hostname: ptr.To(gatewayv1.Hostname("custom.example.com")),
+						AllowedRoutes: &gatewayv1.AllowedRoutes{
+							Namespaces: &gatewayv1.RouteNamespaces{
+								From: ptr.To(gatewayv1.NamespacesFromSame),
+							},
+						},
+						TLS: &gatewayv1.GatewayTLSConfig{
+							Mode: ptr.To(gatewayv1.TLSModeTerminate),
+							Options: map[gatewayv1.AnnotationKey]gatewayv1.AnnotationValue{
+								gatewayv1.AnnotationKey(certificateIssuerTLSOption): autoIssuerSentinel,
+							},
+						},
+					},
+				)
+			}),
+			existingUpstreamObjects: []client.Object{
+				newDomain(upstreamNamespace.Name, "custom.example.com", func(d *networkingv1alpha.Domain) {
+					d.Spec.DomainName = "custom.example.com"
+					apimeta.SetStatusCondition(&d.Status.Conditions, metav1.Condition{
+						Type:   networkingv1alpha.DomainConditionVerified,
+						Status: metav1.ConditionTrue,
+					})
+				}),
+			},
+			assertDownstream: func(t *testing.T, downstreamClient client.Client, downstreamGateway *gatewayv1.Gateway) {
+				var cert cmv1.Certificate
+				certKey := client.ObjectKey{
+					Namespace: downstreamGateway.Namespace,
+					Name:      listenerCertificateName("test-gw", "https-hostname-0"),
+				}
+				if assert.NoError(t, downstreamClient.Get(context.Background(), certKey, &cert),
+					"Certificate must be created when ClusterIssuerMap maps auto to a real issuer",
+				) {
+					assert.Equal(t, "real-issuer", cert.Spec.IssuerRef.Name,
+						"Certificate IssuerRef must use the ClusterIssuerMap-translated value, not the literal `auto` sentinel",
+					)
+				}
+			},
+		},
 	}
 
 	logger := zap.New(zap.UseFlagOptions(&zap.Options{Development: true}))
@@ -544,6 +608,9 @@ func TestEnsureDownstreamGatewayWildcardCert(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			testCfg := config.NetworkServicesOperator{Gateway: *baseConfig.DeepCopy()}
 			testCfg.Gateway.DefaultListenerTLSSecretName = tt.defaultTLSSecretName
+			if tt.configMutator != nil {
+				tt.configMutator(&testCfg.Gateway)
+			}
 
 			tt.existingUpstreamObjects = append(tt.existingUpstreamObjects, &gatewayv1.GatewayClass{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
## Summary

Regression introduced by #143. The new `auto` inter-listener resolution was placed ahead of the existing `ClusterIssuerMap` lookup, which silently bypasses admin-level translations like staging's:

```yaml
gateway:
  clusterIssuerMap:
    auto: datum-gateway-http
```

In that config, both the operator-injected default-https and any custom-hostname listener carry `certificate-issuer: auto`. Pre-#143, both got mapped to `datum-gateway-http` via ClusterIssuerMap and a Certificate was created. Post-#143, the new code matches the sentinel first, calls `resolveAutoIssuer` (which finds no other real issuer because every TLS listener is `auto`), hits the `continue`, and skips Certificate creation entirely. Custom domains then surface as **"Certificate not found in downstream cluster"**.

Reorder so `ClusterIssuerMap` is consulted first; only fall back to inter-listener resolution when the value is **still** `auto` after mapping (i.e. the admin didn't provide a translation, which is the e2e case #143 was originally addressing).

## Validated against staging

- Staging operator deployment is running `main-20260428-224143` (= PR #143 merge commit).
- HTTPProxy `again1-meony3` (project `zachs-project-z5pegw`) with custom hostname `test.testctl.dev` reports `Certificate not found in downstream cluster`.
- `ClusterIssuer datum-gateway-http` exists in the NSO downstream (Karmada), `Ready=True`, ACME-registered against Let's Encrypt prod — so the issuer mapping is correct, but the operator never reaches Certificate creation because of the ordering bug above.
- Downstream namespace `ns-766e2306-…` in Karmada contains zero `Certificate` resources for that gateway.

## Test plan

- [x] `go build ./...`, `go test ./internal/controller/...` clean
- [ ] After deploy: `again1-meony3-https-hostname-0` Certificate appears in Karmada referencing `ClusterIssuer datum-gateway-http`, secret materializes, listener programs, HTTPProxy reports `CertificateReady`
- [x] e2e `gateway-accepted` (no `clusterIssuerMap` configured) still passes — `default-https` should still inherit the user's listener issuer via the inter-listener fallback path

Ref: #116