### PR TITLE
chore: add last transition resource metrics

### DIFF
--- a/config/resource-metrics/httpproxies.yaml
+++ b/config/resource-metrics/httpproxies.yaml
@@ -52,6 +52,17 @@ spec:
               reason: [reason]
               status: [status]
             valueFrom: [status]
+      - name: "status_condition_last_transition_time"
+        help: "last transition time for status conditions"
+        each:
+          type: Gauge
+          gauge:
+            path: [status, conditions]
+            labelsFromPath:
+              type: [type]
+              reason: [reason]
+              status: [status]
+            valueFrom: [lastTransitionTime]
       - name: "custom_hostname"
         help: "Custom hostname defined on the proxy"
         errorLogV: 10

--- a/config/resource-metrics/networks.yaml
+++ b/config/resource-metrics/networks.yaml
@@ -40,3 +40,14 @@ spec:
                 reason: [reason]
                 status: [status]
               valueFrom: [status]
+        - name: "status_condition_last_transition_time"
+          help: "last transition time for status conditions"
+          each:
+            type: Gauge
+            gauge:
+              path: [status, conditions]
+              labelsFromPath:
+                type: [type]
+                reason: [reason]
+                status: [status]
+              valueFrom: [lastTransitionTime]

--- a/config/resource-metrics/subnet-claims.yaml
+++ b/config/resource-metrics/subnet-claims.yaml
@@ -45,3 +45,14 @@ spec:
                 reason: [reason]
                 status: [status]
               valueFrom: [status]
+        - name: "status_condition_last_transition_time"
+          help: "last transition time for status conditions"
+          each:
+            type: Gauge
+            gauge:
+              path: [status, conditions]
+              labelsFromPath:
+                type: [type]
+                reason: [reason]
+                status: [status]
+              valueFrom: [lastTransitionTime]

--- a/config/resource-metrics/subnets.yaml
+++ b/config/resource-metrics/subnets.yaml
@@ -42,3 +42,14 @@ spec:
                 reason: [reason]
                 status: [status]
               valueFrom: [status]
+        - name: "status_condition_last_transition_time"
+          help: "last transition time for status conditions"
+          each:
+            type: Gauge
+            gauge:
+              path: [status, conditions]
+              labelsFromPath:
+                type: [type]
+                reason: [reason]
+                status: [status]
+              valueFrom: [lastTransitionTime]


### PR DESCRIPTION
This is a port of https://github.com/datum-cloud/network-services-operator/pull/203 to resource state metrics.

I've discovered that NSO ResourceMetricsPolicies are currently not registered in the metrics controller. Porting the metrics to CustomResourceStateMetrics to get them flowing into the dashboard. 