### PR TITLE
feat(iam): add LocationBinding ProtectedResource and viewer role

### DIFF
--- a/config/iam/protected-resources/kustomization.yaml
+++ b/config/iam/protected-resources/kustomization.yaml
@@ -11,6 +11,7 @@ resources:
   - gateways.yaml
   - httpproxies.yaml
   - httproutes.yaml
+  - locationbindings.yaml
   - locations.yaml
   - networkbindings.yaml
   - networkcontexts.yaml

--- a/config/iam/protected-resources/locationbindings.yaml
+++ b/config/iam/protected-resources/locationbindings.yaml
@@ -1,0 +1,21 @@
+apiVersion: iam.miloapis.com/v1alpha1
+kind: ProtectedResource
+metadata:
+  name: networking.datumapis.com-locationbinding
+spec:
+  serviceRef:
+    name: "networking.datumapis.com"
+  kind: LocationBinding
+  plural: locationbindings
+  singular: locationbinding
+  permissions:
+    - list
+    - get
+    - create
+    - update
+    - patch
+    - watch
+    - delete
+  parentResources:
+    - apiGroup: resourcemanager.miloapis.com
+      kind: Project

--- a/config/iam/roles/kustomization.yaml
+++ b/config/iam/roles/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
   - gateway-viewer.yaml
   - location-admin.yaml
   - location-viewer.yaml
+  - locationbinding-viewer.yaml
   - networking-admin.yaml
   - networking-viewer.yaml
   - domain-admin.yaml

--- a/config/iam/roles/locationbinding-viewer.yaml
+++ b/config/iam/roles/locationbinding-viewer.yaml
@@ -1,0 +1,13 @@
+apiVersion: iam.miloapis.com/v1alpha1
+kind: Role
+metadata:
+  name: networking.datumapis.com-locationbinding-viewer
+  annotations:
+    kubernetes.io/display-name: Location Binding Viewer
+    kubernetes.io/description: "View access to location binding resources"
+spec:
+  launchStage: Beta
+  includedPermissions:
+    - networking.datumapis.com/locationbindings.list
+    - networking.datumapis.com/locationbindings.get
+    - networking.datumapis.com/locationbindings.watch


### PR DESCRIPTION
## What

Registers `LocationBinding` with Milo IAM and adds a read-only viewer role.

- New `ProtectedResource` `networking.datumapis.com-locationbinding` (`plural: locationbindings`), parented to `resourcemanager.miloapis.com/Project`, mirroring the existing `locations` ProtectedResource.
- New `Role` `networking.datumapis.com-locationbinding-viewer` granting `locationbindings.{list,get,watch}`.
- Both wired into the respective `config/iam/.../kustomization.yaml`.

## Why

`LocationBinding` had **no IAM coverage**: no ProtectedResource registered it, and no role granted any `locationbindings.*` permission. Milo's IAM authorizer only authorizes resources registered as ProtectedResources, so `locationbindings` were denied for every identity except `system:masters`. As a result, consumers / project owners could not list or read the LocationBindings projected into their own projects — even though the type is a consumer-facing projection of a Location into a project's control plane.

## Unblocks

A follow-up PR on `datum-cloud/infra` appends `networking.datumapis.com-locationbinding-viewer` to the project `owner` role so owners can read the LocationBindings in their own project (read-only, project-scoped).

## Validation

`kubectl kustomize config/iam` builds cleanly and includes the new ProtectedResource and Role.

🤖 Generated with [Claude Code](https://claude.com/claude-code)