### PR TITLE
fix(test): wait for CA Certificate Ready before reading its secret

### DIFF
--- a/test/e2e/gateway/chainsaw-test.yaml
+++ b/test/e2e/gateway/chainsaw-test.yaml
@@ -45,6 +45,19 @@ spec:
                   kind: ClusterIssuer
                   group: cert-manager.io
 
+        - assert:
+            cluster: nso-infra
+            resource:
+              apiVersion: cert-manager.io/v1
+              kind: Certificate
+              metadata:
+                name: (join('-', [$clusterIssuerName, 'ca']))
+                namespace: cert-manager
+              status:
+                conditions:
+                  - type: Ready
+                    status: "True"
+
         - create:
             cluster: nso-infra
             resource:


### PR DESCRIPTION
The `gateway-accepted` chainsaw test creates a cert-manager `Certificate` and immediately runs a script that reads the secret cert-manager is supposed to produce. There's no wait between the two, so the script can race ahead of the issuance and fail with:

```
Error from server (NotFound): secrets "..." not found
error: no objects passed to apply
```

Asserting `Certificate.status.conditions[Ready]=True` between the `Certificate` create and the secret-copy script gates everything that depends on the issued secret, including the CA `ClusterIssuer` that follows.

Example failure: https://github.com/datum-cloud/network-services-operator/actions/runs/27240379708/job/80442454016 (surfaced in #179, which makes no test-relevant code changes)