### PR TITLE
ci(publish): publish kustomize bundle only after the image build

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -23,6 +23,9 @@ jobs:
     secrets: inherit
 
   publish-kustomize-bundles:
+    # The bundle pins image references to this build, so only publish it once
+    # the container image has been built and pushed.
+    needs: publish-container-image
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
## Problem

In `publish.yaml`, `publish-kustomize-bundles` and `publish-container-image` run in parallel. The bundle pins its image references to the build's tag, so publishing it before — or without — the image completing can yield a bundle that points at an image that doesn't exist yet.

## Fix

Add `needs: publish-container-image` to the bundle job so the kustomize bundle is published only after the container image has been built and pushed (and is skipped if the image build fails).