### PR TITLE
fix(envoy-gateway): roll back EG control plane to v1.7.4

### DIFF
--- a/config/tools/envoy-gateway-downstream/kustomization.yaml
+++ b/config/tools/envoy-gateway-downstream/kustomization.yaml
@@ -6,7 +6,16 @@ helmCharts:
     includeCRDs: false
     namespace: datum-downstream-gateway
     releaseName: envoy-datum-downstream-gateway
-    version: v1.8.1
+    # Rolled back from v1.8.1 to v1.7.4: EG v1.8.0 (PR #8703) reworked OIDC into a
+    # listener-level "dumb" oauth2 filter. When a SecurityPolicy's OIDC clientSecret
+    # is missing, v1.8.x emits a config-less envoy.filters.http.oauth2 at listener
+    # scope, which Envoy rejects ("config must be present for global config"),
+    # rejecting the WHOLE listener snapshot for every tenant on the shared gateway.
+    # v1.7.4 (last pre-redesign release) fails safe: it omits the oauth2 filter for
+    # the broken route and returns a per-route 500 direct response instead. All
+    # extensionManager features used below (policyResources, resources,
+    # translation.includeAll, retry, failOpen) are present in v1.7.4.
+    version: v1.7.4
     repo: oci://docker.io/envoyproxy
     valuesInline:
       config:

--- a/config/tools/envoy-gateway/kustomization.yaml
+++ b/config/tools/envoy-gateway/kustomization.yaml
@@ -5,7 +5,14 @@ helmCharts:
     includeCRDs: true
     namespace: envoy-gateway-system
     releaseName: envoy-gateway
-    version: v1.8.1
+    # Rolled back from v1.8.1 to v1.7.4: EG v1.8.0 (PR #8703) reworked OIDC into a
+    # listener-level "dumb" oauth2 filter. When a SecurityPolicy's OIDC clientSecret
+    # is missing, v1.8.x emits a config-less envoy.filters.http.oauth2 at listener
+    # scope, which Envoy rejects ("config must be present for global config"),
+    # rejecting the WHOLE listener snapshot for every tenant on the shared gateway.
+    # v1.7.4 (last pre-redesign release) fails safe: it omits the oauth2 filter for
+    # the broken route and returns a per-route 500 direct response instead.
+    version: v1.7.4
     repo: oci://docker.io/envoyproxy
     valuesInline:
       config:


### PR DESCRIPTION
## What

Pins the Envoy Gateway control plane (both the management cluster and the downstream `datum-downstream-gateway` charts) from **v1.8.1 → v1.7.4**.

## Why

On v1.8.x, a single tenant's misconfigured OIDC `SecurityPolicy` takes down end-user traffic for **every** tenant on the shared downstream gateway.

- A tenant's OIDC `SecurityPolicy` references a `clientSecret` that doesn't exist on the edge.
- EG v1.8.0 reworked OIDC into a **listener-level** `envoy.filters.http.oauth2` filter ([envoyproxy/gateway#8703](https://github.com/envoyproxy/gateway/pull/8703)). With the secret missing, EG ships that filter **config-less**.
- Envoy rejects it with `config must be present for global config`. Because listener updates are atomic, the **entire** listener snapshot (tcp-80/tcp-443/udp-443) is rejected — so every freshly-rolled proxy pod comes up serving **nothing**.

Observed live on `us-central-1-alice`: proxy pods passing readiness but carrying **0 active filter chains**; WAF/Connector injection from the extension server was healthy and unrelated.

v1.7.4 is the last release before the redesign. It **fails safe**: a missing OIDC secret omits the oauth2 filter for that one route and returns a per-route 500, leaving every other tenant unaffected (verified in [`internal/xds/translator/oidc.go@v1.7.4`](https://github.com/envoyproxy/gateway/blob/v1.7.4/internal/xds/translator/oidc.go) — the filter is only attached when `routeContainsOIDC` is true, with a fully-populated config).

## Safety

- All `extensionManager` features the NSO extension server depends on (`policyResources`, `resources`, `translation.includeAll`, `retry`, `failOpen`, `XDSNameSchemeV2`) are present in v1.7.4.
- `kustomize build --enable-helm` verified for both `config/tools/envoy-gateway` and `config/tools/envoy-gateway-downstream`; extensionManager config renders unchanged.
- Build dependency (`go.mod` EG v1.8.1) is intentionally left as-is — the ext-server gRPC extension protocol is stable across v1.5–v1.8, so a v1.8-built ext-server interoperates with a v1.7.4 control plane. Reverting the whole Go dependency set is out of scope.

## Note for reviewers / rollout

The control-plane chart uses `includeCRDs: true`, so this re-applies Gateway API **v1.4.1** CRDs (v1.8.1 shipped v1.5). Apply server-side; existing CRDs are updated in place, not deleted. NSO's generated CRDs target gateway-api v1.5 — confirm no v1.5-only fields are in use before rollout.

Follow-up: this is an upstream EG robustness gap (Invalid OIDC policy still poisons the shared snapshot); track re-upgrade once fixed upstream, and consider gating Invalid SecurityPolicies out of the shared gateway.