### PR TITLE
fix: AI Edge cert/hostname provisioning broken after v0.22.0 upgrade

### DIFF
--- a/internal/webhook/server.go
+++ b/internal/webhook/server.go
@@ -24,16 +24,6 @@ func (s *clusterAwareWebhookServer) Register(path string, hook http.Handler) {
 		orig := h.Handler
 		h.Handler = admission.HandlerFunc(func(ctx context.Context, req admission.Request) admission.Response {
 			c := clusterFromExtra(req.UserInfo.Extra)
-			if len(c) > 0 {
-				// The cluster names are `<namespace>/<name>` format, but Milo project
-				// discovery resources do not have namespaces and return a cluster name
-				// with a leading `/`.
-				//
-				// In the future, this should be improved to allow the multicluster-provider
-				// discovery mechanism to handle this somehow.
-
-				c = "/" + c
-			}
 			ctx = mccontext.WithCluster(ctx, multicluster.ClusterName(c))
 			return orig.Handle(ctx, req)
 		})


### PR DESCRIPTION
## What broke and why

When we released v0.22.0, we bumped the `go.miloapis.com/milo` library from `v0.7.4` → `v0.28.1`. That library update changed how project clusters are registered internally — they now use the bare project name as the key (e.g. `demo-project-6n41tz`) instead of a slash-prefixed version (`/demo-project-6n41tz`).

Our webhook server had a workaround that manually added a leading `/` to the cluster name before doing a lookup. That workaround was written specifically for the old format. Now that the library was fixed to use the cleaner name format, the workaround makes the lookup wrong — it looks for `/demo-project-6n41tz` but the cluster is registered as `demo-project-6n41tz`, so the webhook rejects every AI Edge (HTTPProxy) create/update with:

```
admission webhook "mgateway-v1.kb.io" denied the request: cluster /demo-project-6n41tz not found
```

This means no Gateway resources can be admitted → no hostname or TLS certificate gets provisioned for any new or existing AI Edge resource.

## Fix

Remove the leading-slash workaround in `internal/webhook/server.go`. The milo library now does the right thing, and the webhook should pass the name through as-is.

## Impact

- All AI Edge (HTTPProxy) resources in staging and prod are affected from the moment v0.22.0 was deployed
- The OOM alerts firing on `milo-apiserver` and `karmada-*` are a downstream effect — the failed webhook causes reconcile retry storms that load those components
- After this fix deploys, existing stale downstream objects will self-heal on re-reconcile

## Root cause commit in milo

https://github.com/datum-cloud/milo/commit/f19b32de47fedc6a88b7cc3e9f191b1b13f32a42