### PR TITLE
chore: upgrade publish workflows to v1.14.0

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -16,7 +16,7 @@ jobs:
       contents: read
       packages: write
       attestations: write
-    uses: datum-cloud/actions/.github/workflows/publish-docker.yaml@v1.13.1
+    uses: datum-cloud/actions/.github/workflows/publish-docker.yaml@v1.14.0
     with:
       image-name: network-services-operator
       platforms: linux/amd64,linux/arm64

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -27,8 +27,10 @@ jobs:
       id-token: write
       contents: read
       packages: write
-    uses: datum-cloud/actions/.github/workflows/publish-kustomize-bundle.yaml@v1.5.1
+    uses: datum-cloud/actions/.github/workflows/publish-kustomize-bundle.yaml@v1.14.0
     with:
       bundle-name: ghcr.io/datum-cloud/network-services-operator-kustomize
       bundle-path: config
+      image-name: ghcr.io/datum-cloud/network-services-operator
+      image-overlays: config/manager
     secrets: inherit


### PR DESCRIPTION
## Summary

Upgrades both publish workflows to `@v1.14.0`:

- `publish-docker.yaml`: produces container images tagged `v0.0.0-main-YYYYMMDD-HHmmss` for branch builds (unchanged from v1.13.1)
- `publish-kustomize-bundle.yaml`: now embeds the container image tag directly into `config/manager/kustomization.yaml` before publishing the OCI bundle, via the new `image-name` and `image-overlays` inputs

## Why

The infra repo has migrated NSO to semver-based `OCIRepository` tracking (no `ImagePolicy` or `ImageUpdateAutomation`). Staging tracks `v0.0.0-main-*` bundles; production tracks `>= 0.x` releases. Since Flux applies the bundle directly, the bundle must contain the correct container image tag — `latest` is not acceptable.

## Prerequisite for infra

After this PR merges, CI will publish `v0.0.0-main-*` kustomize bundles with the correct image embedded. Staging will begin deploying automatically. A new **release tag** must then be cut so production has a `>= 0.x` bundle to track.

## Test plan

- [ ] CI builds container image tagged `v0.0.0-main-*`
- [ ] CI builds kustomize bundle tagged `v0.0.0-main-*` with `newTag` set to the same version (not `latest`)
- [ ] Staging deploys successfully via semver OCIRepository filter