### PR TITLE
fix(httpproxy): keep offline connector backendRef in extension-server mode

### DIFF
--- a/internal/controller/httpproxy_controller.go
+++ b/internal/controller/httpproxy_controller.go
@@ -799,7 +799,23 @@ func (r *HTTPProxyReconciler) collectDesiredResources(
 		}
 
 		for backendIndex, backend := range rule.Backends {
-			if backend.Connector != nil {
+			// Offline-connector handling differs by emission mode:
+			//
+			//   * EPP mode (legacy): emit a backend-less route rule. EG translates
+			//     it into a virtual_host, and the connector EPP
+			//     (buildConnectorOfflineEnvoyPatches) inserts the direct_response 503
+			//     "Tunnel not online" CONNECT route at the front.
+			//   * Extension-server mode: the ext-server keys its offline-503 handling
+			//     on the presence of a connector *cluster*, which EG only emits when
+			//     the route rule carries a backendRef. So we must NOT null the
+			//     backendRef here — fall through and emit the same connector.local
+			//     placeholder EndpointSlice + backendRef as the online case. The
+			//     ext-server then sees the cluster, classifies the connector offline
+			//     from the replicated Connector Ready condition, and inserts the 503
+			//     route itself. Nulling the backendRef leaves EG with a backend-less
+			//     route, which it renders as a bare direct_response 500 (no offline
+			//     page) — the regression this guards against.
+			if backend.Connector != nil && r.Config.Gateway.IsEPPEmissionEnabled() {
 				ready, err := connectorReady(ctx, cl, httpProxy.Namespace, backend.Connector.Name)
 				if err != nil {
 					return nil, err

--- a/internal/controller/httpproxy_controller_test.go
+++ b/internal/controller/httpproxy_controller_test.go
@@ -553,6 +553,11 @@ func TestHTTPProxyReconcile(t *testing.T) {
 			Name: "connector-1",
 		}
 	})
+	connectorModeBHTTPProxy := newHTTPProxy(func(h *networkingv1alpha.HTTPProxy) {
+		h.Spec.Rules[0].Backends[0].Connector = &networkingv1alpha.ConnectorReference{
+			Name: "connector-1",
+		}
+	})
 
 	connectorDownstreamObjects := func(proxy *networkingv1alpha.HTTPProxy) []client.Object {
 		return []client.Object{
@@ -571,6 +576,7 @@ func TestHTTPProxyReconcile(t *testing.T) {
 		existingObjects         []client.Object
 		downstreamObjects       []client.Object
 		namespaceUID            string
+		eppEmissionDisabled     bool
 		postCreateGatewayStatus func(*gatewayv1.Gateway)
 		expectedError           bool
 		expectedConditions      []metav1.Condition
@@ -777,6 +783,82 @@ func TestHTTPProxyReconcile(t *testing.T) {
 					for _, filter := range httpRoute.Spec.Rules[0].Filters {
 						assert.NotEqual(t, gatewayv1.HTTPRouteFilterExtensionRef, filter.Type,
 							"offline connector route must not have an ExtensionRef filter")
+					}
+				}
+			},
+		},
+		{
+			// Regression: in extension-server mode (EPP emission disabled) an
+			// offline connector must keep its backendRef so EG renders a connector
+			// cluster. The ext-server keys its offline-503 "Tunnel not online" route
+			// on that cluster. Nulling the backendRef (the EPP-mode behavior) leaves
+			// EG with a backend-less route, which it renders as a bare
+			// direct_response 500 with no offline page.
+			name:                "offline connector keeps backendRef in extension-server mode",
+			httpProxy:           connectorModeBHTTPProxy,
+			downstreamObjects:   connectorDownstreamObjects(connectorModeBHTTPProxy),
+			namespaceUID:        string(connectorNamespaceUID),
+			eppEmissionDisabled: true,
+			existingObjects: []client.Object{
+				&networkingv1alpha1.Connector{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "connector-1",
+						Namespace: "test",
+					},
+					Status: networkingv1alpha1.ConnectorStatus{
+						Conditions: []metav1.Condition{
+							{
+								Type:   networkingv1alpha1.ConnectorConditionReady,
+								Status: metav1.ConditionFalse,
+								Reason: networkingv1alpha1.ConnectorReasonNotReady,
+							},
+						},
+					},
+				},
+			},
+			postCreateGatewayStatus: func(g *gatewayv1.Gateway) {
+				setGatewayProgrammedWithDefaultHTTPSListener(g)
+			},
+			expectedError: false,
+			expectedConditions: []metav1.Condition{
+				{
+					Type:   networkingv1alpha.HTTPProxyConditionAccepted,
+					Status: metav1.ConditionTrue,
+					Reason: networkingv1alpha.HTTPProxyReasonAccepted,
+				},
+				{
+					Type:   networkingv1alpha.HTTPProxyConditionProgrammed,
+					Status: metav1.ConditionTrue,
+					Reason: networkingv1alpha.HTTPProxyReasonProgrammed,
+				},
+			},
+			assert: func(t *testContext, cl client.Client, httpProxy *networkingv1alpha.HTTPProxy) {
+				ctx := context.Background()
+
+				// Extension-server mode emits no EnvoyPatchPolicy at all.
+				var patchList envoygatewayv1alpha1.EnvoyPatchPolicyList
+				assert.NoError(t, t.downstreamClient.List(ctx, &patchList))
+				assert.Empty(t, patchList.Items, "no EPP should be emitted in extension-server mode")
+
+				// The offline connector route MUST retain a backendRef pointing at
+				// the placeholder EndpointSlice so EG renders a connector cluster.
+				httpRoute := &gatewayv1.HTTPRoute{}
+				assert.NoError(t, cl.Get(ctx, client.ObjectKeyFromObject(httpProxy), httpRoute))
+				if assert.Len(t, httpRoute.Spec.Rules, 1) {
+					if assert.Len(t, httpRoute.Spec.Rules[0].BackendRefs, 1,
+						"offline connector route must keep a backendRef in extension-server mode") {
+						br := httpRoute.Spec.Rules[0].BackendRefs[0]
+						assert.Equal(t, gatewayv1.Kind("EndpointSlice"), *br.Kind)
+					}
+				}
+
+				// The connector.local placeholder EndpointSlice must exist.
+				var sliceList discoveryv1.EndpointSliceList
+				assert.NoError(t, cl.List(ctx, &sliceList, client.InNamespace(httpProxy.Namespace)))
+				if assert.Len(t, sliceList.Items, 1) {
+					if assert.NotEmpty(t, sliceList.Items[0].Endpoints) &&
+						assert.NotEmpty(t, sliceList.Items[0].Endpoints[0].Addresses) {
+						assert.Equal(t, "connector.local", sliceList.Items[0].Endpoints[0].Addresses[0])
 					}
 				}
 			},
@@ -1278,15 +1360,20 @@ func TestHTTPProxyReconcile(t *testing.T) {
 
 			mgr := &fakeMockManager{cl: fakeClient}
 
+			caseConfig := testConfig
+			if tt.eppEmissionDisabled {
+				caseConfig.Gateway.EPPEmissionEnabled = ptr.To(false)
+			}
+
 			reconciler := &HTTPProxyReconciler{
 				mgr:               mgr,
-				Config:            testConfig,
+				Config:            caseConfig,
 				DownstreamCluster: &fakeCluster{cl: fakeDownstreamClient},
 			}
 
 			gatewayReconciler := &GatewayReconciler{
 				mgr:               mgr,
-				Config:            testConfig,
+				Config:            caseConfig,
 				DownstreamCluster: &fakeCluster{cl: fakeDownstreamClient},
 			}
 


### PR DESCRIPTION
## Problem

An **offline connector** backing an HTTPProxy serves a **bare HTTP 500 with an empty body** instead of the **"Tunnel not online" 503** page the legacy EnvoyPatchPolicy (EPP) approach used to serve.

Confirmed live:
- Public prod proxy `tear-backing-9r3fd.datumproxy.net` → `HTTP 500`, empty body. Its connector `datum-connect-mhxj5` is `Ready=False / ConnectorNotReady` ("Connector lease has expired. Agent may be offline.").
- On the staging data plane the offline vhost's only route is `direct_response: { status: 500 }` — **no** `connect_matcher`, **no** 503, **no** connector cluster.

## Root cause

When a connector is not `Ready`, `collectDesiredResources` emitted the route rule with `BackendRefs: nil`.

- **EPP mode (legacy):** correct — EG translates the backend-less rule into a virtual_host and `buildConnectorOfflineEnvoyPatches` inserts the `direct_response` 503 CONNECT route.
- **Extension-server mode** (`eppEmissionEnabled: false`, now the default on staging and prod): the ext-server keys its offline handling on the presence of a connector **cluster**, which EG only emits when the route rule carries a `backendRef`. With a null backendRef, EG produces no cluster, the ext-server's offline map stays empty (`ApplyConnectorRoutes` finds nothing to key on), and EG renders the backend-less route as a bare `direct_response 500`.

The ext-server's offline branch itself works — on staging it fires (`clusters_offline` / `vhosts_connector_applied` > 0) **once a cluster is present**. It classifies online/offline purely from the replicated `Connector` `Ready` condition (`internal/extensionserver/cache/index.go`), ignoring stale `connectionDetails`. The only missing ingredient is the cluster.

## Fix

Only take the null-backendRef path when **EPP emission is enabled**. In extension-server mode an offline connector now falls through to the same `connector.local` placeholder EndpointSlice + backendRef as an online connector. EG renders a connector cluster, and the ext-server inserts the 503 "Tunnel not online" route itself.

This also decouples NSO routing from connector readiness in Mode B — NSO emits a stable backendRef regardless of connector state, and the ext-server owns the online/offline decision on every translation.

## Test

Adds a Mode-B (`eppEmissionDisabled: true`) reconcile case asserting the offline connector route keeps its backendRef + placeholder EndpointSlice and that **no EPP is emitted**. The existing EPP-mode offline test (default config) is unchanged and still asserts the empty-backendRef + EPP behavior.

```
go test ./internal/controller/... ./internal/extensionserver/... -count=1   # ok
go vet ./internal/controller/...                                            # ok
```

## Notes / follow-ups

- This restores the offline page; the **online** connector promotion path (cluster → CONNECT/internal-upstream tunnel) is still unverified end-to-end on a live data plane (no fully-online connector with valid `connectionDetails` was available to exercise it) — tracked separately.
- The EG re-translation trigger gap (status-only connector transitions not re-running translation) is a separate known issue and out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)