### PR TITLE
fix: gate connector EnvoyPatchPolicy per HTTPS listener cert readiness

### DIFF
--- a/internal/controller/connector_routing_compiler.go
+++ b/internal/controller/connector_routing_compiler.go
@@ -9,6 +9,7 @@ import (
 
 	envoygatewayv1alpha1 "github.com/envoyproxy/gateway/api/v1alpha1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/ptr"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
@@ -101,6 +102,7 @@ func buildConnectorEnvoyPatches(
 	gateway *gatewayv1.Gateway,
 	httpProxy *networkingv1alpha.HTTPProxy,
 	backends []connectorBackendPatch,
+	eligibleHTTPSListeners sets.Set[string],
 ) ([]envoygatewayv1alpha1.EnvoyJSONPatchConfig, error) {
 	patches := make([]envoygatewayv1alpha1.EnvoyJSONPatchConfig, 0)
 	// Cluster patch (per connector backend): point the route's cluster at the internal
@@ -131,7 +133,7 @@ func buildConnectorEnvoyPatches(
 	//
 	// Future extension: when sectionName is populated from route attachment
 	// context, patch only that specific HTTPS listener's RouteConfiguration.
-	allHTTPSRouteConfigNames := gatewayHTTPSRouteConfigNames(downstreamNamespace, gateway)
+	allHTTPSRouteConfigNames := gatewayHTTPSRouteConfigNames(downstreamNamespace, gateway, eligibleHTTPSListeners)
 	seenDomainRouteConfig := make(map[string]struct{})
 	for _, backend := range backends {
 		domain := backend.targetHost
@@ -140,6 +142,7 @@ func buildConnectorEnvoyPatches(
 			gateway,
 			backend.sectionName,
 			allHTTPSRouteConfigNames,
+			eligibleHTTPSListeners,
 		)
 		domainValue, err := json.Marshal(domain)
 		if err != nil {
@@ -181,6 +184,7 @@ func buildConnectorEnvoyPatches(
 			gateway,
 			connectRoute.sectionName,
 			allHTTPSRouteConfigNames,
+			eligibleHTTPSListeners,
 		)
 		for _, routeConfigName := range routeConfigNames {
 			patches = append(patches, envoygatewayv1alpha1.EnvoyJSONPatchConfig{
@@ -198,12 +202,26 @@ func buildConnectorEnvoyPatches(
 	return patches, nil
 }
 
-func gatewayHTTPSRouteConfigNames(downstreamNamespace string, gateway *gatewayv1.Gateway) []string {
+// gatewayHTTPSRouteConfigNames returns the RouteConfiguration names for HTTPS
+// listeners that are eligible for patching. A listener is eligible when its name
+// is present in eligibleHTTPSListeners, which the caller computes from per-listener
+// certificate readiness and listener Programmed status. Listeners whose
+// RouteConfiguration Envoy Gateway has not materialized (e.g. a custom-hostname
+// listener with an unissued cert) are excluded so the connector EnvoyPatchPolicy
+// does not target nonexistent xDS resources.
+func gatewayHTTPSRouteConfigNames(
+	downstreamNamespace string,
+	gateway *gatewayv1.Gateway,
+	eligibleHTTPSListeners sets.Set[string],
+) []string {
 	names := make([]string, 0)
 	seen := make(map[string]struct{})
 
 	for _, listener := range gateway.Spec.Listeners {
 		if listener.Protocol != gatewayv1.HTTPSProtocolType {
+			continue
+		}
+		if !eligibleHTTPSListeners.Has(string(listener.Name)) {
 			continue
 		}
 		name := fmt.Sprintf("%s/%s/%s", downstreamNamespace, gateway.Name, listener.Name)
@@ -222,6 +240,7 @@ func gatewayHTTPSRouteConfigNamesForSection(
 	gateway *gatewayv1.Gateway,
 	sectionName *gatewayv1.SectionName,
 	allHTTPSRouteConfigNames []string,
+	eligibleHTTPSListeners sets.Set[string],
 ) []string {
 	if sectionName == nil {
 		return allHTTPSRouteConfigNames
@@ -230,6 +249,9 @@ func gatewayHTTPSRouteConfigNamesForSection(
 	for _, listener := range gateway.Spec.Listeners {
 		if listener.Name != *sectionName || listener.Protocol != gatewayv1.HTTPSProtocolType {
 			continue
+		}
+		if !eligibleHTTPSListeners.Has(string(listener.Name)) {
+			return nil
 		}
 		return []string{fmt.Sprintf("%s/%s/%s", downstreamNamespace, gateway.Name, listener.Name)}
 	}
@@ -366,6 +388,7 @@ func buildConnectorOfflineEnvoyPatches(
 	downstreamNamespace string,
 	gateway *gatewayv1.Gateway,
 	httpProxy *networkingv1alpha.HTTPProxy,
+	eligibleHTTPSListeners sets.Set[string],
 ) ([]envoygatewayv1alpha1.EnvoyJSONPatchConfig, error) {
 	route := map[string]any{
 		"name": fmt.Sprintf("connector-offline-%s", httpProxy.Name),
@@ -386,7 +409,7 @@ func buildConnectorOfflineEnvoyPatches(
 	}
 
 	patches := make([]envoygatewayv1alpha1.EnvoyJSONPatchConfig, 0)
-	for _, routeConfigName := range gatewayHTTPSRouteConfigNames(downstreamNamespace, gateway) {
+	for _, routeConfigName := range gatewayHTTPSRouteConfigNames(downstreamNamespace, gateway, eligibleHTTPSListeners) {
 		patches = append(patches, envoygatewayv1alpha1.EnvoyJSONPatchConfig{
 			Type: "type.googleapis.com/envoy.config.route.v3.RouteConfiguration",
 			Name: routeConfigName,

--- a/internal/controller/connector_routing_compiler.go
+++ b/internal/controller/connector_routing_compiler.go
@@ -202,13 +202,8 @@ func buildConnectorEnvoyPatches(
 	return patches, nil
 }
 
-// gatewayHTTPSRouteConfigNames returns the RouteConfiguration names for HTTPS
-// listeners that are eligible for patching. A listener is eligible when its name
-// is present in eligibleHTTPSListeners, which the caller computes from per-listener
-// certificate readiness and listener Programmed status. Listeners whose
-// RouteConfiguration Envoy Gateway has not materialized (e.g. a custom-hostname
-// listener with an unissued cert) are excluded so the connector EnvoyPatchPolicy
-// does not target nonexistent xDS resources.
+// gatewayHTTPSRouteConfigNames returns the RouteConfiguration names for the
+// gateway's HTTPS listeners, skipping any not in eligibleHTTPSListeners.
 func gatewayHTTPSRouteConfigNames(
 	downstreamNamespace string,
 	gateway *gatewayv1.Gateway,

--- a/internal/controller/httpproxy_controller.go
+++ b/internal/controller/httpproxy_controller.go
@@ -1514,10 +1514,7 @@ func (r *HTTPProxyReconciler) reconcileConnectorEnvoyPatchPolicy(
 		return nil, true, fmt.Errorf("downstreamGatewayClassName is required for connector patching")
 	}
 
-	eligibleHTTPSListeners, err := r.eligibleConnectorHTTPSListeners(ctx, downstreamNamespaceName, gateway)
-	if err != nil {
-		return nil, true, err
-	}
+	eligibleHTTPSListeners := eligibleConnectorHTTPSListeners(gateway)
 
 	// Collect connector backends that are currently ready. If none are ready the
 	// connector is offline and we keep the EPP alive with a direct_response route
@@ -1575,54 +1572,22 @@ func (r *HTTPProxyReconciler) reconcileConnectorEnvoyPatchPolicy(
 	return &policy, connectorOnline, nil
 }
 
-// eligibleConnectorHTTPSListeners returns the HTTPS listeners the connector
-// EnvoyPatchPolicy may target: those Programmed with a Ready Certificate.
-// Patching a listener whose cert hasn't issued targets a RouteConfiguration
-// Envoy Gateway never materializes, leaving the policy stuck Programmed=False.
-// default-https is always eligible once Programmed: it uses the shared wildcard
-// TLS secret and has no per-listener Certificate.
-func (r *HTTPProxyReconciler) eligibleConnectorHTTPSListeners(
-	ctx context.Context,
-	downstreamNamespaceName string,
-	gateway *gatewayv1.Gateway,
-) (sets.Set[string], error) {
+// eligibleConnectorHTTPSListeners returns the gateway's HTTPS listeners that are
+// Programmed. A listener reaches Programmed only once Envoy Gateway has resolved
+// its TLS secret and materialized its RouteConfiguration — exactly what the
+// connector patch targets — so an unprogrammed listener is skipped to avoid a
+// patch stuck Programmed=False/ResourceNotFound.
+func eligibleConnectorHTTPSListeners(gateway *gatewayv1.Gateway) sets.Set[string] {
 	eligible := sets.New[string]()
-	downstreamClient := r.DownstreamCluster.GetClient()
-
 	for _, listener := range gateway.Spec.Listeners {
 		if listener.Protocol != gatewayv1.HTTPSProtocolType {
 			continue
 		}
-
-		if !gatewayListenerProgrammed(gateway.Status.Listeners, listener.Name) {
-			continue
-		}
-
-		if gatewayutil.IsDefaultListener(listener) {
-			eligible.Insert(string(listener.Name))
-			continue
-		}
-
-		certName := resourcename.GetValidDNS1123Name(fmt.Sprintf("%s-%s", gateway.Name, listener.Name))
-		certificate := newUnstructuredForGVK(certificateGVK)
-		certKey := client.ObjectKey{Namespace: downstreamNamespaceName, Name: certName}
-		if err := downstreamClient.Get(ctx, certKey, certificate); err != nil {
-			if apierrors.IsNotFound(err) {
-				continue
-			}
-			return nil, fmt.Errorf("failed to get certificate %s: %w", certName, err)
-		}
-
-		ready, err := isCertificateReady(certificate)
-		if err != nil {
-			return nil, fmt.Errorf("failed to check if certificate %s is ready: %w", certName, err)
-		}
-		if ready {
+		if gatewayListenerProgrammed(gateway.Status.Listeners, listener.Name) {
 			eligible.Insert(string(listener.Name))
 		}
 	}
-
-	return eligible, nil
+	return eligible
 }
 
 func (r *HTTPProxyReconciler) cleanupConnectorEnvoyPatchPolicy(

--- a/internal/controller/httpproxy_controller.go
+++ b/internal/controller/httpproxy_controller.go
@@ -1514,11 +1514,6 @@ func (r *HTTPProxyReconciler) reconcileConnectorEnvoyPatchPolicy(
 		return nil, true, fmt.Errorf("downstreamGatewayClassName is required for connector patching")
 	}
 
-	// Compute the set of HTTPS listeners whose RouteConfiguration is safe to
-	// patch. A custom-hostname listener whose cert-manager Certificate has not
-	// issued never gets a RouteConfiguration in Envoy's xDS, so patching it
-	// leaves the EnvoyPatchPolicy permanently Programmed=False/ResourceNotFound.
-	// Gate per listener so default-https keeps working while other listeners wait.
 	eligibleHTTPSListeners, err := r.eligibleConnectorHTTPSListeners(ctx, downstreamNamespaceName, gateway)
 	if err != nil {
 		return nil, true, err
@@ -1580,19 +1575,12 @@ func (r *HTTPProxyReconciler) reconcileConnectorEnvoyPatchPolicy(
 	return &policy, connectorOnline, nil
 }
 
-// eligibleConnectorHTTPSListeners returns the names of HTTPS listeners whose
-// RouteConfiguration the connector EnvoyPatchPolicy may target. A listener is
-// eligible when it is Programmed and its cert-manager Certificate is Ready.
-//
-// The operator-injected default-https listener is treated as always-eligible
-// once it is Programmed: it has no per-listener hostname and is served by the
-// shared wildcard TLS secret rather than a per-listener Certificate, so a Ready
-// listener-status is the only signal available. The gateway-level gate in
-// reconcileConnectorEnvoyPatchPolicy already requires default-https to be
-// Programmed before this runs.
-//
-// Gating is per listener (not all-or-nothing) so a custom-hostname listener
-// waiting on an unissued cert does not suppress patches for ready listeners.
+// eligibleConnectorHTTPSListeners returns the HTTPS listeners the connector
+// EnvoyPatchPolicy may target: those Programmed with a Ready Certificate.
+// Patching a listener whose cert hasn't issued targets a RouteConfiguration
+// Envoy Gateway never materializes, leaving the policy stuck Programmed=False.
+// default-https is always eligible once Programmed: it uses the shared wildcard
+// TLS secret and has no per-listener Certificate.
 func (r *HTTPProxyReconciler) eligibleConnectorHTTPSListeners(
 	ctx context.Context,
 	downstreamNamespaceName string,

--- a/internal/controller/httpproxy_controller.go
+++ b/internal/controller/httpproxy_controller.go
@@ -1514,6 +1514,16 @@ func (r *HTTPProxyReconciler) reconcileConnectorEnvoyPatchPolicy(
 		return nil, true, fmt.Errorf("downstreamGatewayClassName is required for connector patching")
 	}
 
+	// Compute the set of HTTPS listeners whose RouteConfiguration is safe to
+	// patch. A custom-hostname listener whose cert-manager Certificate has not
+	// issued never gets a RouteConfiguration in Envoy's xDS, so patching it
+	// leaves the EnvoyPatchPolicy permanently Programmed=False/ResourceNotFound.
+	// Gate per listener so default-https keeps working while other listeners wait.
+	eligibleHTTPSListeners, err := r.eligibleConnectorHTTPSListeners(ctx, downstreamNamespaceName, gateway)
+	if err != nil {
+		return nil, true, err
+	}
+
 	// Collect connector backends that are currently ready. If none are ready the
 	// connector is offline and we keep the EPP alive with a direct_response route
 	// so EG never hits a delete+create cycle (which causes the watchable
@@ -1528,7 +1538,7 @@ func (r *HTTPProxyReconciler) reconcileConnectorEnvoyPatchPolicy(
 	if !connectorOnline {
 		// Connector offline: insert a direct_response CONNECT route so clients
 		// receive a clean 503 "Tunnel not online" instead of a connection error.
-		jsonPatches, err = buildConnectorOfflineEnvoyPatches(downstreamNamespaceName, gateway, httpProxy)
+		jsonPatches, err = buildConnectorOfflineEnvoyPatches(downstreamNamespaceName, gateway, httpProxy, eligibleHTTPSListeners)
 	} else {
 		jsonPatches, err = buildConnectorEnvoyPatches(
 			downstreamNamespaceName,
@@ -1536,6 +1546,7 @@ func (r *HTTPProxyReconciler) reconcileConnectorEnvoyPatchPolicy(
 			gateway,
 			httpProxy,
 			connectorBackends,
+			eligibleHTTPSListeners,
 		)
 	}
 	if err != nil {
@@ -1567,6 +1578,63 @@ func (r *HTTPProxyReconciler) reconcileConnectorEnvoyPatchPolicy(
 		return nil, connectorOnline, err
 	}
 	return &policy, connectorOnline, nil
+}
+
+// eligibleConnectorHTTPSListeners returns the names of HTTPS listeners whose
+// RouteConfiguration the connector EnvoyPatchPolicy may target. A listener is
+// eligible when it is Programmed and its cert-manager Certificate is Ready.
+//
+// The operator-injected default-https listener is treated as always-eligible
+// once it is Programmed: it has no per-listener hostname and is served by the
+// shared wildcard TLS secret rather than a per-listener Certificate, so a Ready
+// listener-status is the only signal available. The gateway-level gate in
+// reconcileConnectorEnvoyPatchPolicy already requires default-https to be
+// Programmed before this runs.
+//
+// Gating is per listener (not all-or-nothing) so a custom-hostname listener
+// waiting on an unissued cert does not suppress patches for ready listeners.
+func (r *HTTPProxyReconciler) eligibleConnectorHTTPSListeners(
+	ctx context.Context,
+	downstreamNamespaceName string,
+	gateway *gatewayv1.Gateway,
+) (sets.Set[string], error) {
+	eligible := sets.New[string]()
+	downstreamClient := r.DownstreamCluster.GetClient()
+
+	for _, listener := range gateway.Spec.Listeners {
+		if listener.Protocol != gatewayv1.HTTPSProtocolType {
+			continue
+		}
+
+		if !gatewayListenerProgrammed(gateway.Status.Listeners, listener.Name) {
+			continue
+		}
+
+		if gatewayutil.IsDefaultListener(listener) {
+			eligible.Insert(string(listener.Name))
+			continue
+		}
+
+		certName := resourcename.GetValidDNS1123Name(fmt.Sprintf("%s-%s", gateway.Name, listener.Name))
+		certificate := newUnstructuredForGVK(certificateGVK)
+		certKey := client.ObjectKey{Namespace: downstreamNamespaceName, Name: certName}
+		if err := downstreamClient.Get(ctx, certKey, certificate); err != nil {
+			if apierrors.IsNotFound(err) {
+				continue
+			}
+			return nil, fmt.Errorf("failed to get certificate %s: %w", certName, err)
+		}
+
+		ready, err := isCertificateReady(certificate)
+		if err != nil {
+			return nil, fmt.Errorf("failed to check if certificate %s is ready: %w", certName, err)
+		}
+		if ready {
+			eligible.Insert(string(listener.Name))
+		}
+	}
+
+	return eligible, nil
 }
 
 func (r *HTTPProxyReconciler) cleanupConnectorEnvoyPatchPolicy(

--- a/internal/controller/httpproxy_controller_test.go
+++ b/internal/controller/httpproxy_controller_test.go
@@ -1450,6 +1450,7 @@ func TestBuildConnectorEnvoyPatchesTargetsAllHTTPSListeners(t *testing.T) {
 		gateway,
 		newHTTPProxy(),
 		backends,
+		sets.New("default-https", "https-hostname-0"),
 	)
 	assert.NoError(t, err)
 
@@ -1545,6 +1546,7 @@ func TestBuildConnectorEnvoyPatchesAddsExtendedConnectPathRouteAndFallback(t *te
 		gateway,
 		httpProxy,
 		backends,
+		sets.New("default-https"),
 	)
 	assert.NoError(t, err)
 
@@ -1631,6 +1633,7 @@ func TestBuildConnectorEnvoyPatchesScopesRouteConfigBySectionName(t *testing.T) 
 		gateway,
 		newHTTPProxy(),
 		backends,
+		sets.New("default-https", "https-hostname-0"),
 	)
 	assert.NoError(t, err)
 
@@ -1644,6 +1647,137 @@ func TestBuildConnectorEnvoyPatchesScopesRouteConfigBySectionName(t *testing.T) 
 
 	assert.Equal(t, 2, routeConfigPatchCounts["ns-test/gw/https-hostname-0"])
 	assert.NotContains(t, routeConfigPatchCounts, "ns-test/gw/default-https")
+}
+
+func TestBuildConnectorEnvoyPatchesSkipsIneligibleHTTPSListeners(t *testing.T) {
+	gateway := &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Name: "gw"},
+		Spec: gatewayv1.GatewaySpec{
+			Listeners: []gatewayv1.Listener{
+				{
+					Name:     gatewayv1.SectionName("default-https"),
+					Protocol: gatewayv1.HTTPSProtocolType,
+				},
+				{
+					Name:     gatewayv1.SectionName("https-hostname-0"),
+					Protocol: gatewayv1.HTTPSProtocolType,
+				},
+			},
+		},
+	}
+
+	backends := []connectorBackendPatch{
+		{
+			ruleIndex:  0,
+			matchIndex: 0,
+			targetHost: "127.0.0.1",
+			targetPort: 5432,
+			nodeID:     "node-123",
+		},
+	}
+
+	// Only default-https is eligible; https-hostname-0 has an unissued cert.
+	patches, err := buildConnectorEnvoyPatches(
+		"ns-test",
+		"connector-tunnel",
+		gateway,
+		newHTTPProxy(),
+		backends,
+		sets.New("default-https"),
+	)
+	assert.NoError(t, err)
+
+	routeConfigPatchCounts := map[string]int{}
+	for _, patch := range patches {
+		if patch.Type != routeConfigurationTypeURL {
+			continue
+		}
+		routeConfigPatchCounts[patch.Name]++
+	}
+
+	// Regression case: the unready custom listener is skipped, but the ready
+	// default-https listener still receives its patches.
+	assert.Equal(t, 2, routeConfigPatchCounts["ns-test/gw/default-https"])
+	assert.NotContains(t, routeConfigPatchCounts, "ns-test/gw/https-hostname-0")
+}
+
+func TestBuildConnectorEnvoyPatchesSkipsIneligibleSectionListener(t *testing.T) {
+	gateway := &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Name: "gw"},
+		Spec: gatewayv1.GatewaySpec{
+			Listeners: []gatewayv1.Listener{
+				{
+					Name:     gatewayv1.SectionName("default-https"),
+					Protocol: gatewayv1.HTTPSProtocolType,
+				},
+				{
+					Name:     gatewayv1.SectionName("https-hostname-0"),
+					Protocol: gatewayv1.HTTPSProtocolType,
+				},
+			},
+		},
+	}
+
+	// Backend scoped to https-hostname-0, but that listener is not eligible.
+	backends := []connectorBackendPatch{
+		{
+			sectionName: ptr.To(gatewayv1.SectionName("https-hostname-0")),
+			ruleIndex:   0,
+			matchIndex:  0,
+			targetHost:  "127.0.0.1",
+			targetPort:  5432,
+			nodeID:      "node-123",
+		},
+	}
+
+	patches, err := buildConnectorEnvoyPatches(
+		"ns-test",
+		"connector-tunnel",
+		gateway,
+		newHTTPProxy(),
+		backends,
+		sets.New("default-https"),
+	)
+	assert.NoError(t, err)
+
+	for _, patch := range patches {
+		assert.NotEqual(t, routeConfigurationTypeURL, patch.Type,
+			"no RouteConfiguration patches expected for an ineligible section listener")
+	}
+}
+
+func TestBuildConnectorOfflineEnvoyPatchesSkipsIneligibleHTTPSListeners(t *testing.T) {
+	gateway := &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Name: "gw"},
+		Spec: gatewayv1.GatewaySpec{
+			Listeners: []gatewayv1.Listener{
+				{
+					Name:     gatewayv1.SectionName("default-https"),
+					Protocol: gatewayv1.HTTPSProtocolType,
+				},
+				{
+					Name:     gatewayv1.SectionName("https-hostname-0"),
+					Protocol: gatewayv1.HTTPSProtocolType,
+				},
+			},
+		},
+	}
+
+	patches, err := buildConnectorOfflineEnvoyPatches(
+		"ns-test",
+		gateway,
+		newHTTPProxy(),
+		sets.New("default-https"),
+	)
+	assert.NoError(t, err)
+
+	names := map[string]struct{}{}
+	for _, patch := range patches {
+		names[patch.Name] = struct{}{}
+	}
+
+	assert.Contains(t, names, "ns-test/gw/default-https")
+	assert.NotContains(t, names, "ns-test/gw/https-hostname-0")
 }
 
 func TestHTTPProxyFinalizerCleanup(t *testing.T) {
@@ -2402,6 +2536,216 @@ func TestBuildCertificateStatuses(t *testing.T) {
 					assert.Equal(t, tt.wantMessage, cond.Message)
 				}
 			}
+		})
+	}
+}
+
+func TestEligibleConnectorHTTPSListeners(t *testing.T) {
+	t.Parallel()
+
+	downstreamNamespaceName := "ns-test"
+
+	programmedListenerStatus := func(name string) gatewayv1.ListenerStatus {
+		return gatewayv1.ListenerStatus{
+			Name: gatewayv1.SectionName(name),
+			Conditions: []metav1.Condition{
+				{
+					Type:   string(gatewayv1.ListenerConditionProgrammed),
+					Status: metav1.ConditionTrue,
+					Reason: string(gatewayv1.ListenerReasonProgrammed),
+				},
+			},
+		}
+	}
+
+	httpsListener := func(name string) gatewayv1.Listener {
+		return gatewayv1.Listener{
+			Name:     gatewayv1.SectionName(name),
+			Protocol: gatewayv1.HTTPSProtocolType,
+		}
+	}
+
+	makeCert := func(name string, ready bool) *unstructured.Unstructured {
+		cert := &unstructured.Unstructured{}
+		cert.SetGroupVersionKind(certificateGVK)
+		cert.SetNamespace(downstreamNamespaceName)
+		cert.SetName(name)
+		status := certManagerConditionStatusFalse
+		if ready {
+			status = certManagerConditionStatusTrue
+		}
+		_ = unstructured.SetNestedSlice(cert.Object, []interface{}{
+			map[string]interface{}{
+				"type":   certManagerConditionTypeReady,
+				"status": status,
+				"reason": "test",
+			},
+		}, "status", "conditions")
+		return cert
+	}
+
+	sharedTLSConfig := config.NetworkServicesOperator{
+		Gateway: config.GatewayConfig{
+			DefaultListenerTLSSecretName: "wildcard-tls",
+		},
+	}
+
+	tests := []struct {
+		name              string
+		config            config.NetworkServicesOperator
+		gateway           *gatewayv1.Gateway
+		downstreamObjects []client.Object
+		want              []string
+	}{
+		{
+			name:   "default-https with shared TLS is eligible without a Certificate",
+			config: sharedTLSConfig,
+			gateway: &gatewayv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{Name: "gw"},
+				Spec: gatewayv1.GatewaySpec{
+					Listeners: []gatewayv1.Listener{httpsListener("default-https")},
+				},
+				Status: gatewayv1.GatewayStatus{
+					Listeners: []gatewayv1.ListenerStatus{programmedListenerStatus("default-https")},
+				},
+			},
+			want: []string{"default-https"},
+		},
+		{
+			name:   "default-https is eligible without shared TLS or a Certificate",
+			config: config.NetworkServicesOperator{},
+			gateway: &gatewayv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{Name: "gw"},
+				Spec: gatewayv1.GatewaySpec{
+					Listeners: []gatewayv1.Listener{httpsListener("default-https")},
+				},
+				Status: gatewayv1.GatewayStatus{
+					Listeners: []gatewayv1.ListenerStatus{programmedListenerStatus("default-https")},
+				},
+			},
+			want: []string{"default-https"},
+		},
+		{
+			name:   "custom listener with ready cert is eligible",
+			config: sharedTLSConfig,
+			gateway: &gatewayv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{Name: "gw"},
+				Spec: gatewayv1.GatewaySpec{
+					Listeners: []gatewayv1.Listener{httpsListener("https-hostname-0")},
+				},
+				Status: gatewayv1.GatewayStatus{
+					Listeners: []gatewayv1.ListenerStatus{programmedListenerStatus("https-hostname-0")},
+				},
+			},
+			downstreamObjects: []client.Object{makeCert("gw-https-hostname-0", true)},
+			want:              []string{"https-hostname-0"},
+		},
+		{
+			name:   "custom listener with not-ready cert is skipped",
+			config: sharedTLSConfig,
+			gateway: &gatewayv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{Name: "gw"},
+				Spec: gatewayv1.GatewaySpec{
+					Listeners: []gatewayv1.Listener{httpsListener("https-hostname-0")},
+				},
+				Status: gatewayv1.GatewayStatus{
+					Listeners: []gatewayv1.ListenerStatus{programmedListenerStatus("https-hostname-0")},
+				},
+			},
+			downstreamObjects: []client.Object{makeCert("gw-https-hostname-0", false)},
+			want:              []string{},
+		},
+		{
+			name:   "custom listener with missing cert is skipped",
+			config: sharedTLSConfig,
+			gateway: &gatewayv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{Name: "gw"},
+				Spec: gatewayv1.GatewaySpec{
+					Listeners: []gatewayv1.Listener{httpsListener("https-hostname-0")},
+				},
+				Status: gatewayv1.GatewayStatus{
+					Listeners: []gatewayv1.ListenerStatus{programmedListenerStatus("https-hostname-0")},
+				},
+			},
+			want: []string{},
+		},
+		{
+			name:   "not-programmed listener is skipped even with ready cert",
+			config: sharedTLSConfig,
+			gateway: &gatewayv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{Name: "gw"},
+				Spec: gatewayv1.GatewaySpec{
+					Listeners: []gatewayv1.Listener{httpsListener("https-hostname-0")},
+				},
+			},
+			downstreamObjects: []client.Object{makeCert("gw-https-hostname-0", true)},
+			want:              []string{},
+		},
+		{
+			name:   "ready listener stays eligible while another waits on its cert",
+			config: sharedTLSConfig,
+			gateway: &gatewayv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{Name: "gw"},
+				Spec: gatewayv1.GatewaySpec{
+					Listeners: []gatewayv1.Listener{
+						httpsListener("default-https"),
+						httpsListener("https-hostname-0"),
+						httpsListener("https-hostname-1"),
+					},
+				},
+				Status: gatewayv1.GatewayStatus{
+					Listeners: []gatewayv1.ListenerStatus{
+						programmedListenerStatus("default-https"),
+						programmedListenerStatus("https-hostname-0"),
+						programmedListenerStatus("https-hostname-1"),
+					},
+				},
+			},
+			downstreamObjects: []client.Object{
+				makeCert("gw-https-hostname-0", true),
+				makeCert("gw-https-hostname-1", false),
+			},
+			want: []string{"default-https", "https-hostname-0"},
+		},
+		{
+			name:   "non-HTTPS listeners are ignored",
+			config: sharedTLSConfig,
+			gateway: &gatewayv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{Name: "gw"},
+				Spec: gatewayv1.GatewaySpec{
+					Listeners: []gatewayv1.Listener{
+						{Name: "default-http", Protocol: gatewayv1.HTTPProtocolType},
+						httpsListener("default-https"),
+					},
+				},
+				Status: gatewayv1.GatewayStatus{
+					Listeners: []gatewayv1.ListenerStatus{programmedListenerStatus("default-https")},
+				},
+			},
+			want: []string{"default-https"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			scheme := runtime.NewScheme()
+			_ = gatewayv1.Install(scheme)
+
+			downstreamClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(tt.downstreamObjects...).
+				Build()
+
+			r := &HTTPProxyReconciler{
+				Config:            tt.config,
+				DownstreamCluster: &clusterWithClient{c: downstreamClient, scheme: scheme},
+			}
+
+			got, err := r.eligibleConnectorHTTPSListeners(context.Background(), downstreamNamespaceName, tt.gateway)
+			require.NoError(t, err)
+			assert.ElementsMatch(t, tt.want, got.UnsortedList())
 		})
 	}
 }

--- a/internal/controller/httpproxy_controller_test.go
+++ b/internal/controller/httpproxy_controller_test.go
@@ -2543,8 +2543,6 @@ func TestBuildCertificateStatuses(t *testing.T) {
 func TestEligibleConnectorHTTPSListeners(t *testing.T) {
 	t.Parallel()
 
-	downstreamNamespaceName := "ns-test"
-
 	programmedListenerStatus := func(name string) gatewayv1.ListenerStatus {
 		return gatewayv1.ListenerStatus{
 			Name: gatewayv1.SectionName(name),
@@ -2565,41 +2563,13 @@ func TestEligibleConnectorHTTPSListeners(t *testing.T) {
 		}
 	}
 
-	makeCert := func(name string, ready bool) *unstructured.Unstructured {
-		cert := &unstructured.Unstructured{}
-		cert.SetGroupVersionKind(certificateGVK)
-		cert.SetNamespace(downstreamNamespaceName)
-		cert.SetName(name)
-		status := certManagerConditionStatusFalse
-		if ready {
-			status = certManagerConditionStatusTrue
-		}
-		_ = unstructured.SetNestedSlice(cert.Object, []interface{}{
-			map[string]interface{}{
-				"type":   certManagerConditionTypeReady,
-				"status": status,
-				"reason": "test",
-			},
-		}, "status", "conditions")
-		return cert
-	}
-
-	sharedTLSConfig := config.NetworkServicesOperator{
-		Gateway: config.GatewayConfig{
-			DefaultListenerTLSSecretName: "wildcard-tls",
-		},
-	}
-
 	tests := []struct {
-		name              string
-		config            config.NetworkServicesOperator
-		gateway           *gatewayv1.Gateway
-		downstreamObjects []client.Object
-		want              []string
+		name    string
+		gateway *gatewayv1.Gateway
+		want    []string
 	}{
 		{
-			name:   "default-https with shared TLS is eligible without a Certificate",
-			config: sharedTLSConfig,
+			name: "programmed default-https is eligible",
 			gateway: &gatewayv1.Gateway{
 				ObjectMeta: metav1.ObjectMeta{Name: "gw"},
 				Spec: gatewayv1.GatewaySpec{
@@ -2612,22 +2582,7 @@ func TestEligibleConnectorHTTPSListeners(t *testing.T) {
 			want: []string{"default-https"},
 		},
 		{
-			name:   "default-https is eligible without shared TLS or a Certificate",
-			config: config.NetworkServicesOperator{},
-			gateway: &gatewayv1.Gateway{
-				ObjectMeta: metav1.ObjectMeta{Name: "gw"},
-				Spec: gatewayv1.GatewaySpec{
-					Listeners: []gatewayv1.Listener{httpsListener("default-https")},
-				},
-				Status: gatewayv1.GatewayStatus{
-					Listeners: []gatewayv1.ListenerStatus{programmedListenerStatus("default-https")},
-				},
-			},
-			want: []string{"default-https"},
-		},
-		{
-			name:   "custom listener with ready cert is eligible",
-			config: sharedTLSConfig,
+			name: "programmed custom listener is eligible",
 			gateway: &gatewayv1.Gateway{
 				ObjectMeta: metav1.ObjectMeta{Name: "gw"},
 				Spec: gatewayv1.GatewaySpec{
@@ -2637,53 +2592,20 @@ func TestEligibleConnectorHTTPSListeners(t *testing.T) {
 					Listeners: []gatewayv1.ListenerStatus{programmedListenerStatus("https-hostname-0")},
 				},
 			},
-			downstreamObjects: []client.Object{makeCert("gw-https-hostname-0", true)},
-			want:              []string{"https-hostname-0"},
+			want: []string{"https-hostname-0"},
 		},
 		{
-			name:   "custom listener with not-ready cert is skipped",
-			config: sharedTLSConfig,
+			name: "not-programmed listener is skipped",
 			gateway: &gatewayv1.Gateway{
 				ObjectMeta: metav1.ObjectMeta{Name: "gw"},
 				Spec: gatewayv1.GatewaySpec{
 					Listeners: []gatewayv1.Listener{httpsListener("https-hostname-0")},
-				},
-				Status: gatewayv1.GatewayStatus{
-					Listeners: []gatewayv1.ListenerStatus{programmedListenerStatus("https-hostname-0")},
-				},
-			},
-			downstreamObjects: []client.Object{makeCert("gw-https-hostname-0", false)},
-			want:              []string{},
-		},
-		{
-			name:   "custom listener with missing cert is skipped",
-			config: sharedTLSConfig,
-			gateway: &gatewayv1.Gateway{
-				ObjectMeta: metav1.ObjectMeta{Name: "gw"},
-				Spec: gatewayv1.GatewaySpec{
-					Listeners: []gatewayv1.Listener{httpsListener("https-hostname-0")},
-				},
-				Status: gatewayv1.GatewayStatus{
-					Listeners: []gatewayv1.ListenerStatus{programmedListenerStatus("https-hostname-0")},
 				},
 			},
 			want: []string{},
 		},
 		{
-			name:   "not-programmed listener is skipped even with ready cert",
-			config: sharedTLSConfig,
-			gateway: &gatewayv1.Gateway{
-				ObjectMeta: metav1.ObjectMeta{Name: "gw"},
-				Spec: gatewayv1.GatewaySpec{
-					Listeners: []gatewayv1.Listener{httpsListener("https-hostname-0")},
-				},
-			},
-			downstreamObjects: []client.Object{makeCert("gw-https-hostname-0", true)},
-			want:              []string{},
-		},
-		{
-			name:   "ready listener stays eligible while another waits on its cert",
-			config: sharedTLSConfig,
+			name: "only programmed listeners are eligible",
 			gateway: &gatewayv1.Gateway{
 				ObjectMeta: metav1.ObjectMeta{Name: "gw"},
 				Spec: gatewayv1.GatewaySpec{
@@ -2697,19 +2619,13 @@ func TestEligibleConnectorHTTPSListeners(t *testing.T) {
 					Listeners: []gatewayv1.ListenerStatus{
 						programmedListenerStatus("default-https"),
 						programmedListenerStatus("https-hostname-0"),
-						programmedListenerStatus("https-hostname-1"),
 					},
 				},
-			},
-			downstreamObjects: []client.Object{
-				makeCert("gw-https-hostname-0", true),
-				makeCert("gw-https-hostname-1", false),
 			},
 			want: []string{"default-https", "https-hostname-0"},
 		},
 		{
-			name:   "non-HTTPS listeners are ignored",
-			config: sharedTLSConfig,
+			name: "non-HTTPS listeners are ignored",
 			gateway: &gatewayv1.Gateway{
 				ObjectMeta: metav1.ObjectMeta{Name: "gw"},
 				Spec: gatewayv1.GatewaySpec{
@@ -2729,22 +2645,7 @@ func TestEligibleConnectorHTTPSListeners(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-
-			scheme := runtime.NewScheme()
-			_ = gatewayv1.Install(scheme)
-
-			downstreamClient := fake.NewClientBuilder().
-				WithScheme(scheme).
-				WithObjects(tt.downstreamObjects...).
-				Build()
-
-			r := &HTTPProxyReconciler{
-				Config:            tt.config,
-				DownstreamCluster: &clusterWithClient{c: downstreamClient, scheme: scheme},
-			}
-
-			got, err := r.eligibleConnectorHTTPSListeners(context.Background(), downstreamNamespaceName, tt.gateway)
-			require.NoError(t, err)
+			got := eligibleConnectorHTTPSListeners(tt.gateway)
 			assert.ElementsMatch(t, tt.want, got.UnsortedList())
 		})
 	}


### PR DESCRIPTION
Fixes #184

## Problem

When a customer hostname's TLS certificate hasn't been issued yet — DNS not pointed at us, or the ACME challenge still pending — the connector reconciler still generated an Envoy routing patch for that hostname's HTTPS listener. With no certificate, Envoy Gateway never programs the listener, so the patch can never apply and the connector `EnvoyPatchPolicy` is left stuck `Programmed=False` indefinitely.

Impact: persistent failing policies that obscure real issues, and the "Tunnel not online" fallback never attaches for the affected hostname. Seen in production on `agent.lkms.app` (certificate pending 62 days). Other gateways' traffic is unaffected.

## Fix

Generate the connector patch for an HTTPS listener only once that listener is `Programmed`. A listener reaches `Programmed` only after Envoy Gateway has resolved its TLS secret and materialized its `RouteConfiguration` — exactly what the patch targets — so this gates directly on the condition that matters. Gating is per listener, so a hostname still waiting on its certificate no longer produces a permanently-failing policy while ready hostnames on the same proxy keep working.

This supersedes the partial `default-https`-only gate from #112. PR #107 addressed the same symptom for `TrafficProtectionPolicy` by checking the cert-manager `Certificate`; here we gate on listener `Programmed` instead — the more direct signal (the secret is already resolved by the time the listener programs), which also needs no special-casing for the shared-wildcard `default-https` listener.

## Tests

Unit tests cover programmed / not-programmed listeners, mixed readiness, the default listener, and non-HTTPS listeners. `go build`, `go vet`, `gofmt`, and `go test ./...` pass.
