### PR TITLE
test(e2e): fix flaky CA-secret race in gateway-accepted

### DIFF
--- a/test/e2e/gateway/chainsaw-test.yaml
+++ b/test/e2e/gateway/chainsaw-test.yaml
@@ -56,6 +56,22 @@ spec:
                 ca:
                   secretName: ($clusterIssuerName)
 
+        # Wait for cert-manager to issue the CA before the script copies its
+        # secret. Without this, the copy races issuance and intermittently fails
+        # with "secrets <name> not found / no objects passed to apply".
+        - assert:
+            cluster: nso-infra
+            resource:
+              apiVersion: cert-manager.io/v1
+              kind: Certificate
+              metadata:
+                name: (join('-', [$clusterIssuerName, 'ca']))
+                namespace: cert-manager
+              status:
+                conditions:
+                  - type: Ready
+                    status: "True"
+
         - script:
             # skipCommandOutput: true
             # skipLogOutput: true


### PR DESCRIPTION
## What

Fixes a flaky failure in the `gateway-accepted` chainsaw e2e test.

## Why

The `Create CA` step creates a cert-manager CA `Certificate` and then immediately runs a script that copies the resulting secret into `envoy-gateway-system` — with no wait in between. cert-manager has to issue the self-signed CA and write the secret first; on a slow runner the copy runs too early and fails:

```
Error from server (NotFound): secrets "e2e-chainsaw-..." not found
error: no objects passed to apply
```

→ `exit status 1` → the suite fails. Confirmed flaky: the same branch produced both passing and failing runs on identical code.

## Fix

Add an `assert` that the CA `Certificate` is `Ready` before the copy script (cert-manager writes the secret before marking the cert Ready), making the step deterministic.

## Notes

- Test-infra only; no product code change.
- Surfaced while investigating an e2e failure on #213 (docs-only), which this race had nothing to do with.

🤖 Generated with [Claude Code](https://claude.com/claude-code)