### PR TITLE
fix(iroh-dns): lower default TXT TTL from 30s to 5s

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -197,7 +197,13 @@ type IrohConnectorConfig struct {
 
 	// TTLSeconds is the TTL written on each TXT record.
 	//
-	// +default=30
+	// Restarting a connector before the previous record's TTL expires
+	// leaves the gateway's resolver serving the stale answer, which
+	// gates how quickly a restart becomes reachable. 5s keeps that
+	// floor low while staying well within normal authoritative DNS
+	// query rates for the connector zone.
+	//
+	// +default=5
 	TTLSeconds int32 `json:"ttlSeconds,omitempty"`
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -100,7 +100,7 @@ func TestSetObjectDefaults_IrohConnectorConfig(t *testing.T) {
 	if got, want := iroh.RecordPrefix, "_iroh"; got != want {
 		t.Errorf("RecordPrefix = %q, want %q", got, want)
 	}
-	if got, want := iroh.TTLSeconds, int32(30); got != want {
+	if got, want := iroh.TTLSeconds, int32(5); got != want {
 		t.Errorf("TTLSeconds = %d, want %d", got, want)
 	}
 	if iroh.DownstreamKubeconfigPath != "" {

--- a/internal/config/zz_generated.defaults.go
+++ b/internal/config/zz_generated.defaults.go
@@ -234,7 +234,7 @@ func SetObjectDefaults_NetworkServicesOperator(in *NetworkServicesOperator) {
 		in.Connector.Iroh.RecordPrefix = "_iroh"
 	}
 	if in.Connector.Iroh.TTLSeconds == 0 {
-		in.Connector.Iroh.TTLSeconds = 30
+		in.Connector.Iroh.TTLSeconds = 5
 	}
 	SetDefaults_DiscoveryConfig(&in.Discovery)
 	if in.Redis.DialTimeout == nil {


### PR DESCRIPTION
This is a dramatic improvement to the service by reconverging a tunnel in ~1 second instead of 30+ seconds. 

The TTL is the dominant restart bottleneck: control-plane plumbing (heartbeat → reconcile → DNSRecordSet → Envoy metadata) completes in <1s, but iroh-gateway's resolver serves the stale TXT until it expires.

With this change:

```
% ./datum-connect tunnel listen --endpoint localhost:9999
Found existing tunnel for localhost:9999:
  id: tunnel-9zllw
  label: 4a66d3990335
  endpoint: http://localhost:9999

Tunnel already configured correctly.

Your endpoint ID: 6b66d57da4dc764e357fc69d454cd101f8a2a7bd60ee682f6f768bc23065b28a
Setting up tunnel...
  ✓ tunnel accepted (0.2s) [HTTPProxy/tunnel-9zllw]
  ✓ TLS certificate issued (0.2s) [HTTPProxy/tunnel-9zllw]
  ✓ connector ready (0.2s) [Connector/datum-connect-mhxj5]
  ✓ iroh DNS published (0.2s) [Connector/datum-connect-mhxj5]
  ✓ route programmed (0.2s) [HTTPProxy/tunnel-9zllw]
  ✓ envoy metadata propagated (1.0s) [HTTPProxy/tunnel-9zllw]
Verifying connectivity...
  ✓ origin reachable (0.1s) [http://localhost:9999]: HTTP 200
  ✓ proxy responding (0.1s) [https://tip-post-nqt7t.datumproxy.net]: HTTP 200
Tunnel ready after 1 sec: https://tip-post-nqt7t.datumproxy.net
Press Ctrl+C to stop...
```

Measured on `datum-connect`:

| Scenario | Time to proxy responding |
|---|---|
| Restart immediately after stop, TTL=30 | ~30s |
| Restart 35s after stop (TTL elapsed) | ~1s |

Cost: a few extra authoritative DNS queries per active endpoint. Negligible at connector-zone cardinality.

Refs: datum-cloud/enhancements#756