### PR TITLE
Harden Backend & SecurityPolicy against SSRF / egress abuse

### DIFF
--- a/internal/validation/backend_validation.go
+++ b/internal/validation/backend_validation.go
@@ -32,6 +32,17 @@ func validateBackendEndpoints(endpoints []envoygatewayv1alpha1.BackendEndpoint, 
 		if endpoint.Unix != nil {
 			allErrs = append(allErrs, field.Forbidden(endpointPath.Child("unix"), "unix endpoints are not permitted"))
 		}
+
+		// Constrain egress targets so a tenant cannot point a Backend at
+		// cluster-local or cloud-metadata addresses (SSRF). Mirrors the rules
+		// enforced for HTTPProxy backends.
+		if endpoint.IP != nil {
+			allErrs = append(allErrs, validateExternalHost(endpointPath.Child("ip", "address"), endpoint.IP.Address)...)
+		}
+
+		if endpoint.FQDN != nil {
+			allErrs = append(allErrs, validateExternalHost(endpointPath.Child("fqdn", "hostname"), endpoint.FQDN.Hostname)...)
+		}
 	}
 
 	return allErrs

--- a/internal/validation/backend_validation_test.go
+++ b/internal/validation/backend_validation_test.go
@@ -40,6 +40,84 @@ func TestValidateBackend(t *testing.T) {
 				field.Forbidden(field.NewPath("spec", "endpoints").Index(0).Child("unix"), ""),
 			},
 		},
+		// SSRF / egress hardening – IP address checks
+		"ip endpoint - link-local (169.254.169.254) is rejected": {
+			backend: &envoygatewayv1alpha1.Backend{
+				Spec: envoygatewayv1alpha1.BackendSpec{
+					Endpoints: []envoygatewayv1alpha1.BackendEndpoint{
+						{
+							IP: &envoygatewayv1alpha1.IPEndpoint{
+								Address: "169.254.169.254",
+							},
+						},
+					},
+				},
+			},
+			expectedErrors: field.ErrorList{
+				field.Invalid(field.NewPath("spec", "endpoints").Index(0).Child("ip", "address"), "", ""),
+			},
+		},
+		"ip endpoint - loopback (127.0.0.1) is rejected": {
+			backend: &envoygatewayv1alpha1.Backend{
+				Spec: envoygatewayv1alpha1.BackendSpec{
+					Endpoints: []envoygatewayv1alpha1.BackendEndpoint{
+						{
+							IP: &envoygatewayv1alpha1.IPEndpoint{
+								Address: "127.0.0.1",
+							},
+						},
+					},
+				},
+			},
+			expectedErrors: field.ErrorList{
+				field.Invalid(field.NewPath("spec", "endpoints").Index(0).Child("ip", "address"), "", ""),
+			},
+		},
+		"ip endpoint - public IP (203.0.113.10) is allowed": {
+			backend: &envoygatewayv1alpha1.Backend{
+				Spec: envoygatewayv1alpha1.BackendSpec{
+					Endpoints: []envoygatewayv1alpha1.BackendEndpoint{
+						{
+							IP: &envoygatewayv1alpha1.IPEndpoint{
+								Address: "203.0.113.10",
+							},
+						},
+					},
+				},
+			},
+			expectedErrors: field.ErrorList{},
+		},
+		// SSRF / egress hardening – FQDN hostname checks
+		"fqdn endpoint - single-label name (metadata) is rejected": {
+			backend: &envoygatewayv1alpha1.Backend{
+				Spec: envoygatewayv1alpha1.BackendSpec{
+					Endpoints: []envoygatewayv1alpha1.BackendEndpoint{
+						{
+							FQDN: &envoygatewayv1alpha1.FQDNEndpoint{
+								Hostname: "metadata",
+							},
+						},
+					},
+				},
+			},
+			expectedErrors: field.ErrorList{
+				field.Invalid(field.NewPath("spec", "endpoints").Index(0).Child("fqdn", "hostname"), "", ""),
+			},
+		},
+		"fqdn endpoint - valid FQDN (jwks.example.com) is allowed": {
+			backend: &envoygatewayv1alpha1.Backend{
+				Spec: envoygatewayv1alpha1.BackendSpec{
+					Endpoints: []envoygatewayv1alpha1.BackendEndpoint{
+						{
+							FQDN: &envoygatewayv1alpha1.FQDNEndpoint{
+								Hostname: "jwks.example.com",
+							},
+						},
+					},
+				},
+			},
+			expectedErrors: field.ErrorList{},
+		},
 	}
 
 	for name, scenario := range scenarios {

--- a/internal/validation/network.go
+++ b/internal/validation/network.go
@@ -1,0 +1,85 @@
+package validation
+
+import (
+	"fmt"
+	"net"
+	"net/url"
+
+	"k8s.io/apimachinery/pkg/util/validation"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+// validateExternalHost validates that a host (IP literal or DNS name) used as an
+// egress target by the shared data plane is not an internal or link-local
+// address that could be abused for SSRF against cluster-local or cloud-metadata
+// services (e.g. 169.254.169.254).
+//
+// The rules intentionally mirror those already enforced for HTTPProxy backends
+// (see validateHTTPProxyRuleBackend): IP literals must not be unspecified,
+// loopback, or link-local; DNS names must be fully qualified, which rejects
+// single-label internal names such as "localhost", "kubernetes", or "metadata".
+// RFC1918 / unique-local ranges are intentionally NOT blocked here, to stay
+// consistent with the HTTPProxy rules; egress allowlisting is tracked
+// separately.
+func validateExternalHost(fldPath *field.Path, host string) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	if ip := net.ParseIP(host); ip != nil {
+		if ip.IsUnspecified() {
+			allErrs = append(allErrs, field.Invalid(fldPath, host, fmt.Sprintf("may not be unspecified (%v)", host)))
+		}
+		if ip.IsLoopback() {
+			allErrs = append(allErrs, field.Invalid(fldPath, host, "may not be in the loopback range (127.0.0.0/8, ::1/128)"))
+		}
+		if ip.IsLinkLocalUnicast() {
+			allErrs = append(allErrs, field.Invalid(fldPath, host, "may not be in the link-local range (169.254.0.0/16, fe80::/10)"))
+		}
+		if ip.IsLinkLocalMulticast() {
+			allErrs = append(allErrs, field.Invalid(fldPath, host, "may not be in the link-local multicast range (224.0.0.0/24, ff02::/10)"))
+		}
+		return allErrs
+	}
+
+	// Not an IP literal: require a fully-qualified domain name so single-label
+	// internal service names cannot be used to reach cluster-local services.
+	allErrs = append(allErrs, validation.IsFullyQualifiedDomainName(fldPath, host)...)
+
+	return allErrs
+}
+
+// validateExternalHTTPSURL validates a free-form URL string that the shared data
+// plane will fetch on a tenant's behalf (e.g. OIDC issuer/endpoints, remote
+// JWKS). The URL must be a valid absolute https URL with no userinfo component
+// and a host that passes validateExternalHost. An empty value is treated as
+// valid (callers decide whether the field is required).
+func validateExternalHTTPSURL(fldPath *field.Path, raw string) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	if raw == "" {
+		return allErrs
+	}
+
+	u, err := url.Parse(raw)
+	if err != nil {
+		allErrs = append(allErrs, field.Invalid(fldPath, raw, fmt.Sprintf("invalid URL: %s", err)))
+		return allErrs
+	}
+
+	if u.Scheme != "https" {
+		allErrs = append(allErrs, field.NotSupported(fldPath.Key("scheme"), u.Scheme, []string{"https"}))
+	}
+
+	if u.User != nil {
+		allErrs = append(allErrs, field.Invalid(fldPath.Key("userinfo"), fmt.Sprintf("%s:redacted", u.User.Username()), "must not have a userinfo component"))
+	}
+
+	host := u.Hostname()
+	if host == "" {
+		allErrs = append(allErrs, field.Required(fldPath.Key("host"), "must have a host component"))
+		return allErrs
+	}
+
+	allErrs = append(allErrs, validateExternalHost(fldPath.Key("host"), host)...)
+
+	return allErrs
+}

--- a/internal/validation/network_test.go
+++ b/internal/validation/network_test.go
@@ -1,0 +1,188 @@
+package validation
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+func TestValidateExternalHost(t *testing.T) {
+	fldPath := field.NewPath("host")
+
+	tests := []struct {
+		name           string
+		host           string
+		expectedErrors field.ErrorList
+	}{
+		// IP literal – blocked ranges
+		{
+			name: "loopback IPv4 is rejected",
+			host: "127.0.0.1",
+			expectedErrors: field.ErrorList{
+				field.Invalid(fldPath, "", ""),
+			},
+		},
+		{
+			name: "loopback IPv6 is rejected",
+			host: "::1",
+			expectedErrors: field.ErrorList{
+				field.Invalid(fldPath, "", ""),
+			},
+		},
+		{
+			name: "link-local unicast IPv4 (169.254.169.254) is rejected",
+			host: "169.254.169.254",
+			expectedErrors: field.ErrorList{
+				field.Invalid(fldPath, "", ""),
+			},
+		},
+		{
+			name: "unspecified IPv4 (0.0.0.0) is rejected",
+			host: "0.0.0.0",
+			expectedErrors: field.ErrorList{
+				field.Invalid(fldPath, "", ""),
+			},
+		},
+		// IP literal – allowed ranges
+		{
+			name:           "public IPv4 (203.0.113.10) is allowed",
+			host:           "203.0.113.10",
+			expectedErrors: field.ErrorList{},
+		},
+		{
+			name:           "RFC1918 IPv4 (10.0.0.1) is allowed (allowlisted separately)",
+			host:           "10.0.0.1",
+			expectedErrors: field.ErrorList{},
+		},
+		// DNS names – single-label rejected, FQDN allowed
+		{
+			name: "single-label name (metadata) is rejected",
+			host: "metadata",
+			expectedErrors: field.ErrorList{
+				field.Invalid(fldPath, "", ""),
+			},
+		},
+		{
+			name: "single-label name (localhost) is rejected",
+			host: "localhost",
+			expectedErrors: field.ErrorList{
+				field.Invalid(fldPath, "", ""),
+			},
+		},
+		{
+			name:           "valid FQDN (jwks.example.com) is allowed",
+			host:           "jwks.example.com",
+			expectedErrors: field.ErrorList{},
+		},
+		{
+			name:           "valid FQDN with subdomain (auth.idp.example.com) is allowed",
+			host:           "auth.idp.example.com",
+			expectedErrors: field.ErrorList{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			errs := validateExternalHost(fldPath, tt.host)
+			delta := cmp.Diff(tt.expectedErrors, errs, cmpopts.IgnoreFields(field.Error{}, "BadValue", "Detail"))
+			if delta != "" {
+				t.Errorf("validateExternalHost(%q): expected errors %v, got %v, diff: %v",
+					tt.host, tt.expectedErrors, errs, delta)
+			}
+		})
+	}
+}
+
+func TestValidateExternalHTTPSURL(t *testing.T) {
+	fldPath := field.NewPath("spec", "url")
+
+	tests := []struct {
+		name           string
+		raw            string
+		expectedErrors field.ErrorList
+	}{
+		// Empty string is valid (caller decides whether field is required)
+		{
+			name:           "empty string is allowed",
+			raw:            "",
+			expectedErrors: field.ErrorList{},
+		},
+		// Scheme checks
+		{
+			// "http://x" yields two errors: NotSupported at [scheme] (http vs https)
+			// and Invalid at [host] ("x" is a single-label name).
+			name: "http scheme is rejected and single-label host also produces error",
+			raw:  "http://x",
+			expectedErrors: field.ErrorList{
+				field.NotSupported(fldPath.Key("scheme"), "", []string{"https"}),
+				field.Invalid(fldPath.Key("host"), "", ""),
+			},
+		},
+		{
+			name: "ftp scheme is rejected",
+			raw:  "ftp://example.com/keys",
+			expectedErrors: field.ErrorList{
+				field.NotSupported(fldPath.Key("scheme"), "", []string{"https"}),
+			},
+		},
+		// Userinfo checks
+		{
+			name: "userinfo component is rejected",
+			raw:  "https://user:pass@example.com/keys",
+			expectedErrors: field.ErrorList{
+				field.Invalid(fldPath.Key("userinfo"), "", ""),
+			},
+		},
+		// Host validation (SSRF)
+		{
+			name: "link-local IP host is rejected",
+			raw:  "https://169.254.169.254/latest/meta-data",
+			expectedErrors: field.ErrorList{
+				field.Invalid(fldPath.Key("host"), "", ""),
+			},
+		},
+		{
+			name: "loopback IP host is rejected",
+			raw:  "https://127.0.0.1/keys",
+			expectedErrors: field.ErrorList{
+				field.Invalid(fldPath.Key("host"), "", ""),
+			},
+		},
+		{
+			name: "single-label hostname is rejected",
+			raw:  "https://metadata/keys",
+			expectedErrors: field.ErrorList{
+				field.Invalid(fldPath.Key("host"), "", ""),
+			},
+		},
+		// Valid cases
+		{
+			name:           "valid https URL with FQDN is allowed",
+			raw:            "https://accounts.example.com",
+			expectedErrors: field.ErrorList{},
+		},
+		{
+			name:           "valid https URL with path is allowed",
+			raw:            "https://jwks.example.com/oidc/keys",
+			expectedErrors: field.ErrorList{},
+		},
+		{
+			name:           "valid https URL with public IP is allowed",
+			raw:            "https://203.0.113.10/keys",
+			expectedErrors: field.ErrorList{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			errs := validateExternalHTTPSURL(fldPath, tt.raw)
+			delta := cmp.Diff(tt.expectedErrors, errs, cmpopts.IgnoreFields(field.Error{}, "BadValue", "Detail"))
+			if delta != "" {
+				t.Errorf("validateExternalHTTPSURL(%q): expected errors %v, got %v, diff: %v",
+					tt.raw, tt.expectedErrors, errs, delta)
+			}
+		})
+	}
+}

--- a/internal/validation/securitypolicy_validation.go
+++ b/internal/validation/securitypolicy_validation.go
@@ -3,6 +3,7 @@ package validation
 import (
 	envoygatewayv1alpha1 "github.com/envoyproxy/gateway/api/v1alpha1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/utils/ptr"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"go.datum.net/network-services-operator/internal/config"
@@ -175,6 +176,14 @@ func validateSecurityPolicyOIDCProvider(provider envoygatewayv1alpha1.OIDCProvid
 
 	allErrs = append(allErrs, validateGatewayBackendCluster(provider.BackendCluster, fldPath, opts)...)
 
+	// The shared data plane fetches these endpoints on the tenant's behalf, so
+	// constrain them to external https URLs to prevent SSRF against cluster-local
+	// or cloud-metadata services.
+	allErrs = append(allErrs, validateExternalHTTPSURL(fldPath.Child("issuer"), provider.Issuer)...)
+	allErrs = append(allErrs, validateExternalHTTPSURL(fldPath.Child("authorizationEndpoint"), ptr.Deref(provider.AuthorizationEndpoint, ""))...)
+	allErrs = append(allErrs, validateExternalHTTPSURL(fldPath.Child("tokenEndpoint"), ptr.Deref(provider.TokenEndpoint, ""))...)
+	allErrs = append(allErrs, validateExternalHTTPSURL(fldPath.Child("endSessionEndpoint"), ptr.Deref(provider.EndSessionEndpoint, ""))...)
+
 	return allErrs
 }
 
@@ -212,6 +221,11 @@ func validateRemoteJWKS(remoteJWKS *envoygatewayv1alpha1.RemoteJWKS, fldPath *fi
 	allErrs := field.ErrorList{}
 
 	allErrs = append(allErrs, validateGatewayBackendCluster(remoteJWKS.BackendCluster, fldPath, opts)...)
+
+	// When no BackendCluster is configured, the data plane fetches the JWKS
+	// directly from this URI; constrain it to an external https URL to prevent
+	// SSRF against cluster-local or cloud-metadata services.
+	allErrs = append(allErrs, validateExternalHTTPSURL(fldPath.Child("uri"), remoteJWKS.URI)...)
 
 	return allErrs
 }

--- a/internal/validation/securitypolicy_validation_test.go
+++ b/internal/validation/securitypolicy_validation_test.go
@@ -7,11 +7,11 @@ import (
 	envoygatewayv1alpha1 "github.com/envoyproxy/gateway/api/v1alpha1"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"go.datum.net/network-services-operator/internal/config"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/utils/ptr"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	"go.datum.net/network-services-operator/internal/config"
 )
 
 func TestValidateSecurityPolicy(t *testing.T) {
@@ -349,6 +349,71 @@ func TestValidateSecurityPolicy(t *testing.T) {
 			},
 			expectedErrors: field.ErrorList{
 				field.TooMany(field.NewPath("spec", "authorization", "rules").Index(0).Child("principal", "clientCIDRs"), 3, 2),
+			},
+		},
+		// SSRF / egress hardening – OIDC provider URL checks
+		"oidc provider issuer - http scheme rejected": {
+			securityPolicy: &envoygatewayv1alpha1.SecurityPolicy{
+				Spec: envoygatewayv1alpha1.SecurityPolicySpec{
+					OIDC: &envoygatewayv1alpha1.OIDC{
+						Provider: envoygatewayv1alpha1.OIDCProvider{
+							// "http://x" produces two errors: one NotSupported at [scheme]
+							// because the scheme is not https, and one Invalid at [host]
+							// because "x" is a single-label name that fails FQDN validation.
+							Issuer: "http://x",
+						},
+					},
+				},
+			},
+			expectedErrors: field.ErrorList{
+				field.NotSupported(field.NewPath("spec", "oidc", "provider", "issuer").Key("scheme"), "", []string{"https"}),
+				field.Invalid(field.NewPath("spec", "oidc", "provider", "issuer").Key("host"), "", ""),
+			},
+		},
+		"oidc provider issuer - link-local IP rejected": {
+			securityPolicy: &envoygatewayv1alpha1.SecurityPolicy{
+				Spec: envoygatewayv1alpha1.SecurityPolicySpec{
+					OIDC: &envoygatewayv1alpha1.OIDC{
+						Provider: envoygatewayv1alpha1.OIDCProvider{
+							Issuer: "https://169.254.169.254/",
+						},
+					},
+				},
+			},
+			expectedErrors: field.ErrorList{
+				field.Invalid(field.NewPath("spec", "oidc", "provider", "issuer").Key("host"), "", ""),
+			},
+		},
+		"oidc provider issuer - valid https URL is allowed": {
+			securityPolicy: &envoygatewayv1alpha1.SecurityPolicy{
+				Spec: envoygatewayv1alpha1.SecurityPolicySpec{
+					OIDC: &envoygatewayv1alpha1.OIDC{
+						Provider: envoygatewayv1alpha1.OIDCProvider{
+							Issuer: "https://accounts.example.com",
+						},
+					},
+				},
+			},
+			expectedErrors: field.ErrorList{},
+		},
+		// SSRF / egress hardening – JWT RemoteJWKS URI checks
+		"jwt remoteJWKS uri - link-local IP rejected": {
+			securityPolicy: &envoygatewayv1alpha1.SecurityPolicy{
+				Spec: envoygatewayv1alpha1.SecurityPolicySpec{
+					JWT: &envoygatewayv1alpha1.JWT{
+						Providers: []envoygatewayv1alpha1.JWTProvider{
+							{
+								Name: "test-provider",
+								RemoteJWKS: &envoygatewayv1alpha1.RemoteJWKS{
+									URI: "https://169.254.169.254/keys",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedErrors: field.ErrorList{
+				field.Invalid(field.NewPath("spec", "jwt", "providers").Index(0).Child("remoteJWKS", "uri").Key("host"), "", ""),
 			},
 		},
 	}


### PR DESCRIPTION
## Why

Tenants create `Backend` and `SecurityPolicy` resources that NSO translates into the **shared** downstream Envoy data plane. Several tenant-controlled fields are *egress targets* the shared data plane dials or fetches on the tenant's behalf — and they were unvalidated. A tenant could point them at cluster-local or cloud-metadata addresses (e.g. `169.254.169.254`), giving an SSRF vector against shared infrastructure and other tenants.

These gaps are **pre-existing** (not introduced by the Gateway API 1.5 / EG 1.8 upgrade) — surfaced by the multi-tenancy security review of that upgrade. This PR closes the two genuinely exploitable ones.

## What changed

New shared helper `internal/validation/network.go`:
- `validateExternalHost` — IP literals must not be unspecified / loopback / link-local (this is what blocks `169.254.169.254`); DNS names must be fully-qualified (rejects single-label internal names like `localhost`, `kubernetes`, `metadata`).
- `validateExternalHTTPSURL` — must be an absolute `https` URL, no userinfo, host passes `validateExternalHost`.

Wired in:
- **`Backend`** (`backend_validation.go`) — `IP` and `FQDN` endpoints validated against `validateExternalHost`.
- **`SecurityPolicy`** (`securitypolicy_validation.go`) — OIDC `issuer` / `authorizationEndpoint` / `tokenEndpoint` / `endSessionEndpoint` and `RemoteJWKS.URI` validated as external https URLs.

Rules intentionally **mirror the existing HTTPProxy backend checks** for consistency.

### Deliberately out of scope
- **`BackendTLSPolicy`** reviewed and left unchanged: its `caCertificateRefs` are namespace-less `LocalObjectReference`s, so the flattened downstream-namespace model already contains them — no cross-tenant gap to close.
- **RFC1918 / in-cluster DNS** targeting is *not* blocked (same as the HTTPProxy rules today). Broader egress allowlisting is a larger policy decision tracked separately.

## Tests
New/extended table cases in `backend_validation_test.go`, `securitypolicy_validation_test.go`, and a focused `network_test.go` (loopback/link-local/unspecified/RFC1918/single-label/valid-FQDN, plus URL scheme/userinfo/host cases). `go build ./...` and `go test ./internal/validation/...` green.

## Review notes
- **Stacked on #189** (base is the `deps/envoy-gateway-1.8-gatewayapi-1.5` branch) because the SecurityPolicy `RemoteJWKS.URI` field exists in the Envoy Gateway 1.8 types. Once #189 merges, I'll retarget this PR's base to `main`.
- Draft pending CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)