### PR TITLE
fix: gate ActivityPolicy create/update audit rules on 2xx outcome

### DIFF
--- a/config/milo/activity/policies/backendtlspolicy-policy.yaml
+++ b/config/milo/activity/policies/backendtlspolicy-policy.yaml
@@ -16,12 +16,12 @@ spec:
   auditRules:
     # BackendTLSPolicy creation with spec available
     - name: create
-      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && has(audit.requestObject.spec)"
+      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && has(audit.requestObject.spec) && audit.responseStatus.code >= 200 && audit.responseStatus.code < 300"
       summary: "{{ actor }} created backend TLS policy {{ link(audit.responseObject.metadata.name, audit.objectRef) }}"
 
     # BackendTLSPolicy creation fallback (no spec)
     - name: create-fallback
-      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create'"
+      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && audit.responseStatus.code >= 200 && audit.responseStatus.code < 300"
       summary: "{{ actor }} created {{ link('a backend TLS policy', audit.objectRef) }}"
 
     # BackendTLSPolicy deletion with responseObject.spec available (response contains the deleted resource)

--- a/config/milo/activity/policies/backendtlspolicy-policy.yaml
+++ b/config/milo/activity/policies/backendtlspolicy-policy.yaml
@@ -14,10 +14,13 @@ spec:
     kind: BackendTLSPolicy
 
   auditRules:
-    # BackendTLSPolicy creation with spec available
+    # BackendTLSPolicy creation with spec available.
+    # Rejected creates return a Status responseObject (no metadata.name); for
+    # generateName creates objectRef.name is also empty, so fall back to
+    # responseObject.details.name. has() is guarded per level.
     - name: create
       match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && has(audit.requestObject.spec)"
-      summary: "{{ actor }} created backend TLS policy {{ has(audit.responseObject.metadata.name) ? link(audit.responseObject.metadata.name, audit.objectRef) : link(audit.objectRef.name, audit.objectRef) }}"
+      summary: "{{ actor }} created backend TLS policy {{ has(audit.responseObject.metadata.name) ? link(audit.responseObject.metadata.name, audit.objectRef) : has(audit.objectRef.name) ? link(audit.objectRef.name, audit.objectRef) : (has(audit.responseObject.details) && has(audit.responseObject.details.name)) ? link(audit.responseObject.details.name, audit.objectRef) : link('a backend TLS policy', audit.objectRef) }}"
 
     # BackendTLSPolicy creation fallback (no spec)
     - name: create-fallback

--- a/config/milo/activity/policies/backendtlspolicy-policy.yaml
+++ b/config/milo/activity/policies/backendtlspolicy-policy.yaml
@@ -14,17 +14,14 @@ spec:
     kind: BackendTLSPolicy
 
   auditRules:
-    # BackendTLSPolicy creation with spec available.
-    # Rejected creates return a Status responseObject (no metadata.name); for
-    # generateName creates objectRef.name is also empty, so fall back to
-    # responseObject.details.name. has() is guarded per level.
+    # BackendTLSPolicy creation with spec available
     - name: create
-      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && has(audit.requestObject.spec)"
-      summary: "{{ actor }} created backend TLS policy {{ has(audit.responseObject.metadata.name) ? link(audit.responseObject.metadata.name, audit.objectRef) : has(audit.objectRef.name) ? link(audit.objectRef.name, audit.objectRef) : (has(audit.responseObject.details) && has(audit.responseObject.details.name)) ? link(audit.responseObject.details.name, audit.objectRef) : link('a backend TLS policy', audit.objectRef) }}"
+      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && has(audit.requestObject.spec) && audit.responseStatus.code >= 200 && audit.responseStatus.code < 300"
+      summary: "{{ actor }} created backend TLS policy {{ link(audit.responseObject.metadata.name, audit.objectRef) }}"
 
     # BackendTLSPolicy creation fallback (no spec)
     - name: create-fallback
-      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create'"
+      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && audit.responseStatus.code >= 200 && audit.responseStatus.code < 300"
       summary: "{{ actor }} created {{ link('a backend TLS policy', audit.objectRef) }}"
 
     # BackendTLSPolicy deletion with responseObject.spec available (response contains the deleted resource)
@@ -39,10 +36,10 @@ spec:
 
     # BackendTLSPolicy update with spec available - excludes status subresource
     - name: update
-      match: "!audit.user.username.startsWith('system:') && audit.verb in ['update', 'patch'] && !has(audit.objectRef.subresource) && has(audit.requestObject.spec)"
+      match: "!audit.user.username.startsWith('system:') && audit.verb in ['update', 'patch'] && !has(audit.objectRef.subresource) && has(audit.requestObject.spec) && audit.responseStatus.code >= 200 && audit.responseStatus.code < 300"
       summary: "{{ actor }} updated backend TLS policy {{ link(audit.objectRef.name, audit.objectRef) }}"
 
     # BackendTLSPolicy update fallback (no spec)
     - name: update-fallback
-      match: "!audit.user.username.startsWith('system:') && audit.verb in ['update', 'patch'] && !has(audit.objectRef.subresource)"
+      match: "!audit.user.username.startsWith('system:') && audit.verb in ['update', 'patch'] && !has(audit.objectRef.subresource) && audit.responseStatus.code >= 200 && audit.responseStatus.code < 300"
       summary: "{{ actor }} updated {{ link('a backend TLS policy', audit.objectRef) }}"

--- a/config/milo/activity/policies/backendtlspolicy-policy.yaml
+++ b/config/milo/activity/policies/backendtlspolicy-policy.yaml
@@ -17,7 +17,7 @@ spec:
     # BackendTLSPolicy creation with spec available
     - name: create
       match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && has(audit.requestObject.spec)"
-      summary: "{{ actor }} created backend TLS policy {{ link(audit.responseObject.metadata.name, audit.objectRef) }}"
+      summary: "{{ actor }} created backend TLS policy {{ has(audit.responseObject.metadata.name) ? link(audit.responseObject.metadata.name, audit.objectRef) : link(audit.objectRef.name, audit.objectRef) }}"
 
     # BackendTLSPolicy creation fallback (no spec)
     - name: create-fallback

--- a/config/milo/activity/policies/connector-policy.yaml
+++ b/config/milo/activity/policies/connector-policy.yaml
@@ -17,7 +17,7 @@ spec:
     # Connector creation with spec available
     - name: create
       match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && has(audit.requestObject.spec)"
-      summary: "{{ actor }} created connector {{ link(audit.responseObject.metadata.name, audit.objectRef) }}"
+      summary: "{{ actor }} created connector {{ has(audit.responseObject.metadata.name) ? link(audit.responseObject.metadata.name, audit.objectRef) : link(audit.objectRef.name, audit.objectRef) }}"
 
     # Connector creation fallback (no spec)
     - name: create-fallback

--- a/config/milo/activity/policies/connector-policy.yaml
+++ b/config/milo/activity/policies/connector-policy.yaml
@@ -14,10 +14,15 @@ spec:
     kind: Connector
 
   auditRules:
-    # Connector creation with spec available
+    # Connector creation with spec available.
+    # Clients create Connectors via generateName (e.g. "datum-connect-"). A rejected
+    # create (quota/admission) returns a Status as responseObject with no metadata.name,
+    # and objectRef.name is empty because no name was assigned — so fall back to
+    # responseObject.details.name. has() is guarded per level (nested has errors on a
+    # missing intermediate).
     - name: create
       match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && has(audit.requestObject.spec)"
-      summary: "{{ actor }} created connector {{ has(audit.responseObject.metadata.name) ? link(audit.responseObject.metadata.name, audit.objectRef) : link(audit.objectRef.name, audit.objectRef) }}"
+      summary: "{{ actor }} created connector {{ has(audit.responseObject.metadata.name) ? link(audit.responseObject.metadata.name, audit.objectRef) : has(audit.objectRef.name) ? link(audit.objectRef.name, audit.objectRef) : (has(audit.responseObject.details) && has(audit.responseObject.details.name)) ? link(audit.responseObject.details.name, audit.objectRef) : link('a connector', audit.objectRef) }}"
 
     # Connector creation fallback (no spec)
     - name: create-fallback

--- a/config/milo/activity/policies/connector-policy.yaml
+++ b/config/milo/activity/policies/connector-policy.yaml
@@ -14,19 +14,14 @@ spec:
     kind: Connector
 
   auditRules:
-    # Connector creation with spec available.
-    # Clients create Connectors via generateName (e.g. "datum-connect-"). A rejected
-    # create (quota/admission) returns a Status as responseObject with no metadata.name,
-    # and objectRef.name is empty because no name was assigned — so fall back to
-    # responseObject.details.name. has() is guarded per level (nested has errors on a
-    # missing intermediate).
+    # Connector creation with spec available
     - name: create
-      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && has(audit.requestObject.spec)"
-      summary: "{{ actor }} created connector {{ has(audit.responseObject.metadata.name) ? link(audit.responseObject.metadata.name, audit.objectRef) : has(audit.objectRef.name) ? link(audit.objectRef.name, audit.objectRef) : (has(audit.responseObject.details) && has(audit.responseObject.details.name)) ? link(audit.responseObject.details.name, audit.objectRef) : link('a connector', audit.objectRef) }}"
+      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && has(audit.requestObject.spec) && audit.responseStatus.code >= 200 && audit.responseStatus.code < 300"
+      summary: "{{ actor }} created connector {{ link(audit.responseObject.metadata.name, audit.objectRef) }}"
 
     # Connector creation fallback (no spec)
     - name: create-fallback
-      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create'"
+      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && audit.responseStatus.code >= 200 && audit.responseStatus.code < 300"
       summary: "{{ actor }} created {{ link('a connector', audit.objectRef) }}"
 
     # Connector deletion with responseObject.spec available (response contains the deleted resource)
@@ -41,10 +36,10 @@ spec:
 
     # Connector update with spec available - excludes status subresource
     - name: update
-      match: "!audit.user.username.startsWith('system:') && audit.verb in ['update', 'patch'] && !has(audit.objectRef.subresource) && has(audit.requestObject.spec)"
+      match: "!audit.user.username.startsWith('system:') && audit.verb in ['update', 'patch'] && !has(audit.objectRef.subresource) && has(audit.requestObject.spec) && audit.responseStatus.code >= 200 && audit.responseStatus.code < 300"
       summary: "{{ actor }} updated connector {{ link(audit.objectRef.name, audit.objectRef) }}"
 
     # Connector update fallback (no spec)
     - name: update-fallback
-      match: "!audit.user.username.startsWith('system:') && audit.verb in ['update', 'patch'] && !has(audit.objectRef.subresource)"
+      match: "!audit.user.username.startsWith('system:') && audit.verb in ['update', 'patch'] && !has(audit.objectRef.subresource) && audit.responseStatus.code >= 200 && audit.responseStatus.code < 300"
       summary: "{{ actor }} updated {{ link('a connector', audit.objectRef) }}"

--- a/config/milo/activity/policies/connector-policy.yaml
+++ b/config/milo/activity/policies/connector-policy.yaml
@@ -16,12 +16,12 @@ spec:
   auditRules:
     # Connector creation with spec available
     - name: create
-      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && has(audit.requestObject.spec)"
+      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && has(audit.requestObject.spec) && audit.responseStatus.code >= 200 && audit.responseStatus.code < 300"
       summary: "{{ actor }} created connector {{ link(audit.responseObject.metadata.name, audit.objectRef) }}"
 
     # Connector creation fallback (no spec)
     - name: create-fallback
-      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create'"
+      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && audit.responseStatus.code >= 200 && audit.responseStatus.code < 300"
       summary: "{{ actor }} created {{ link('a connector', audit.objectRef) }}"
 
     # Connector deletion with responseObject.spec available (response contains the deleted resource)

--- a/config/milo/activity/policies/connectoradvertisement-policy.yaml
+++ b/config/milo/activity/policies/connectoradvertisement-policy.yaml
@@ -15,17 +15,14 @@ spec:
     kind: ConnectorAdvertisement
 
   auditRules:
-    # ConnectorAdvertisement creation with spec available.
-    # Like Connector, advertisements may be created via generateName; a rejected create
-    # yields a Status responseObject (no metadata.name) with an empty objectRef.name, so
-    # fall back to responseObject.details.name. has() is guarded per level.
+    # ConnectorAdvertisement creation with spec available
     - name: create
-      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && has(audit.requestObject.spec)"
-      summary: "{{ actor }} created connector advertisement {{ has(audit.responseObject.metadata.name) ? link(audit.responseObject.metadata.name, audit.objectRef) : has(audit.objectRef.name) ? link(audit.objectRef.name, audit.objectRef) : (has(audit.responseObject.details) && has(audit.responseObject.details.name)) ? link(audit.responseObject.details.name, audit.objectRef) : link('a connector advertisement', audit.objectRef) }}"
+      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && has(audit.requestObject.spec) && audit.responseStatus.code >= 200 && audit.responseStatus.code < 300"
+      summary: "{{ actor }} created connector advertisement {{ link(audit.responseObject.metadata.name, audit.objectRef) }}"
 
     # ConnectorAdvertisement creation fallback (no spec)
     - name: create-fallback
-      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create'"
+      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && audit.responseStatus.code >= 200 && audit.responseStatus.code < 300"
       summary: "{{ actor }} created {{ link('a connector advertisement', audit.objectRef) }}"
 
     # ConnectorAdvertisement deletion with responseObject.spec available (response contains the deleted resource)
@@ -40,10 +37,10 @@ spec:
 
     # ConnectorAdvertisement update with spec available - excludes status subresource
     - name: update
-      match: "!audit.user.username.startsWith('system:') && audit.verb in ['update', 'patch'] && !has(audit.objectRef.subresource) && has(audit.requestObject.spec)"
+      match: "!audit.user.username.startsWith('system:') && audit.verb in ['update', 'patch'] && !has(audit.objectRef.subresource) && has(audit.requestObject.spec) && audit.responseStatus.code >= 200 && audit.responseStatus.code < 300"
       summary: "{{ actor }} updated connector advertisement {{ link(audit.objectRef.name, audit.objectRef) }}"
 
     # ConnectorAdvertisement update fallback (no spec)
     - name: update-fallback
-      match: "!audit.user.username.startsWith('system:') && audit.verb in ['update', 'patch'] && !has(audit.objectRef.subresource)"
+      match: "!audit.user.username.startsWith('system:') && audit.verb in ['update', 'patch'] && !has(audit.objectRef.subresource) && audit.responseStatus.code >= 200 && audit.responseStatus.code < 300"
       summary: "{{ actor }} updated {{ link('a connector advertisement', audit.objectRef) }}"

--- a/config/milo/activity/policies/connectoradvertisement-policy.yaml
+++ b/config/milo/activity/policies/connectoradvertisement-policy.yaml
@@ -18,7 +18,7 @@ spec:
     # ConnectorAdvertisement creation with spec available
     - name: create
       match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && has(audit.requestObject.spec)"
-      summary: "{{ actor }} created connector advertisement {{ link(audit.responseObject.metadata.name, audit.objectRef) }}"
+      summary: "{{ actor }} created connector advertisement {{ has(audit.responseObject.metadata.name) ? link(audit.responseObject.metadata.name, audit.objectRef) : link(audit.objectRef.name, audit.objectRef) }}"
 
     # ConnectorAdvertisement creation fallback (no spec)
     - name: create-fallback

--- a/config/milo/activity/policies/connectoradvertisement-policy.yaml
+++ b/config/milo/activity/policies/connectoradvertisement-policy.yaml
@@ -15,10 +15,13 @@ spec:
     kind: ConnectorAdvertisement
 
   auditRules:
-    # ConnectorAdvertisement creation with spec available
+    # ConnectorAdvertisement creation with spec available.
+    # Like Connector, advertisements may be created via generateName; a rejected create
+    # yields a Status responseObject (no metadata.name) with an empty objectRef.name, so
+    # fall back to responseObject.details.name. has() is guarded per level.
     - name: create
       match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && has(audit.requestObject.spec)"
-      summary: "{{ actor }} created connector advertisement {{ has(audit.responseObject.metadata.name) ? link(audit.responseObject.metadata.name, audit.objectRef) : link(audit.objectRef.name, audit.objectRef) }}"
+      summary: "{{ actor }} created connector advertisement {{ has(audit.responseObject.metadata.name) ? link(audit.responseObject.metadata.name, audit.objectRef) : has(audit.objectRef.name) ? link(audit.objectRef.name, audit.objectRef) : (has(audit.responseObject.details) && has(audit.responseObject.details.name)) ? link(audit.responseObject.details.name, audit.objectRef) : link('a connector advertisement', audit.objectRef) }}"
 
     # ConnectorAdvertisement creation fallback (no spec)
     - name: create-fallback

--- a/config/milo/activity/policies/connectoradvertisement-policy.yaml
+++ b/config/milo/activity/policies/connectoradvertisement-policy.yaml
@@ -17,12 +17,12 @@ spec:
   auditRules:
     # ConnectorAdvertisement creation with spec available
     - name: create
-      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && has(audit.requestObject.spec)"
+      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && has(audit.requestObject.spec) && audit.responseStatus.code >= 200 && audit.responseStatus.code < 300"
       summary: "{{ actor }} created connector advertisement {{ link(audit.responseObject.metadata.name, audit.objectRef) }}"
 
     # ConnectorAdvertisement creation fallback (no spec)
     - name: create-fallback
-      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create'"
+      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && audit.responseStatus.code >= 200 && audit.responseStatus.code < 300"
       summary: "{{ actor }} created {{ link('a connector advertisement', audit.objectRef) }}"
 
     # ConnectorAdvertisement deletion with responseObject.spec available (response contains the deleted resource)

--- a/config/milo/activity/policies/domain-policy.yaml
+++ b/config/milo/activity/policies/domain-policy.yaml
@@ -17,12 +17,12 @@ spec:
   auditRules:
     # Domain creation with spec.domainName available - use domain name as display text
     - name: create
-      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && has(audit.requestObject.spec)"
+      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && has(audit.requestObject.spec) && audit.responseStatus.code >= 200 && audit.responseStatus.code < 300"
       summary: "{{ actor }} created domain {{ link(audit.responseObject.spec.domainName, audit.objectRef) }}"
 
     # Domain creation fallback (no spec)
     - name: create-fallback
-      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create'"
+      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && audit.responseStatus.code >= 200 && audit.responseStatus.code < 300"
       summary: "{{ actor }} created {{ link('a domain', audit.objectRef) }}"
 
     # Domain deletion with responseObject.spec available (response contains the deleted resource)

--- a/config/milo/activity/policies/domain-policy.yaml
+++ b/config/milo/activity/policies/domain-policy.yaml
@@ -15,17 +15,14 @@ spec:
     kind: Domain
 
   auditRules:
-    # Domain creation with spec.domainName available - use domain name as display text.
-    # A rejected create returns a Status responseObject (no spec), so has() must guard
-    # the spec level too: nested has(responseObject.spec.domainName) errors when spec is
-    # absent. Fall back to objectRef.name, then responseObject.details.name (generateName).
+    # Domain creation with spec.domainName available - use domain name as display text
     - name: create
-      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && has(audit.requestObject.spec)"
-      summary: "{{ actor }} created domain {{ (has(audit.responseObject.spec) && has(audit.responseObject.spec.domainName)) ? link(audit.responseObject.spec.domainName, audit.objectRef) : has(audit.objectRef.name) ? link(audit.objectRef.name, audit.objectRef) : (has(audit.responseObject.details) && has(audit.responseObject.details.name)) ? link(audit.responseObject.details.name, audit.objectRef) : link('a domain', audit.objectRef) }}"
+      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && has(audit.requestObject.spec) && audit.responseStatus.code >= 200 && audit.responseStatus.code < 300"
+      summary: "{{ actor }} created domain {{ link(audit.responseObject.spec.domainName, audit.objectRef) }}"
 
     # Domain creation fallback (no spec)
     - name: create-fallback
-      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create'"
+      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && audit.responseStatus.code >= 200 && audit.responseStatus.code < 300"
       summary: "{{ actor }} created {{ link('a domain', audit.objectRef) }}"
 
     # Domain deletion with responseObject.spec available (response contains the deleted resource)
@@ -38,13 +35,12 @@ spec:
       match: "!audit.user.username.startsWith('system:') && audit.verb == 'delete'"
       summary: "{{ actor }} deleted a domain"
 
-    # Domain update with spec available - excludes status subresource.
-    # Same Status-response guarding as create: a rejected update has no responseObject.spec.
+    # Domain update with spec available - excludes status subresource
     - name: update
-      match: "!audit.user.username.startsWith('system:') && audit.verb in ['update', 'patch'] && !has(audit.objectRef.subresource) && has(audit.requestObject.spec)"
-      summary: "{{ actor }} updated domain {{ (has(audit.responseObject.spec) && has(audit.responseObject.spec.domainName)) ? link(audit.responseObject.spec.domainName, audit.objectRef) : has(audit.objectRef.name) ? link(audit.objectRef.name, audit.objectRef) : (has(audit.responseObject.details) && has(audit.responseObject.details.name)) ? link(audit.responseObject.details.name, audit.objectRef) : link('a domain', audit.objectRef) }}"
+      match: "!audit.user.username.startsWith('system:') && audit.verb in ['update', 'patch'] && !has(audit.objectRef.subresource) && has(audit.requestObject.spec) && audit.responseStatus.code >= 200 && audit.responseStatus.code < 300"
+      summary: "{{ actor }} updated domain {{ link(audit.responseObject.spec.domainName, audit.objectRef) }}"
 
     # Domain update fallback (no spec)
     - name: update-fallback
-      match: "!audit.user.username.startsWith('system:') && audit.verb in ['update', 'patch'] && !has(audit.objectRef.subresource)"
+      match: "!audit.user.username.startsWith('system:') && audit.verb in ['update', 'patch'] && !has(audit.objectRef.subresource) && audit.responseStatus.code >= 200 && audit.responseStatus.code < 300"
       summary: "{{ actor }} updated {{ link('a domain', audit.objectRef) }}"

--- a/config/milo/activity/policies/domain-policy.yaml
+++ b/config/milo/activity/policies/domain-policy.yaml
@@ -18,7 +18,7 @@ spec:
     # Domain creation with spec.domainName available - use domain name as display text
     - name: create
       match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && has(audit.requestObject.spec)"
-      summary: "{{ actor }} created domain {{ link(audit.responseObject.spec.domainName, audit.objectRef) }}"
+      summary: "{{ actor }} created domain {{ has(audit.responseObject.spec.domainName) ? link(audit.responseObject.spec.domainName, audit.objectRef) : link(audit.objectRef.name, audit.objectRef) }}"
 
     # Domain creation fallback (no spec)
     - name: create-fallback
@@ -38,7 +38,7 @@ spec:
     # Domain update with spec available - excludes status subresource
     - name: update
       match: "!audit.user.username.startsWith('system:') && audit.verb in ['update', 'patch'] && !has(audit.objectRef.subresource) && has(audit.requestObject.spec)"
-      summary: "{{ actor }} updated domain {{ link(audit.responseObject.spec.domainName, audit.objectRef) }}"
+      summary: "{{ actor }} updated domain {{ has(audit.responseObject.spec.domainName) ? link(audit.responseObject.spec.domainName, audit.objectRef) : link(audit.objectRef.name, audit.objectRef) }}"
 
     # Domain update fallback (no spec)
     - name: update-fallback

--- a/config/milo/activity/policies/domain-policy.yaml
+++ b/config/milo/activity/policies/domain-policy.yaml
@@ -15,10 +15,13 @@ spec:
     kind: Domain
 
   auditRules:
-    # Domain creation with spec.domainName available - use domain name as display text
+    # Domain creation with spec.domainName available - use domain name as display text.
+    # A rejected create returns a Status responseObject (no spec), so has() must guard
+    # the spec level too: nested has(responseObject.spec.domainName) errors when spec is
+    # absent. Fall back to objectRef.name, then responseObject.details.name (generateName).
     - name: create
       match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && has(audit.requestObject.spec)"
-      summary: "{{ actor }} created domain {{ has(audit.responseObject.spec.domainName) ? link(audit.responseObject.spec.domainName, audit.objectRef) : link(audit.objectRef.name, audit.objectRef) }}"
+      summary: "{{ actor }} created domain {{ (has(audit.responseObject.spec) && has(audit.responseObject.spec.domainName)) ? link(audit.responseObject.spec.domainName, audit.objectRef) : has(audit.objectRef.name) ? link(audit.objectRef.name, audit.objectRef) : (has(audit.responseObject.details) && has(audit.responseObject.details.name)) ? link(audit.responseObject.details.name, audit.objectRef) : link('a domain', audit.objectRef) }}"
 
     # Domain creation fallback (no spec)
     - name: create-fallback
@@ -35,10 +38,11 @@ spec:
       match: "!audit.user.username.startsWith('system:') && audit.verb == 'delete'"
       summary: "{{ actor }} deleted a domain"
 
-    # Domain update with spec available - excludes status subresource
+    # Domain update with spec available - excludes status subresource.
+    # Same Status-response guarding as create: a rejected update has no responseObject.spec.
     - name: update
       match: "!audit.user.username.startsWith('system:') && audit.verb in ['update', 'patch'] && !has(audit.objectRef.subresource) && has(audit.requestObject.spec)"
-      summary: "{{ actor }} updated domain {{ has(audit.responseObject.spec.domainName) ? link(audit.responseObject.spec.domainName, audit.objectRef) : link(audit.objectRef.name, audit.objectRef) }}"
+      summary: "{{ actor }} updated domain {{ (has(audit.responseObject.spec) && has(audit.responseObject.spec.domainName)) ? link(audit.responseObject.spec.domainName, audit.objectRef) : has(audit.objectRef.name) ? link(audit.objectRef.name, audit.objectRef) : (has(audit.responseObject.details) && has(audit.responseObject.details.name)) ? link(audit.responseObject.details.name, audit.objectRef) : link('a domain', audit.objectRef) }}"
 
     # Domain update fallback (no spec)
     - name: update-fallback

--- a/config/milo/activity/policies/gateway-policy.yaml
+++ b/config/milo/activity/policies/gateway-policy.yaml
@@ -15,11 +15,13 @@ spec:
 
   auditRules:
     # Gateway creation with spec available
-    # responseObject lacks metadata.name when a create is rejected (the apiserver
-    # returns a Status object), so guard the leaf and fall back to objectRef.name.
+    # A rejected create returns a Status object as responseObject (no metadata.name).
+    # For generateName creates rejected before naming, objectRef.name is also empty,
+    # so fall back further to responseObject.details.name (carried on the Status).
+    # has() is guarded at each level: nested has(a.b.c) errors if b is absent.
     - name: create
       match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && has(audit.requestObject.spec)"
-      summary: "{{ actor }} created gateway {{ has(audit.responseObject.metadata.name) ? link(audit.responseObject.metadata.name, audit.objectRef) : link(audit.objectRef.name, audit.objectRef) }}"
+      summary: "{{ actor }} created gateway {{ has(audit.responseObject.metadata.name) ? link(audit.responseObject.metadata.name, audit.objectRef) : has(audit.objectRef.name) ? link(audit.objectRef.name, audit.objectRef) : (has(audit.responseObject.details) && has(audit.responseObject.details.name)) ? link(audit.responseObject.details.name, audit.objectRef) : link('a gateway', audit.objectRef) }}"
 
     # Gateway creation fallback (no spec)
     - name: create-fallback

--- a/config/milo/activity/policies/gateway-policy.yaml
+++ b/config/milo/activity/policies/gateway-policy.yaml
@@ -15,17 +15,13 @@ spec:
 
   auditRules:
     # Gateway creation with spec available
-    # A rejected create returns a Status object as responseObject (no metadata.name).
-    # For generateName creates rejected before naming, objectRef.name is also empty,
-    # so fall back further to responseObject.details.name (carried on the Status).
-    # has() is guarded at each level: nested has(a.b.c) errors if b is absent.
     - name: create
-      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && has(audit.requestObject.spec)"
-      summary: "{{ actor }} created gateway {{ has(audit.responseObject.metadata.name) ? link(audit.responseObject.metadata.name, audit.objectRef) : has(audit.objectRef.name) ? link(audit.objectRef.name, audit.objectRef) : (has(audit.responseObject.details) && has(audit.responseObject.details.name)) ? link(audit.responseObject.details.name, audit.objectRef) : link('a gateway', audit.objectRef) }}"
+      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && has(audit.requestObject.spec) && audit.responseStatus.code >= 200 && audit.responseStatus.code < 300"
+      summary: "{{ actor }} created gateway {{ link(audit.responseObject.metadata.name, audit.objectRef) }}"
 
     # Gateway creation fallback (no spec)
     - name: create-fallback
-      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create'"
+      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && audit.responseStatus.code >= 200 && audit.responseStatus.code < 300"
       summary: "{{ actor }} created {{ link('a gateway', audit.objectRef) }}"
 
     # Gateway deletion with responseObject.spec available (response contains the deleted resource)
@@ -40,10 +36,10 @@ spec:
 
     # Gateway update with spec available - excludes status subresource
     - name: update
-      match: "!audit.user.username.startsWith('system:') && audit.verb in ['update', 'patch'] && !has(audit.objectRef.subresource) && has(audit.requestObject.spec)"
+      match: "!audit.user.username.startsWith('system:') && audit.verb in ['update', 'patch'] && !has(audit.objectRef.subresource) && has(audit.requestObject.spec) && audit.responseStatus.code >= 200 && audit.responseStatus.code < 300"
       summary: "{{ actor }} updated gateway {{ link(audit.objectRef.name, audit.objectRef) }}"
 
     # Gateway update fallback (no spec)
     - name: update-fallback
-      match: "!audit.user.username.startsWith('system:') && audit.verb in ['update', 'patch'] && !has(audit.objectRef.subresource)"
+      match: "!audit.user.username.startsWith('system:') && audit.verb in ['update', 'patch'] && !has(audit.objectRef.subresource) && audit.responseStatus.code >= 200 && audit.responseStatus.code < 300"
       summary: "{{ actor }} updated {{ link('a gateway', audit.objectRef) }}"

--- a/config/milo/activity/policies/gateway-policy.yaml
+++ b/config/milo/activity/policies/gateway-policy.yaml
@@ -16,12 +16,12 @@ spec:
   auditRules:
     # Gateway creation with spec available
     - name: create
-      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && has(audit.requestObject.spec)"
+      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && has(audit.requestObject.spec) && audit.responseStatus.code >= 200 && audit.responseStatus.code < 300"
       summary: "{{ actor }} created gateway {{ link(audit.responseObject.metadata.name, audit.objectRef) }}"
 
     # Gateway creation fallback (no spec)
     - name: create-fallback
-      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create'"
+      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && audit.responseStatus.code >= 200 && audit.responseStatus.code < 300"
       summary: "{{ actor }} created {{ link('a gateway', audit.objectRef) }}"
 
     # Gateway deletion with responseObject.spec available (response contains the deleted resource)

--- a/config/milo/activity/policies/gateway-policy.yaml
+++ b/config/milo/activity/policies/gateway-policy.yaml
@@ -15,9 +15,11 @@ spec:
 
   auditRules:
     # Gateway creation with spec available
+    # responseObject lacks metadata.name when a create is rejected (the apiserver
+    # returns a Status object), so guard the leaf and fall back to objectRef.name.
     - name: create
       match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && has(audit.requestObject.spec)"
-      summary: "{{ actor }} created gateway {{ link(audit.responseObject.metadata.name, audit.objectRef) }}"
+      summary: "{{ actor }} created gateway {{ has(audit.responseObject.metadata.name) ? link(audit.responseObject.metadata.name, audit.objectRef) : link(audit.objectRef.name, audit.objectRef) }}"
 
     # Gateway creation fallback (no spec)
     - name: create-fallback

--- a/config/milo/activity/policies/httpproxy-policy.yaml
+++ b/config/milo/activity/policies/httpproxy-policy.yaml
@@ -17,12 +17,12 @@ spec:
   auditRules:
     # HTTPProxy creation with spec.hostnames available - use first hostname as display text
     - name: create
-      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && has(audit.requestObject.spec) && has(audit.requestObject.spec.hostnames) && size(audit.requestObject.spec.hostnames) > 0"
+      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && has(audit.requestObject.spec) && has(audit.requestObject.spec.hostnames) && size(audit.requestObject.spec.hostnames) > 0 && audit.responseStatus.code >= 200 && audit.responseStatus.code < 300"
       summary: "{{ actor }} created HTTP proxy {{ link(string(audit.requestObject.spec.hostnames[0]), audit.objectRef) }}"
 
     # HTTPProxy creation fallback (no spec or no hostnames)
     - name: create-fallback
-      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create'"
+      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && audit.responseStatus.code >= 200 && audit.responseStatus.code < 300"
       summary: "{{ actor }} created {{ link('an HTTP proxy', audit.objectRef) }}"
 
     # HTTPProxy deletion with responseObject.spec.hostnames available

--- a/config/milo/activity/policies/httpproxy-policy.yaml
+++ b/config/milo/activity/policies/httpproxy-policy.yaml
@@ -37,10 +37,10 @@ spec:
 
     # HTTPProxy update with spec.hostnames available - excludes status subresource
     - name: update
-      match: "!audit.user.username.startsWith('system:') && audit.verb in ['update', 'patch'] && !has(audit.objectRef.subresource) && has(audit.requestObject.spec) && has(audit.requestObject.spec.hostnames) && size(audit.requestObject.spec.hostnames) > 0"
+      match: "!audit.user.username.startsWith('system:') && audit.verb in ['update', 'patch'] && !has(audit.objectRef.subresource) && has(audit.requestObject.spec) && has(audit.requestObject.spec.hostnames) && size(audit.requestObject.spec.hostnames) > 0 && audit.responseStatus.code >= 200 && audit.responseStatus.code < 300"
       summary: "{{ actor }} updated HTTP proxy {{ link(string(audit.requestObject.spec.hostnames[0]), audit.objectRef) }}"
 
     # HTTPProxy update fallback (no spec or no hostnames)
     - name: update-fallback
-      match: "!audit.user.username.startsWith('system:') && audit.verb in ['update', 'patch'] && !has(audit.objectRef.subresource)"
+      match: "!audit.user.username.startsWith('system:') && audit.verb in ['update', 'patch'] && !has(audit.objectRef.subresource) && audit.responseStatus.code >= 200 && audit.responseStatus.code < 300"
       summary: "{{ actor }} updated {{ link('an HTTP proxy', audit.objectRef) }}"

--- a/config/milo/activity/policies/httproute-policy.yaml
+++ b/config/milo/activity/policies/httproute-policy.yaml
@@ -16,12 +16,12 @@ spec:
   auditRules:
     # HTTPRoute creation with spec.hostnames available - use first hostname as display text
     - name: create
-      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && has(audit.requestObject.spec) && has(audit.requestObject.spec.hostnames) && size(audit.requestObject.spec.hostnames) > 0"
+      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && has(audit.requestObject.spec) && has(audit.requestObject.spec.hostnames) && size(audit.requestObject.spec.hostnames) > 0 && audit.responseStatus.code >= 200 && audit.responseStatus.code < 300"
       summary: "{{ actor }} created HTTP route {{ link(string(audit.requestObject.spec.hostnames[0]), audit.objectRef) }}"
 
     # HTTPRoute creation fallback (no spec or no hostnames)
     - name: create-fallback
-      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create'"
+      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && audit.responseStatus.code >= 200 && audit.responseStatus.code < 300"
       summary: "{{ actor }} created {{ link('an HTTP route', audit.objectRef) }}"
 
     # HTTPRoute deletion with responseObject.spec.hostnames available

--- a/config/milo/activity/policies/httproute-policy.yaml
+++ b/config/milo/activity/policies/httproute-policy.yaml
@@ -36,10 +36,10 @@ spec:
 
     # HTTPRoute update with spec.hostnames available - excludes status subresource
     - name: update
-      match: "!audit.user.username.startsWith('system:') && audit.verb in ['update', 'patch'] && !has(audit.objectRef.subresource) && has(audit.requestObject.spec) && has(audit.requestObject.spec.hostnames) && size(audit.requestObject.spec.hostnames) > 0"
+      match: "!audit.user.username.startsWith('system:') && audit.verb in ['update', 'patch'] && !has(audit.objectRef.subresource) && has(audit.requestObject.spec) && has(audit.requestObject.spec.hostnames) && size(audit.requestObject.spec.hostnames) > 0 && audit.responseStatus.code >= 200 && audit.responseStatus.code < 300"
       summary: "{{ actor }} updated HTTP route {{ link(string(audit.requestObject.spec.hostnames[0]), audit.objectRef) }}"
 
     # HTTPRoute update fallback (no spec or no hostnames)
     - name: update-fallback
-      match: "!audit.user.username.startsWith('system:') && audit.verb in ['update', 'patch'] && !has(audit.objectRef.subresource)"
+      match: "!audit.user.username.startsWith('system:') && audit.verb in ['update', 'patch'] && !has(audit.objectRef.subresource) && audit.responseStatus.code >= 200 && audit.responseStatus.code < 300"
       summary: "{{ actor }} updated {{ link('an HTTP route', audit.objectRef) }}"

--- a/config/milo/activity/policies/trafficprotectionpolicy-policy.yaml
+++ b/config/milo/activity/policies/trafficprotectionpolicy-policy.yaml
@@ -14,17 +14,14 @@ spec:
     kind: TrafficProtectionPolicy
 
   auditRules:
-    # TrafficProtectionPolicy creation with spec available.
-    # Rejected creates return a Status responseObject (no metadata.name); for
-    # generateName creates objectRef.name is also empty, so fall back to
-    # responseObject.details.name. has() is guarded per level.
+    # TrafficProtectionPolicy creation with spec available
     - name: create
-      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && has(audit.requestObject.spec)"
-      summary: "{{ actor }} created traffic protection policy {{ has(audit.responseObject.metadata.name) ? link(audit.responseObject.metadata.name, audit.objectRef) : has(audit.objectRef.name) ? link(audit.objectRef.name, audit.objectRef) : (has(audit.responseObject.details) && has(audit.responseObject.details.name)) ? link(audit.responseObject.details.name, audit.objectRef) : link('a traffic protection policy', audit.objectRef) }}"
+      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && has(audit.requestObject.spec) && audit.responseStatus.code >= 200 && audit.responseStatus.code < 300"
+      summary: "{{ actor }} created traffic protection policy {{ link(audit.responseObject.metadata.name, audit.objectRef) }}"
 
     # TrafficProtectionPolicy creation fallback (no spec)
     - name: create-fallback
-      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create'"
+      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && audit.responseStatus.code >= 200 && audit.responseStatus.code < 300"
       summary: "{{ actor }} created {{ link('a traffic protection policy', audit.objectRef) }}"
 
     # TrafficProtectionPolicy deletion with responseObject.spec available (response contains the deleted resource)
@@ -39,10 +36,10 @@ spec:
 
     # TrafficProtectionPolicy update with spec available - excludes status subresource
     - name: update
-      match: "!audit.user.username.startsWith('system:') && audit.verb in ['update', 'patch'] && !has(audit.objectRef.subresource) && has(audit.requestObject.spec)"
+      match: "!audit.user.username.startsWith('system:') && audit.verb in ['update', 'patch'] && !has(audit.objectRef.subresource) && has(audit.requestObject.spec) && audit.responseStatus.code >= 200 && audit.responseStatus.code < 300"
       summary: "{{ actor }} updated traffic protection policy {{ link(audit.objectRef.name, audit.objectRef) }}"
 
     # TrafficProtectionPolicy update fallback (no spec)
     - name: update-fallback
-      match: "!audit.user.username.startsWith('system:') && audit.verb in ['update', 'patch'] && !has(audit.objectRef.subresource)"
+      match: "!audit.user.username.startsWith('system:') && audit.verb in ['update', 'patch'] && !has(audit.objectRef.subresource) && audit.responseStatus.code >= 200 && audit.responseStatus.code < 300"
       summary: "{{ actor }} updated {{ link('a traffic protection policy', audit.objectRef) }}"

--- a/config/milo/activity/policies/trafficprotectionpolicy-policy.yaml
+++ b/config/milo/activity/policies/trafficprotectionpolicy-policy.yaml
@@ -16,12 +16,12 @@ spec:
   auditRules:
     # TrafficProtectionPolicy creation with spec available
     - name: create
-      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && has(audit.requestObject.spec)"
+      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && has(audit.requestObject.spec) && audit.responseStatus.code >= 200 && audit.responseStatus.code < 300"
       summary: "{{ actor }} created traffic protection policy {{ link(audit.responseObject.metadata.name, audit.objectRef) }}"
 
     # TrafficProtectionPolicy creation fallback (no spec)
     - name: create-fallback
-      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create'"
+      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && audit.responseStatus.code >= 200 && audit.responseStatus.code < 300"
       summary: "{{ actor }} created {{ link('a traffic protection policy', audit.objectRef) }}"
 
     # TrafficProtectionPolicy deletion with responseObject.spec available (response contains the deleted resource)

--- a/config/milo/activity/policies/trafficprotectionpolicy-policy.yaml
+++ b/config/milo/activity/policies/trafficprotectionpolicy-policy.yaml
@@ -14,10 +14,13 @@ spec:
     kind: TrafficProtectionPolicy
 
   auditRules:
-    # TrafficProtectionPolicy creation with spec available
+    # TrafficProtectionPolicy creation with spec available.
+    # Rejected creates return a Status responseObject (no metadata.name); for
+    # generateName creates objectRef.name is also empty, so fall back to
+    # responseObject.details.name. has() is guarded per level.
     - name: create
       match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && has(audit.requestObject.spec)"
-      summary: "{{ actor }} created traffic protection policy {{ has(audit.responseObject.metadata.name) ? link(audit.responseObject.metadata.name, audit.objectRef) : link(audit.objectRef.name, audit.objectRef) }}"
+      summary: "{{ actor }} created traffic protection policy {{ has(audit.responseObject.metadata.name) ? link(audit.responseObject.metadata.name, audit.objectRef) : has(audit.objectRef.name) ? link(audit.objectRef.name, audit.objectRef) : (has(audit.responseObject.details) && has(audit.responseObject.details.name)) ? link(audit.responseObject.details.name, audit.objectRef) : link('a traffic protection policy', audit.objectRef) }}"
 
     # TrafficProtectionPolicy creation fallback (no spec)
     - name: create-fallback

--- a/config/milo/activity/policies/trafficprotectionpolicy-policy.yaml
+++ b/config/milo/activity/policies/trafficprotectionpolicy-policy.yaml
@@ -17,7 +17,7 @@ spec:
     # TrafficProtectionPolicy creation with spec available
     - name: create
       match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && has(audit.requestObject.spec)"
-      summary: "{{ actor }} created traffic protection policy {{ link(audit.responseObject.metadata.name, audit.objectRef) }}"
+      summary: "{{ actor }} created traffic protection policy {{ has(audit.responseObject.metadata.name) ? link(audit.responseObject.metadata.name, audit.objectRef) : link(audit.objectRef.name, audit.objectRef) }}"
 
     # TrafficProtectionPolicy creation fallback (no spec)
     - name: create-fallback

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/envoyproxy/go-control-plane/envoy v1.37.1-0.20260409050421-3f47accd6e14
 	github.com/go-logr/logr v1.4.3
 	github.com/go-redis/redis/v7 v7.4.1
+	github.com/google/cel-go v0.26.0
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
 	github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus v1.1.0
@@ -43,6 +44,7 @@ require (
 	sigs.k8s.io/gateway-api v1.5.1
 	sigs.k8s.io/gateway-api/conformance v1.5.1
 	sigs.k8s.io/multicluster-runtime v0.23.3
+	sigs.k8s.io/yaml v1.6.0
 )
 
 require (
@@ -165,7 +167,6 @@ require (
 	github.com/golang-sql/sqlexp v0.1.0 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/btree v1.1.3 // indirect
-	github.com/google/cel-go v0.26.0 // indirect
 	github.com/google/gnostic-models v0.7.0 // indirect
 	github.com/google/go-containerregistry v0.21.6 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
@@ -319,5 +320,4 @@ require (
 	sigs.k8s.io/mcs-api v0.5.0 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.2 // indirect
-	sigs.k8s.io/yaml v1.6.0 // indirect
 )

--- a/test/activitypolicy/policies_test.go
+++ b/test/activitypolicy/policies_test.go
@@ -1,0 +1,224 @@
+package activitypolicy_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/google/cel-go/cel"
+	"sigs.k8s.io/yaml"
+)
+
+// These tests guard the ActivityPolicy audit rules under
+// config/milo/activity/policies against a single defect with two symptoms:
+// create/update rules that fire on FAILED (non-2xx) requests. On a rejected
+// request the audit responseObject is a metav1.Status, so a summary that
+// dereferences audit.responseObject.<leaf> throws and the event is lost to the
+// DLQ (DLQSlowLeak); the same rule also emits a false "created"/"updated"
+// activity for an attempt that never succeeded. The fix gates every create and
+// update rule's match on audit.responseStatus.code in [200,300).
+
+const policiesGlob = "../../config/milo/activity/policies/*-policy.yaml"
+
+type auditRule struct {
+	Name    string `json:"name"`
+	Match   string `json:"match"`
+	Summary string `json:"summary"`
+}
+
+type policy struct {
+	Metadata struct {
+		Name string `json:"name"`
+	} `json:"metadata"`
+	Spec struct {
+		AuditRules []auditRule `json:"auditRules"`
+	} `json:"spec"`
+}
+
+func loadPolicies(t *testing.T) []policy {
+	t.Helper()
+	paths, err := filepath.Glob(policiesGlob)
+	if err != nil {
+		t.Fatalf("glob %q: %v", policiesGlob, err)
+	}
+	if len(paths) == 0 {
+		t.Fatalf("no policy files matched %q", policiesGlob)
+	}
+	policies := make([]policy, 0, len(paths))
+	for _, p := range paths {
+		b, err := os.ReadFile(p)
+		if err != nil {
+			t.Fatalf("read %s: %v", p, err)
+		}
+		var pol policy
+		if err := yaml.Unmarshal(b, &pol); err != nil {
+			t.Fatalf("unmarshal %s: %v", p, err)
+		}
+		if pol.Metadata.Name == "" {
+			pol.Metadata.Name = filepath.Base(p)
+		}
+		policies = append(policies, pol)
+	}
+	return policies
+}
+
+// verbOf classifies a rule by the write verb its match targets.
+func verbOf(match string) string {
+	switch {
+	case strings.Contains(match, "audit.verb == 'create'"):
+		return "create"
+	case strings.Contains(match, "audit.verb in ['update', 'patch']"):
+		return "update"
+	case strings.Contains(match, "audit.verb == 'delete'"):
+		return "delete"
+	default:
+		return "other"
+	}
+}
+
+func gatesOn2xx(match string) bool {
+	return strings.Contains(match, "audit.responseStatus.code >= 200") &&
+		strings.Contains(match, "audit.responseStatus.code < 300")
+}
+
+func newEnv(t *testing.T) *cel.Env {
+	t.Helper()
+	env, err := cel.NewEnv(cel.Variable("audit", cel.DynType))
+	if err != nil {
+		t.Fatalf("cel env: %v", err)
+	}
+	return env
+}
+
+func evalMatch(t *testing.T, env *cel.Env, match string, audit map[string]any) bool {
+	t.Helper()
+	ast, iss := env.Compile(match)
+	if iss != nil && iss.Err() != nil {
+		t.Fatalf("compile %q: %v", match, iss.Err())
+	}
+	prg, err := env.Program(ast)
+	if err != nil {
+		t.Fatalf("program %q: %v", match, err)
+	}
+	out, _, err := prg.Eval(map[string]any{"audit": audit})
+	if err != nil {
+		t.Fatalf("eval %q: %v", match, err)
+	}
+	b, ok := out.Value().(bool)
+	if !ok {
+		t.Fatalf("match %q did not evaluate to bool, got %T", match, out.Value())
+	}
+	return b
+}
+
+// auditEvent builds an audit payload for the given verb and response code.
+// A 2xx response carries a real created/updated object; a non-2xx response
+// carries a metav1.Status (no metadata.name, no spec), as the API server sends
+// on a rejected write.
+func auditEvent(verb string, code int) map[string]any {
+	var responseObject map[string]any
+	if code >= 200 && code < 300 {
+		responseObject = map[string]any{
+			"metadata": map[string]any{"name": "obj-1"},
+			"spec": map[string]any{
+				"domainName": "example.datumchainsaw.art",
+				"hostnames":  []any{"example.datumchainsaw.art"},
+			},
+		}
+	} else {
+		responseObject = map[string]any{
+			"kind":       "Status",
+			"apiVersion": "v1",
+			"status":     "Failure",
+			"reason":     "Forbidden",
+			"code":       code,
+		}
+	}
+	return map[string]any{
+		"user": map[string]any{"username": "alice@example.com"},
+		"verb": verb,
+		"requestObject": map[string]any{
+			"spec": map[string]any{
+				"domainName": "example.datumchainsaw.art",
+				"hostnames":  []any{"example.datumchainsaw.art"},
+			},
+		},
+		"responseObject": responseObject,
+		"objectRef":      map[string]any{"name": "obj-1"},
+		"responseStatus": map[string]any{"code": code},
+	}
+}
+
+func failCodeFor(verb string) int {
+	if verb == "create" {
+		return 403
+	}
+	return 409
+}
+
+func successCodeFor(verb string) int {
+	if verb == "create" {
+		return 201
+	}
+	return 200
+}
+
+// Structural guard: every create/update rule must gate on a 2xx response.
+func TestCreateUpdateRulesGateOn2xx(t *testing.T) {
+	for _, pol := range loadPolicies(t) {
+		for _, r := range pol.Spec.AuditRules {
+			v := verbOf(r.Match)
+			if v != "create" && v != "update" {
+				continue
+			}
+			t.Run(pol.Metadata.Name+"/"+r.Name, func(t *testing.T) {
+				if !gatesOn2xx(r.Match) {
+					t.Errorf("%s rule %q (%s) is not gated on a 2xx response:\n  %s",
+						pol.Metadata.Name, r.Name, v, r.Match)
+				}
+			})
+		}
+	}
+}
+
+// Semantic guard: create/update rules must NOT match a failed request, and MUST
+// still match the successful one — the two properties that fix the DLQ leak and
+// the false-activity emission together.
+func TestCreateUpdateRulesFireOnlyOnSuccess(t *testing.T) {
+	env := newEnv(t)
+	for _, pol := range loadPolicies(t) {
+		for _, r := range pol.Spec.AuditRules {
+			v := verbOf(r.Match)
+			if v != "create" && v != "update" {
+				continue
+			}
+			t.Run(pol.Metadata.Name+"/"+r.Name, func(t *testing.T) {
+				if got := evalMatch(t, env, r.Match, auditEvent(v, failCodeFor(v))); got {
+					t.Errorf("%s rule %q matched a failed %s (code %d); it would DLQ / emit a false activity",
+						pol.Metadata.Name, r.Name, v, failCodeFor(v))
+				}
+				if got := evalMatch(t, env, r.Match, auditEvent(v, successCodeFor(v))); !got {
+					t.Errorf("%s rule %q did not match a successful %s (code %d); the gate broke the happy path",
+						pol.Metadata.Name, r.Name, v, successCodeFor(v))
+				}
+			})
+		}
+	}
+}
+
+// Every rule's match must compile — catches CEL typos before they reach milo.
+func TestAllMatchesCompile(t *testing.T) {
+	env := newEnv(t)
+	for _, pol := range loadPolicies(t) {
+		for _, r := range pol.Spec.AuditRules {
+			if strings.TrimSpace(r.Match) == "" {
+				t.Errorf("%s rule %q has an empty match", pol.Metadata.Name, r.Name)
+				continue
+			}
+			if _, iss := env.Compile(r.Match); iss != nil && iss.Err() != nil {
+				t.Errorf("%s rule %q match does not compile: %v", pol.Metadata.Name, r.Name, iss.Err())
+			}
+		}
+	}
+}


### PR DESCRIPTION
## What

Gate every **create** and **update** audit rule across all NSO ActivityPolicies on the request outcome — append `audit.responseStatus.code >= 200 && audit.responseStatus.code < 300` to each rule's `match` — so an activity rule fires only for a request that actually succeeded. Ships a `test/activitypolicy` suite that proves the invariant.

Consolidates the two changes that converged on this mechanism (this branch + #241) plus the tests into one PR.

## Why — one defect, two symptoms

Create/update rules matched on `has(audit.requestObject.spec)` (or the verb alone), so a **rejected** request (403 / 409 / 422 / admission-deny) still matched. Two failures fall out of that:

1. **DLQ leak.** On a rejected write the apiserver returns a `Status` object as `responseObject` — no `spec`, no `metadata.name`. A summary dereferencing `audit.responseObject.<leaf>` throws, the event is lost to the DLQ, and retries fail identically. Prod `DLQSlowLeak` on `gateway.networking.k8s.io-gateway` (`error_type=cel_summary`, ~120 events/6h, climbing):

   ```
   rule 0 summary: summary template evaluation failed:
   eval "link(audit.responseObject.metadata.name, audit.objectRef)": no such key: name
   ```

2. **False activities.** Even rules that dereference only `requestObject` / `objectRef` (so they don't DLQ) still emit a false "created X" / "updated X" in the timeline for an attempt that never succeeded.

Gating on 2xx fixes both at once — the rule simply does not fire on a failed request.

## Scope

All 8 policies — `backendtlspolicy`, `connector`, `connectoradvertisement`, `domain`, `gateway`, `httpproxy`, `httproute`, `trafficprotectionpolicy` — for `create`, `create-fallback`, `update`, `update-fallback`.

`delete` rules are unchanged (they already guard `has(audit.responseObject.spec)`; delete responses are not outcome-gated here).

The `httpproxy` / `httproute` **update** rules were the last gap — the create-gate change had missed them — and were surfaced by the new test, then closed.

## Tests (`test/activitypolicy`)

- **structural** — every create/update rule's `match` gates on `responseStatus.code` in `[200,300)`
- **semantic (cel-go)** — each create/update rule matches a successful write and does **not** match a failed one
- **compile** — every rule `match` parses

## Prod remediation

Merge + NSO release → Flux re-applies the corrected ActivityPolicy CRs (overwriting the live objects); the processor retries the DLQ backlog. No `kubectl`.

## Related (same bug class, separate repos)

- milo-os/milo — create rules (separate PR)
- milo-os/billing — billingaccountbinding (separate PR)
- Runbook: milo-os/activity#213 · Investigation: milo-os/activity#212
