### PR TITLE
fix(gateway,iroh-dns): tolerate legacy slash-encoded cluster names in remaining decoders

### DIFF
--- a/internal/controller/gateway_resource_replicator_controller.go
+++ b/internal/controller/gateway_resource_replicator_controller.go
@@ -800,7 +800,7 @@ func typedEnqueueDownstreamGVKRequest(gvk schema.GroupVersionKind) mchandler.Typ
 				return nil
 			}
 
-			clusterName := multicluster.ClusterName(strings.TrimPrefix(strings.ReplaceAll(clusterLabel, "_", "/"), "cluster-"))
+			clusterName := multicluster.ClusterName(downstreamclient.UpstreamClusterNameFromLabel(clusterLabel))
 
 			request := GVKRequest{
 				GVK: gvk,

--- a/internal/controller/httpproxy_controller.go
+++ b/internal/controller/httpproxy_controller.go
@@ -632,7 +632,7 @@ func (r *HTTPProxyReconciler) enqueueHTTPProxyForDownstreamCertificate() func(cl
 			if upstreamNs == "" || upstreamName == "" || upstreamCluster == "" {
 				return nil
 			}
-			clusterName := multicluster.ClusterName(strings.TrimPrefix(strings.ReplaceAll(upstreamCluster, "_", "/"), "cluster-"))
+			clusterName := multicluster.ClusterName(downstreamclient.UpstreamClusterNameFromLabel(upstreamCluster))
 			return []mcreconcile.Request{{
 				ClusterName: clusterName,
 				Request:     ctrl.Request{NamespacedName: types.NamespacedName{Namespace: upstreamNs, Name: upstreamName}},

--- a/internal/controller/iroh_dns_controller.go
+++ b/internal/controller/iroh_dns_controller.go
@@ -264,7 +264,11 @@ func encodeIrohClusterLabel(clusterName string) string {
 }
 
 func decodeIrohClusterLabel(label string) string {
-	return strings.TrimPrefix(strings.ReplaceAll(label, "_", "/"), "cluster-")
+	// Tolerate labels written before #196, when cluster names carried a leading
+	// slash (encoded as "_"): strip it so the result matches the slash-less name
+	// the provider now engages. Mirrors downstreamclient.UpstreamClusterNameFromLabel.
+	name := strings.TrimPrefix(strings.ReplaceAll(label, "_", "/"), "cluster-")
+	return strings.TrimPrefix(name, "/")
 }
 
 func connectorEndpointZ32(connector *networkingv1alpha1.Connector) (string, error) {

--- a/internal/controller/iroh_dns_controller_test.go
+++ b/internal/controller/iroh_dns_controller_test.go
@@ -202,18 +202,24 @@ func TestBuildDesiredRecordSet_RecordContents(t *testing.T) {
 }
 
 func TestEncodeDecodeIrohClusterLabel(t *testing.T) {
-	tests := []string{
-		"",
-		"/test-project-staging",
-		"/zachs-project-z5pegw",
-		"plain-no-slashes",
-		"/with/multiple/slashes",
-	}
-	for _, want := range tests {
-		t.Run(want, func(t *testing.T) {
-			got := decodeIrohClusterLabel(encodeIrohClusterLabel(want))
-			if got != want {
+	// Modern (slash-less) cluster names round-trip exactly.
+	for _, want := range []string{"", "test-project-staging", "zachs-project-z5pegw", "plain-no-slashes"} {
+		t.Run("roundtrip/"+want, func(t *testing.T) {
+			if got := decodeIrohClusterLabel(encodeIrohClusterLabel(want)); got != want {
 				t.Errorf("round-trip mismatch: encode(%q) -> decode = %q", want, got)
+			}
+		})
+	}
+
+	// Labels written before #196 carried a leading slash; decode strips it so
+	// they resolve to the slash-less name the provider now engages.
+	for label, want := range map[string]string{
+		"cluster-_test-project-staging": "test-project-staging",
+		"cluster-_zachs-project-z5pegw": "zachs-project-z5pegw",
+	} {
+		t.Run("legacy/"+label, func(t *testing.T) {
+			if got := decodeIrohClusterLabel(label); got != want {
+				t.Errorf("decodeIrohClusterLabel(%q) = %q, want %q", label, got, want)
 			}
 		})
 	}

--- a/internal/controller/trafficprotectionpolicy_controller.go
+++ b/internal/controller/trafficprotectionpolicy_controller.go
@@ -1337,7 +1337,7 @@ func (r *TrafficProtectionPolicyReconciler) enqueuePoliciesForCertificate() hand
 		// cluster via mcsingle.Get (which requires clusterName == "single").
 		// The label value is "cluster-<name>" with "/" replaced by "_".
 		clusterLabel := downstreamNamespace.Labels[downstreamclient.UpstreamOwnerClusterNameLabel]
-		upstreamClusterName := multicluster.ClusterName(strings.TrimPrefix(strings.ReplaceAll(clusterLabel, "_", "/"), "cluster-"))
+		upstreamClusterName := multicluster.ClusterName(downstreamclient.UpstreamClusterNameFromLabel(clusterLabel))
 
 		logger.Info("certificate became ready, enqueueing reconcile", "certificate", cert.GetName(), "upstreamNamespace", upstreamNamespace)
 


### PR DESCRIPTION
## Problem

Follow-up to #199. That PR fixed two of the spots that decode the `meta.datumapis.com/upstream-cluster-name` label back into a cluster name, but the same legacy slash-encoded labels (`cluster-_<project>`, written before #196) are decoded in **four more** places. Each still rebuilds `/<project>`, which no longer matches the slash-less name the provider engages — so reconciles for pre-#196 resources keep failing the cluster lookup and logging `cluster /<project> not found` on every replica, and their downstream→upstream event propagation stays broken.

## Fix

Route the remaining decoders through the shared `UpstreamClusterNameFromLabel` helper (added in #199), and strip the legacy leading slash in the iroh-dns controller's own `decodeIrohClusterLabel`:

- `gateway_resource_replicator_controller.go` (replicator enqueue)
- `httpproxy_controller.go` (downstream Gateway watch)
- `trafficprotectionpolicy_controller.go` (certificate-ready enqueue)
- `iroh_dns_controller.go` (`decodeIrohClusterLabel`) + round-trip test updated for the slash-less canonical form

No data migration — existing resources keep resolving and re-stamp to the new label format on their next reconcile.

Follow-up to #199 / #196.