### PR TITLE
feat(quota): add display name, description, and owner to networking registrations

### DIFF
--- a/config/quota/registrations/backend-registration.yaml
+++ b/config/quota/registrations/backend-registration.yaml
@@ -5,6 +5,10 @@ metadata:
   labels:
     app.kubernetes.io/name: network-services-operator
     app.kubernetes.io/component: quota-system
+    services.miloapis.com/owner: networking.datumapis.com
+  annotations:
+    kubernetes.io/display-name: "Backends"
+    kubernetes.io/description: "Maximum number of backends that can be created within a project"
 spec:
   consumerType:
     apiGroup: resourcemanager.miloapis.com

--- a/config/quota/registrations/backendtlspolicy-registration.yaml
+++ b/config/quota/registrations/backendtlspolicy-registration.yaml
@@ -5,6 +5,10 @@ metadata:
   labels:
     app.kubernetes.io/name: network-services-operator
     app.kubernetes.io/component: quota-system
+    services.miloapis.com/owner: networking.datumapis.com
+  annotations:
+    kubernetes.io/display-name: "Backend TLS Policies"
+    kubernetes.io/description: "Maximum number of backend TLS policies that can be created within a project"
 spec:
   consumerType:
     apiGroup: resourcemanager.miloapis.com

--- a/config/quota/registrations/backendtrafficpolicy-registration.yaml
+++ b/config/quota/registrations/backendtrafficpolicy-registration.yaml
@@ -5,6 +5,10 @@ metadata:
   labels:
     app.kubernetes.io/name: network-services-operator
     app.kubernetes.io/component: quota-system
+    services.miloapis.com/owner: networking.datumapis.com
+  annotations:
+    kubernetes.io/display-name: "Backend Traffic Policies"
+    kubernetes.io/description: "Maximum number of backend traffic policies that can be created within a project"
 spec:
   consumerType:
     apiGroup: resourcemanager.miloapis.com

--- a/config/quota/registrations/connector-registration.yaml
+++ b/config/quota/registrations/connector-registration.yaml
@@ -5,6 +5,10 @@ metadata:
   labels:
     app.kubernetes.io/name: network-services-operator
     app.kubernetes.io/component: quota-system
+    services.miloapis.com/owner: networking.datumapis.com
+  annotations:
+    kubernetes.io/display-name: "Connectors"
+    kubernetes.io/description: "Maximum number of connectors that can be created within a project"
 spec:
   consumerType:
     apiGroup: resourcemanager.miloapis.com

--- a/config/quota/registrations/connectoradvertisement-registration.yaml
+++ b/config/quota/registrations/connectoradvertisement-registration.yaml
@@ -5,6 +5,10 @@ metadata:
   labels:
     app.kubernetes.io/name: network-services-operator
     app.kubernetes.io/component: quota-system
+    services.miloapis.com/owner: networking.datumapis.com
+  annotations:
+    kubernetes.io/display-name: "Connector Advertisements"
+    kubernetes.io/description: "Maximum number of connector advertisements that can be created within a project"
 spec:
   consumerType:
     apiGroup: resourcemanager.miloapis.com

--- a/config/quota/registrations/domain-registration.yaml
+++ b/config/quota/registrations/domain-registration.yaml
@@ -5,6 +5,10 @@ metadata:
   labels:
     app.kubernetes.io/name: network-services-operator
     app.kubernetes.io/component: quota-system
+    services.miloapis.com/owner: networking.datumapis.com
+  annotations:
+    kubernetes.io/display-name: "Domains"
+    kubernetes.io/description: "Maximum number of domains that can be created within a project"
 spec:
   consumerType:
     apiGroup: resourcemanager.miloapis.com

--- a/config/quota/registrations/endpointslice-registration.yaml
+++ b/config/quota/registrations/endpointslice-registration.yaml
@@ -5,6 +5,10 @@ metadata:
   labels:
     app.kubernetes.io/name: network-services-operator
     app.kubernetes.io/component: quota-system
+    services.miloapis.com/owner: networking.datumapis.com
+  annotations:
+    kubernetes.io/display-name: "Endpoint Slices"
+    kubernetes.io/description: "Maximum number of endpoint slices that can be created within a project"
 spec:
   consumerType:
     apiGroup: resourcemanager.miloapis.com

--- a/config/quota/registrations/gateway-registration.yaml
+++ b/config/quota/registrations/gateway-registration.yaml
@@ -5,6 +5,10 @@ metadata:
   labels:
     app.kubernetes.io/name: network-services-operator
     app.kubernetes.io/component: quota-system
+    services.miloapis.com/owner: networking.datumapis.com
+  annotations:
+    kubernetes.io/display-name: "Gateways"
+    kubernetes.io/description: "Maximum number of gateways that can be created within a project"
 spec:
   consumerType:
     apiGroup: resourcemanager.miloapis.com

--- a/config/quota/registrations/httpproxy-registration.yaml
+++ b/config/quota/registrations/httpproxy-registration.yaml
@@ -5,6 +5,10 @@ metadata:
   labels:
     app.kubernetes.io/name: network-services-operator
     app.kubernetes.io/component: quota-system
+    services.miloapis.com/owner: networking.datumapis.com
+  annotations:
+    kubernetes.io/display-name: "HTTP Proxies"
+    kubernetes.io/description: "Maximum number of HTTP proxies that can be created within a project"
 spec:
   consumerType:
     apiGroup: resourcemanager.miloapis.com

--- a/config/quota/registrations/httproute-registration.yaml
+++ b/config/quota/registrations/httproute-registration.yaml
@@ -5,6 +5,10 @@ metadata:
   labels:
     app.kubernetes.io/name: network-services-operator
     app.kubernetes.io/component: quota-system
+    services.miloapis.com/owner: networking.datumapis.com
+  annotations:
+    kubernetes.io/display-name: "HTTP Routes"
+    kubernetes.io/description: "Maximum number of HTTP routes that can be created within a project"
 spec:
   consumerType:
     apiGroup: resourcemanager.miloapis.com

--- a/config/quota/registrations/httproutefilter-registration.yaml
+++ b/config/quota/registrations/httproutefilter-registration.yaml
@@ -5,6 +5,10 @@ metadata:
   labels:
     app.kubernetes.io/name: network-services-operator
     app.kubernetes.io/component: quota-system
+    services.miloapis.com/owner: networking.datumapis.com
+  annotations:
+    kubernetes.io/display-name: "HTTP Route Filters"
+    kubernetes.io/description: "Maximum number of HTTP route filters that can be created within a project"
 spec:
   consumerType:
     apiGroup: resourcemanager.miloapis.com

--- a/config/quota/registrations/securitypolicy-registration.yaml
+++ b/config/quota/registrations/securitypolicy-registration.yaml
@@ -5,6 +5,10 @@ metadata:
   labels:
     app.kubernetes.io/name: network-services-operator
     app.kubernetes.io/component: quota-system
+    services.miloapis.com/owner: networking.datumapis.com
+  annotations:
+    kubernetes.io/display-name: "Security Policies"
+    kubernetes.io/description: "Maximum number of security policies that can be created within a project"
 spec:
   consumerType:
     apiGroup: resourcemanager.miloapis.com

--- a/config/quota/registrations/trafficprotectionpolicy-registration.yaml
+++ b/config/quota/registrations/trafficprotectionpolicy-registration.yaml
@@ -5,6 +5,10 @@ metadata:
   labels:
     app.kubernetes.io/name: network-services-operator
     app.kubernetes.io/component: quota-system
+    services.miloapis.com/owner: networking.datumapis.com
+  annotations:
+    kubernetes.io/display-name: "Traffic Protection Policies"
+    kubernetes.io/description: "Maximum number of traffic protection policies that can be created within a project"
 spec:
   consumerType:
     apiGroup: resourcemanager.miloapis.com


### PR DESCRIPTION
Part of datum-cloud/enhancements#735. Adopts the milo quota display metadata convention for all 13 networking quota registrations.

Adds `services.miloapis.com/owner: networking.datumapis.com` + `kubernetes.io/display-name` + `kubernetes.io/description` to each (metadata-only, spec unchanged).

Display names: HTTP Proxies, Domains, Gateways, HTTP Routes, HTTP Route Filters, Backends, Backend TLS Policies, Backend Traffic Policies, Security Policies, Connectors, Connector Advertisements, Traffic Protection Policies, Endpoint Slices.
