### PR TITLE
fix: detachHTTPRoutes uses Spec.ParentRefs not Status.Parents

### DIFF
--- a/internal/controller/gateway_controller.go
+++ b/internal/controller/gateway_controller.go
@@ -1596,26 +1596,33 @@ func (r *GatewayReconciler) detachHTTPRoutes(
 			continue
 		}
 
-		var parents []gatewayv1.RouteParentStatus
-		for _, parent := range route.Status.Parents {
-			if ptr.Deref(parent.ParentRef.Group, gatewayv1.GroupName) == gatewayv1.GroupName &&
-				ptr.Deref(parent.ParentRef.Kind, KindGateway) == KindGateway &&
-				string(parent.ParentRef.Name) == gateway.Name {
-				logger.Info("removing parent ref from httproute", jsonKeyName, route.Name, "parent", parent.ParentRef.Name)
+		var remainingRefs []gatewayv1.ParentReference
+		for _, ref := range route.Spec.ParentRefs {
+			if ptr.Deref(ref.Group, gatewayv1.GroupName) == gatewayv1.GroupName &&
+				ptr.Deref(ref.Kind, KindGateway) == KindGateway &&
+				string(ref.Name) == gateway.Name {
+				logger.Info("removing parent ref from httproute", jsonKeyName, route.Name, "parent", ref.Name)
 				continue
 			}
-			parents = append(parents, parent)
+			remainingRefs = append(remainingRefs, ref)
 		}
 
-		if len(parents) == 0 && deleteWhenNoParents {
+		if len(remainingRefs) == len(route.Spec.ParentRefs) {
+			continue
+		}
+
+		if len(remainingRefs) == 0 && deleteWhenNoParents {
 			logger.Info("deleting httproute due to no parents", jsonKeyName, route.Name)
 			if err := gatewayClient.Delete(ctx, &route); err != nil {
 				result.Err = err
 				return result
 			}
-		} else if !equality.Semantic.DeepEqual(route.Status.Parents, parents) {
-			route.Status.Parents = parents
-			result.AddStatusUpdate(gatewayClient, &route)
+		} else {
+			route.Spec.ParentRefs = remainingRefs
+			if err := gatewayClient.Update(ctx, &route); err != nil {
+				result.Err = err
+				return result
+			}
 		}
 	}
 	return result


### PR DESCRIPTION
## Summary

Fixes #231.

`detachHTTPRoutes` was iterating `route.Status.Parents` (written by Envoy Gateway, can be stale or empty at finalization time) instead of `route.Spec.ParentRefs` (written by NSO, always authoritative). This caused orphaned downstream HTTPRoutes when EG hadn't yet processed a route at finalization time, or when Karmada's status aggregation lagged behind spec changes.

- Replace `Status.Parents` iteration with `Spec.ParentRefs`
- Build `remainingRefs` excluding the gateway being finalized
- Delete route when no refs remain and `deleteWhenNoParents=true`
- Update `Spec.ParentRefs` when refs remain (EG reconciles status from spec naturally)
- Drop the status subresource mutation entirely

## Test plan

- [ ] `make test` passes
- [ ] Delete an upstream Gateway; verify all attached downstream HTTPRoutes with no other parents are deleted from Karmada
- [ ] Delete an upstream Gateway; verify downstream HTTPRoutes with other parent refs have the deleted gateway's ref removed from spec (not deleted)
- [ ] No orphaned downstream HTTPRoutes remain after gateway finalization completes