### PR TITLE
fix(gateway): tolerate legacy slash-encoded upstream cluster names

### DIFF
--- a/internal/controller/gateway_controller.go
+++ b/internal/controller/gateway_controller.go
@@ -2111,7 +2111,7 @@ func (r *GatewayReconciler) listGatewaysAttachedByDownstreamHTTPRoute(clusterNam
 							Name:      string(parentRef.Name),
 						},
 					},
-					ClusterName: multicluster.ClusterName(strings.TrimPrefix(strings.ReplaceAll(httpRoute.Labels[downstreamclient.UpstreamOwnerClusterNameLabel], "_", "/"), "cluster-")),
+					ClusterName: multicluster.ClusterName(downstreamclient.UpstreamClusterNameFromLabel(httpRoute.Labels[downstreamclient.UpstreamOwnerClusterNameLabel])),
 				})
 
 			}

--- a/internal/downstreamclient/enqueue_upstream_owner.go
+++ b/internal/downstreamclient/enqueue_upstream_owner.go
@@ -3,7 +3,6 @@ package downstreamclient
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -116,7 +115,7 @@ func (e *enqueueRequestForOwner[object]) getOwnerReconcileRequest(obj metav1.Obj
 					Namespace: labels[UpstreamOwnerNamespaceLabel],
 				},
 			},
-			ClusterName: multicluster.ClusterName(strings.TrimPrefix(strings.ReplaceAll(labels[UpstreamOwnerClusterNameLabel], "_", "/"), "cluster-")),
+			ClusterName: multicluster.ClusterName(UpstreamClusterNameFromLabel(labels[UpstreamOwnerClusterNameLabel])),
 		}
 		result[request] = empty{}
 	}

--- a/internal/downstreamclient/mappednamespace.go
+++ b/internal/downstreamclient/mappednamespace.go
@@ -128,6 +128,20 @@ const (
 	UpstreamOwnerNamespaceLabel   = "meta.datumapis.com/upstream-namespace"
 )
 
+// UpstreamClusterNameFromLabel decodes the upstream cluster name from the value
+// of UpstreamOwnerClusterNameLabel, reversing the encoding applied when the
+// label is written ("cluster-" prefix, slashes encoded as underscores).
+//
+// It also tolerates labels written before the cluster name format changed in
+// #196: those carried a leading slash (e.g. "/project", encoded as
+// "cluster-_project") which decodes to "/project". The multicluster provider
+// now engages clusters under the slash-less name ("project"), so the leading
+// slash is stripped to keep legacy downstream resources resolvable.
+func UpstreamClusterNameFromLabel(value string) string {
+	name := strings.TrimPrefix(strings.ReplaceAll(value, "_", "/"), "cluster-")
+	return strings.TrimPrefix(name, "/")
+}
+
 func (c *mappedNamespaceResourceStrategy) SetControllerReference(ctx context.Context, owner, controlled metav1.Object, opts ...controllerutil.OwnerReferenceOption) error {
 	// TODO(jreese) add owner validation
 

--- a/internal/downstreamclient/upstream_cluster_name_test.go
+++ b/internal/downstreamclient/upstream_cluster_name_test.go
@@ -1,0 +1,40 @@
+package downstreamclient
+
+import "testing"
+
+func TestUpstreamClusterNameFromLabel(t *testing.T) {
+	cases := []struct {
+		name  string
+		label string
+		want  string
+	}{
+		{
+			name:  "modern slash-less name",
+			label: "cluster-my-project-abc123",
+			want:  "my-project-abc123",
+		},
+		{
+			name:  "legacy leading-slash name (pre-#196)",
+			label: "cluster-_my-project-abc123",
+			want:  "my-project-abc123",
+		},
+		{
+			name:  "multi-segment name is preserved",
+			label: "cluster-org_my-project",
+			want:  "org/my-project",
+		},
+		{
+			name:  "empty label",
+			label: "",
+			want:  "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := UpstreamClusterNameFromLabel(tc.label); got != tc.want {
+				t.Errorf("UpstreamClusterNameFromLabel(%q) = %q, want %q", tc.label, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

Gateways across many projects log a constant stream of `cluster /<project> not found` reconcile errors — identical on every replica — and their downstream→upstream events stop propagating (a cert going Ready or a listener becoming Programmed no longer re-reconciles the upstream Gateway).

## Cause

#196 removed the leading slash from project cluster names (the provider now engages clusters as `my-project`, not `/my-project`). But downstream resources created **before** that change still carry the old encoding in the `meta.datumapis.com/upstream-cluster-name` label (`/my-project` → `cluster-_my-project`).

The gateway controller's downstream-resource watches decode that label to rebuild the cluster name. For legacy labels they reconstruct `/my-project`, which no longer matches the engaged key — so every such reconcile fails the cluster lookup, is logged + requeued on all replicas, and the downstream→upstream trigger silently breaks.

## Fix

Route both decode sites through a shared `UpstreamClusterNameFromLabel` helper that strips the legacy leading slash, so resources written under either format resolve to the current cluster key. No data migration: existing resources keep working as-is and naturally re-stamp to the new format as their gateways reconcile.

- `internal/downstreamclient/enqueue_upstream_owner.go` (Gateway + Certificate watches)
- `internal/controller/gateway_controller.go` (HTTPRoute watch)
- unit test covering legacy, modern, multi-segment, and empty inputs

Follow-up to #196.