### PR TITLE
feat(o11y): add envoy patch policy alert

### DIFF
--- a/config/telemetry/alerts/gateways.yaml
+++ b/config/telemetry/alerts/gateways.yaml
@@ -22,6 +22,16 @@ spec:
         summary: "Gateway {{ $labels.resource_name }} is taking longer than 60 seconds to reach Ready status"
         description: "Gateway {{ $labels.resource_name }} in namespace {{ $labels.resource_namespace }} has been in creation state for {{ $value }} seconds without reaching Ready status (Accepted=True AND Programmed=True), which exceeds the 60-second SLO threshold."
 
+    - alert: EnvoyPatchPolicyProgrammingFailed
+      expr: |
+        envoy_gateway_envoypatchpolicy_status_condition{type="Programmed"} == 0
+      for: 5m
+      labels:
+        severity: critical
+      annotations:
+        summary: "EnvoyPatchPolicy {{ $labels.name }} failed to program"
+        description: "EnvoyPatchPolicy {{ $labels.name }} in namespace {{ $labels.namespace }} has been unable to apply its xDS patch for over 5 minutes (reason: {{ $labels.reason }}). Customer traffic on affected gateways may be impacted."
+
     - alert: GatewayDegradedSLOViolation
       expr: |
         (


### PR DESCRIPTION
Adds `EnvoyPatchPolicyProgrammingFailed` to the gateway SLO alert group.

On 2026-06-15, customer gateways with custom hostnames stopped serving traffic. One of the issues was `EnvoyPatchPolicy` resources failing with `ResourceNotFound` - Envoy Gateway couldn't find the target xDS RouteConfiguration to apply the patch.

The existing gateway SLO alerts didn't fire because `Gateway.status.conditions[Programmed]` remained True; the failure was on the patch policy layer, not the gateway itself.

*Fix*: Alert when any `EnvoyPatchPolicy` has been `Programmed=False` for more than 5 minutes. The reason label is included in the description so oncall immediately knows whether it's ResourceNotFound, Invalid, etc.

Related to https://github.com/datum-cloud/engineering/issues/317