### PR TITLE
fix: show newly created networking resources in the activity feed

### DIFF
--- a/config/milo/activity/policies/backendtlspolicy-policy.yaml
+++ b/config/milo/activity/policies/backendtlspolicy-policy.yaml
@@ -17,7 +17,7 @@ spec:
     # BackendTLSPolicy creation with spec available
     - name: create
       match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && has(audit.requestObject.spec)"
-      summary: "{{ actor }} created backend TLS policy {{ link(audit.objectRef.name, audit.objectRef) }}"
+      summary: "{{ actor }} created backend TLS policy {{ link(audit.responseObject.metadata.name, audit.objectRef) }}"
 
     # BackendTLSPolicy creation fallback (no spec)
     - name: create-fallback

--- a/config/milo/activity/policies/connector-policy.yaml
+++ b/config/milo/activity/policies/connector-policy.yaml
@@ -17,7 +17,7 @@ spec:
     # Connector creation with spec available
     - name: create
       match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && has(audit.requestObject.spec)"
-      summary: "{{ actor }} created connector {{ link(audit.objectRef.name, audit.objectRef) }}"
+      summary: "{{ actor }} created connector {{ link(audit.responseObject.metadata.name, audit.objectRef) }}"
 
     # Connector creation fallback (no spec)
     - name: create-fallback

--- a/config/milo/activity/policies/connectoradvertisement-policy.yaml
+++ b/config/milo/activity/policies/connectoradvertisement-policy.yaml
@@ -18,7 +18,7 @@ spec:
     # ConnectorAdvertisement creation with spec available
     - name: create
       match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && has(audit.requestObject.spec)"
-      summary: "{{ actor }} created connector advertisement {{ link(audit.objectRef.name, audit.objectRef) }}"
+      summary: "{{ actor }} created connector advertisement {{ link(audit.responseObject.metadata.name, audit.objectRef) }}"
 
     # ConnectorAdvertisement creation fallback (no spec)
     - name: create-fallback

--- a/config/milo/activity/policies/domain-policy.yaml
+++ b/config/milo/activity/policies/domain-policy.yaml
@@ -18,7 +18,7 @@ spec:
     # Domain creation with spec.domainName available - use domain name as display text
     - name: create
       match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && has(audit.requestObject.spec)"
-      summary: "{{ actor }} created domain {{ link(audit.requestObject.spec.domainName, audit.objectRef) }}"
+      summary: "{{ actor }} created domain {{ link(audit.responseObject.spec.domainName, audit.objectRef) }}"
 
     # Domain creation fallback (no spec)
     - name: create-fallback
@@ -38,7 +38,7 @@ spec:
     # Domain update with spec available - excludes status subresource
     - name: update
       match: "!audit.user.username.startsWith('system:') && audit.verb in ['update', 'patch'] && !has(audit.objectRef.subresource) && has(audit.requestObject.spec)"
-      summary: "{{ actor }} updated domain {{ link(audit.requestObject.spec.domainName, audit.objectRef) }}"
+      summary: "{{ actor }} updated domain {{ link(audit.responseObject.spec.domainName, audit.objectRef) }}"
 
     # Domain update fallback (no spec)
     - name: update-fallback

--- a/config/milo/activity/policies/gateway-policy.yaml
+++ b/config/milo/activity/policies/gateway-policy.yaml
@@ -17,7 +17,7 @@ spec:
     # Gateway creation with spec available
     - name: create
       match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && has(audit.requestObject.spec)"
-      summary: "{{ actor }} created gateway {{ link(audit.objectRef.name, audit.objectRef) }}"
+      summary: "{{ actor }} created gateway {{ link(audit.responseObject.metadata.name, audit.objectRef) }}"
 
     # Gateway creation fallback (no spec)
     - name: create-fallback

--- a/config/milo/activity/policies/trafficprotectionpolicy-policy.yaml
+++ b/config/milo/activity/policies/trafficprotectionpolicy-policy.yaml
@@ -17,7 +17,7 @@ spec:
     # TrafficProtectionPolicy creation with spec available
     - name: create
       match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && has(audit.requestObject.spec)"
-      summary: "{{ actor }} created traffic protection policy {{ link(audit.objectRef.name, audit.objectRef) }}"
+      summary: "{{ actor }} created traffic protection policy {{ link(audit.responseObject.metadata.name, audit.objectRef) }}"
 
     # TrafficProtectionPolicy creation fallback (no spec)
     - name: create-fallback


### PR DESCRIPTION
## What this does

When you create a networking resource — a Connector, Gateway, Domain, and a few others — it should show up in your activity feed with its name. For resources whose name is assigned automatically at creation, that entry was quietly going missing. This makes those create events show up reliably.

## What changed

- Create summaries now use the resource's assigned name, so they always show up.
- Domain summaries read the domain name from the saved record (where it always lives), matching how deletes already work.
- Updates and deletes are untouched — they were already fine.

Connectors are the one we saw slipping through in production; the rest get the same small fix proactively so they don't hit it later.

Fixes #222

