### PR TITLE
test: add Network and NetworkContext lifecycle e2e tests

### DIFF
--- a/test/e2e/network-context-lifecycle/chainsaw-test.yaml
+++ b/test/e2e/network-context-lifecycle/chainsaw-test.yaml
@@ -1,0 +1,114 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: network-context-lifecycle
+spec:
+  cluster: nso-standard
+  steps:
+    - name: Create Network
+      try:
+        - create:
+            resource:
+              apiVersion: networking.datumapis.com/v1alpha
+              kind: Network
+              metadata:
+                name: test-cascade-network
+                namespace: default
+              spec:
+                ipam:
+                  mode: Auto
+
+    - name: Create NetworkBinding and assert NetworkContext is created
+      description: |
+        The binding controller creates a NetworkContext owned by the Network.
+        This ownership is what the Network finalizer relies on to garbage-collect
+        the context on delete.
+      try:
+        - create:
+            resource:
+              apiVersion: networking.datumapis.com/v1alpha
+              kind: NetworkBinding
+              metadata:
+                name: test-cascade-binding
+                namespace: default
+              spec:
+                network:
+                  name: test-cascade-network
+                location:
+                  name: test-location
+                  namespace: default
+        - assert:
+            resource:
+              apiVersion: networking.datumapis.com/v1alpha
+              kind: NetworkContext
+              metadata:
+                name: test-cascade-network-default-test-location
+                namespace: default
+                (length(ownerReferences[?kind == 'Network' && controller == `true`]) == `1`): true
+
+    - name: Mark NetworkContext as Programmed
+      description: |
+        A plugin is expected to program the context at its backend and set the
+        Programmed condition. No such plugin runs in the local harness, so the
+        condition is set directly. A kubectl command is used because Chainsaw
+        does not support updating subresources.
+        See https://github.com/kyverno/chainsaw/issues/300.
+      try:
+        - script:
+            content: |
+              kubectl -n default patch networkcontext test-cascade-network-default-test-location \
+                --subresource=status --type=merge \
+                -p '{"status":{"conditions":[{"type": "Programmed", "status": "True", "reason": "Test", "message": "test", "lastTransitionTime": "2025-02-24T23:59:09Z"}]}}'
+
+    - name: Assert NetworkContext becomes Ready
+      description: |
+        The networkcontext controller derives Ready from Programmed. This asserts
+        that transition, which no other e2e exercises.
+      try:
+        - assert:
+            timeout: 1m
+            resource:
+              apiVersion: networking.datumapis.com/v1alpha
+              kind: NetworkContext
+              metadata:
+                name: test-cascade-network-default-test-location
+                namespace: default
+              status:
+                (conditions[?type == 'Ready'][0].status): 'True'
+
+    - name: Assert NetworkBinding becomes Ready
+      try:
+        - wait:
+            apiVersion: networking.datumapis.com/v1alpha
+            kind: NetworkBinding
+            name: test-cascade-binding
+            namespace: default
+            timeout: 1m
+            for:
+              condition:
+                name: Ready
+                value: 'true'
+
+    - name: Delete Network and assert cascade cleanup
+      description: |
+        Deleting the Network drives its finalizer to garbage-collect the owned
+        NetworkContext before releasing. The delete blocks until the Network is
+        gone, which can only happen after the context is removed; the script then
+        confirms the context is absent.
+      try:
+        - delete:
+            timeout: 1m
+            ref:
+              apiVersion: networking.datumapis.com/v1alpha
+              kind: Network
+              name: test-cascade-network
+              namespace: default
+        - script:
+            content: |
+              set -e
+              if kubectl -n default get networkcontext test-cascade-network-default-test-location 2>/dev/null; then
+                echo "NetworkContext still exists after Network deletion" >&2
+                exit 1
+              fi
+              echo "NetworkContext garbage-collected"

--- a/test/e2e/network-context-lifecycle/chainsaw-test.yaml
+++ b/test/e2e/network-context-lifecycle/chainsaw-test.yaml
@@ -75,7 +75,9 @@ spec:
                 name: test-cascade-network-default-test-location
                 namespace: default
               status:
-                (conditions[?type == 'Ready'][0].status): 'True'
+                conditions:
+                  - type: Ready
+                    status: 'True'
 
     - name: Assert NetworkBinding becomes Ready
       try:

--- a/test/e2e/network-context-lifecycle/chainsaw-test.yaml
+++ b/test/e2e/network-context-lifecycle/chainsaw-test.yaml
@@ -75,9 +75,7 @@ spec:
                 name: test-cascade-network-default-test-location
                 namespace: default
               status:
-                conditions:
-                  - type: Ready
-                    status: 'True'
+                (length(conditions[?type == 'Ready' && status == 'True']) == `1`): true
 
     - name: Assert NetworkBinding becomes Ready
       try:

--- a/test/e2e/network-crud/chainsaw-test.yaml
+++ b/test/e2e/network-crud/chainsaw-test.yaml
@@ -22,27 +22,32 @@ spec:
               - name: NETWORK_NAME
                 value: (@.metadata.name)
 
-    - name: Assert Network is Ready
+    - name: Assert Network is admitted and finalized
+      description: |
+        NSO's network controller writes no readiness condition on a bare
+        Network; readiness is provider-driven and no provider runs in the local
+        kind harness. What NSO owns here is admission and the finalizer
+        lifecycle, so that is what this asserts.
       try:
         - assert:
-            timeout: 2m
+            timeout: 30s
             resource:
               apiVersion: networking.datumapis.com/v1alpha
               kind: Network
               metadata:
                 name: ($NETWORK_NAME)
                 namespace: default
-              status:
-                (conditions[?type == 'Ready'][0].status): 'True'
+                (contains(finalizers, 'networking.datumapis.com/network-controller')): true
 
     - name: Delete Network
+      description: |
+        Delete blocks until the object is gone, asserting the network controller
+        releases its finalizer (no NetworkContexts exist to garbage-collect).
       try:
-        - script:
+        - delete:
             timeout: 1m
-            env:
-              - name: NETWORK_NAME
-                value: ($NETWORK_NAME)
-            content: |
-              set -e
-              kubectl delete network.networking.datumapis.com $NETWORK_NAME -n default --wait=true --timeout=60s
-              echo "Network $NETWORK_NAME deleted"
+            ref:
+              apiVersion: networking.datumapis.com/v1alpha
+              kind: Network
+              name: ($NETWORK_NAME)
+              namespace: default

--- a/test/e2e/network-crud/chainsaw-test.yaml
+++ b/test/e2e/network-crud/chainsaw-test.yaml
@@ -1,0 +1,48 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: network-crud
+spec:
+  cluster: nso-standard
+  steps:
+    - name: Create Network
+      try:
+        - create:
+            resource:
+              apiVersion: networking.datumapis.com/v1alpha
+              kind: Network
+              metadata:
+                name: (to_lower(concat('e2e-net-', replace_all(time_now(), ':', '-'))))
+                namespace: default
+              spec:
+                ipam:
+                  mode: Auto
+            outputs:
+              - name: NETWORK_NAME
+                value: (@.metadata.name)
+
+    - name: Assert Network is Ready
+      try:
+        - assert:
+            timeout: 2m
+            resource:
+              apiVersion: networking.datumapis.com/v1alpha
+              kind: Network
+              metadata:
+                name: ($NETWORK_NAME)
+                namespace: default
+              status:
+                (conditions[?type == 'Ready'][0].status): 'True'
+
+    - name: Delete Network
+      try:
+        - script:
+            timeout: 1m
+            env:
+              - name: NETWORK_NAME
+                value: ($NETWORK_NAME)
+            content: |
+              set -e
+              kubectl delete network.networking.datumapis.com $NETWORK_NAME -n default --wait=true --timeout=60s
+              echo "Network $NETWORK_NAME deleted"

--- a/test/e2e/network-crud/chainsaw-test.yaml
+++ b/test/e2e/network-crud/chainsaw-test.yaml
@@ -13,14 +13,11 @@ spec:
               apiVersion: networking.datumapis.com/v1alpha
               kind: Network
               metadata:
-                name: (to_lower(concat('e2e-net-', replace_all(time_now(), ':', '-'))))
+                name: test-network-crud
                 namespace: default
               spec:
                 ipam:
                   mode: Auto
-            outputs:
-              - name: NETWORK_NAME
-                value: (@.metadata.name)
 
     - name: Assert Network is admitted and finalized
       description: |
@@ -35,9 +32,10 @@ spec:
               apiVersion: networking.datumapis.com/v1alpha
               kind: Network
               metadata:
-                name: ($NETWORK_NAME)
+                name: test-network-crud
                 namespace: default
-                (contains(finalizers, 'networking.datumapis.com/network-controller')): true
+                finalizers:
+                  - networking.datumapis.com/network-controller
 
     - name: Delete Network
       description: |
@@ -49,5 +47,5 @@ spec:
             ref:
               apiVersion: networking.datumapis.com/v1alpha
               kind: Network
-              name: ($NETWORK_NAME)
+              name: test-network-crud
               namespace: default


### PR DESCRIPTION
## What

Adds local kind-harness e2e coverage for two NSO-owned reconcile paths that had none:

- **`test/e2e/network-crud`** — bare `Network` lifecycle: admission, the `networking.datumapis.com/network-controller` finalizer, and clean deletion (finalizer release with no children to garbage-collect).
- **`test/e2e/network-context-lifecycle`** — `NetworkContext` readiness and cascade delete: it builds the `Network`, `NetworkBinding`, and `NetworkContext` chain, drives the context `Programmed`, asserts the controller derives `Ready`, asserts the `NetworkBinding` then reaches `Ready`, then deletes the `Network` and asserts its finalizer cascade-deletes the owned `NetworkContext` before releasing.

## Why

`network-crud` guards CRD/webhook/finalizer wiring. `network-context-lifecycle` guards the two behaviors most likely to regress silently: the `Programmed` to `Ready` transition and the finalizer's owned-child garbage collection.

## Coverage boundary

Readiness in this stack is provider-driven — `NetworkContext.Ready` follows `NetworkContext.Programmed`, and NSO never sets `Programmed`; an external plugin does. No provider runs in the local harness, so:

- `network-crud` does not assert a bare `Network` reaches `Ready` (nothing local can make that true).
- `network-context-lifecycle` patches `Programmed` directly to stand in for the plugin (mirroring `networkbinding/ready-when-context-is-ready`), then asserts the operator-owned consequences.

Out of scope (needs a real provider): actual IPAM allocation and a genuine backend `Programmed` signal.

## Verification

CI e2e (kind) and `task dev:test` locally. Both tests pass; behavior confirmed in CI — the `NetworkContext` reconciles to `Ready` once `Programmed` is set, the ownerReference back to the `Network` is present, and deleting the `Network` cascades to the context.
