### PR TITLE
feat: register Network Services in the service catalog (Phase 1)

### DIFF
--- a/config/services/kustomization.yaml
+++ b/config/services/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+components:
+  - networking.datumapis.com

--- a/config/services/networking.datumapis.com/kustomization.yaml
+++ b/config/services/networking.datumapis.com/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+resources:
+  - service.yaml
+  - serviceconfiguration.yaml

--- a/config/services/networking.datumapis.com/service.yaml
+++ b/config/services/networking.datumapis.com/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: services.miloapis.com/v1alpha1
+kind: Service
+metadata:
+  name: networking-datumapis-com
+  labels:
+    app.kubernetes.io/name: network-services-operator
+    app.kubernetes.io/managed-by: kustomize
+spec:
+  serviceName: networking.datumapis.com
+  phase: Draft
+  displayName: Network Services
+  description: |
+    Managed HTTP/HTTPS edge proxy, routing, and traffic protection
+    for Datum Cloud workloads. Provides programmable ingress via
+    Gateway API HTTPRoute and WAF/rate-limit policies. Billed via
+    the networking.datumapis.com/gateway meter family.
+  owner:
+    producerProjectRef:
+      name: datum-cloud

--- a/config/services/networking.datumapis.com/serviceconfiguration.yaml
+++ b/config/services/networking.datumapis.com/serviceconfiguration.yaml
@@ -1,0 +1,77 @@
+apiVersion: services.miloapis.com/v1alpha1
+kind: ServiceConfiguration
+metadata:
+  name: networking-datumapis-com
+spec:
+  phase: Draft
+  serviceRef:
+    name: networking-datumapis-com
+  monitoredResourceTypes:
+    - type: networking.datumapis.com/HTTPRoute
+      displayName: HTTP Route
+      description: |
+        A customer-defined HTTP routing configuration attached to a managed
+        Gateway. One HTTPRoute represents a single HTTP service surface on
+        the Datum Cloud edge. Usage events cover proxied request count,
+        egress bytes, ingress bytes, and active connection seconds.
+      gvk:
+        group: gateway.networking.k8s.io
+        kind: HTTPRoute
+      labels:
+        - name: region
+          description: Datum deployment region serving the requests.
+        - name: gateway
+          description: Name of the underlying Gateway resource.
+        - name: gateway_namespace
+          description: Namespace of the underlying Gateway resource.
+        - name: gateway_class
+          description: GatewayClass of the underlying Gateway.
+        - name: httproute_name
+          description: Name of the HTTPRoute that served the request.
+        - name: httproute_namespace
+          description: Namespace of the HTTPRoute that served the request.
+  meters:
+    - name: networking.datumapis.com/gateway/requests
+      displayName: HTTP Route Requests
+      description: HTTP requests proxied through the route.
+      measurement:
+        aggregation: Sum
+        unit: "{request}"
+      billing:
+        consumedUnit: "{request}"
+        pricingUnit: "{request}"
+      monitoredResourceTypes:
+        - networking.datumapis.com/HTTPRoute
+    - name: networking.datumapis.com/gateway/egress-bytes
+      displayName: HTTP Route Egress Bytes
+      description: Bytes sent downstream by the route.
+      measurement:
+        aggregation: Sum
+        unit: By
+      billing:
+        consumedUnit: By
+        pricingUnit: GiBy
+      monitoredResourceTypes:
+        - networking.datumapis.com/HTTPRoute
+    - name: networking.datumapis.com/gateway/ingress-bytes
+      displayName: HTTP Route Ingress Bytes
+      description: Bytes received from clients by the route.
+      measurement:
+        aggregation: Sum
+        unit: By
+      billing:
+        consumedUnit: By
+        pricingUnit: GiBy
+      monitoredResourceTypes:
+        - networking.datumapis.com/HTTPRoute
+    - name: networking.datumapis.com/gateway/connection-seconds
+      displayName: HTTP Route Connection Seconds
+      description: Seconds long-lived connections (e.g. WebSocket) are held open.
+      measurement:
+        aggregation: Sum
+        unit: s
+      billing:
+        consumedUnit: s
+        pricingUnit: h
+      monitoredResourceTypes:
+        - networking.datumapis.com/HTTPRoute


### PR DESCRIPTION
Implements Phase 1 of the service-catalog-registration design brief (PR #156, issue #155): pure YAML, no Go changes.

## What this PR adds

A Kustomize bundle under `config/services/` that registers Network Services in the platform service catalog and declares its monitored resource and meters:

- **`Service`** (`services.miloapis.com/v1alpha1`)
  - `serviceName: networking.datumapis.com`
  - `phase: Draft`
  - `owner.producerProjectRef.name: datum-cloud`
- **`ServiceConfiguration`** (`services.miloapis.com/v1alpha1`)
  - Monitored resource: `HTTPRoute` (`gateway.networking.k8s.io`)
  - Six optional dimensions: `region`, `gateway`, `gateway_namespace`, `gateway_class`, `httproute_name`, `httproute_namespace`
  - Four meters inline under `networking.datumapis.com/gateway/*`: `requests`, `egress-bytes`, `ingress-bytes`, `connection-seconds`

## Bundle layout

```
config/services/
  kustomization.yaml
  networking.datumapis.com/
    kustomization.yaml      # kind: Component
    service.yaml
    serviceconfiguration.yaml
```

Matches the per-service-domain layout used by `compute` in `datum-cloud/datum`. The inner `kustomization.yaml` is a Kustomize `Component`, mirroring the compute reference.

## What this PR does NOT add

- No `MonitoredResourceType` or `MeterDefinition` resources directly — those are produced by the catalog's fan-out controller from `ServiceConfiguration.spec`, so no `config/billing/` bundle is needed.
- No Go code changes — Phase 1 is YAML-only.
- No Flux wiring — that is a separate step in `datum-cloud/infra` handled by the platform/infra team after sign-off.

Phase 2 (usage emission from the edge proxy) remains blocked on OD-5 through OD-8 in the design brief.

## Test plan

- [x] `kubectl kustomize config/services/` renders both resources without error
- [ ] Reviewer confirms `Service` and `ServiceConfiguration` shapes match the catalog CRDs in the deployment target
- [ ] After merge: platform/infra wires `config/services/` into Flux; confirm the fan-out controller produces the expected `MonitoredResourceType` and `MeterDefinition` resources in the billing namespace
- [ ] Confirm `Service` appears in the catalog in `Draft` phase

Refs #155. Design brief: PR #156.
