### PR TITLE
test: migrate httproute-accepted e2e from infra

### DIFF
--- a/test/e2e/httproute-accepted/chainsaw-test.yaml
+++ b/test/e2e/httproute-accepted/chainsaw-test.yaml
@@ -1,0 +1,215 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: httproute-accepted
+spec:
+  bindings:
+    - name: clusterIssuerName
+      value: (join('-', ['e2e', $namespace]))
+    - name: gatewayClassName
+      value: (join('-', ['e2e', $namespace]))
+  cluster: nso-standard
+  steps:
+    - name: Create CA
+      try:
+        - create:
+            cluster: nso-infra
+            resource:
+              apiVersion: cert-manager.io/v1
+              kind: ClusterIssuer
+              metadata:
+                name: (join('-', [$clusterIssuerName, 'issuer']))
+              spec:
+                selfSigned: {}
+
+        - create:
+            cluster: nso-infra
+            resource:
+              apiVersion: cert-manager.io/v1
+              kind: Certificate
+              metadata:
+                name: (join('-', [$clusterIssuerName, 'ca']))
+                namespace: cert-manager
+              spec:
+                isCA: true
+                commonName: (join('-', [$clusterIssuerName, 'ca']))
+                secretName: ($clusterIssuerName)
+                privateKey:
+                  algorithm: ECDSA
+                  size: 256
+                issuerRef:
+                  name: (join('-', [$clusterIssuerName, 'issuer']))
+                  kind: ClusterIssuer
+                  group: cert-manager.io
+
+        - create:
+            cluster: nso-infra
+            resource:
+              apiVersion: cert-manager.io/v1
+              kind: ClusterIssuer
+              metadata:
+                name: ($clusterIssuerName)
+              spec:
+                ca:
+                  secretName: ($clusterIssuerName)
+
+        - assert:
+            cluster: nso-infra
+            resource:
+              apiVersion: cert-manager.io/v1
+              kind: Certificate
+              metadata:
+                name: (join('-', [$clusterIssuerName, 'ca']))
+                namespace: cert-manager
+              status:
+                conditions:
+                  - type: Ready
+                    status: "True"
+
+    - name: Create GatewayClass for the upstream gateways
+      try:
+        - create:
+            cluster: nso-standard
+            resource:
+              apiVersion: gateway.networking.k8s.io/v1
+              kind: GatewayClass
+              metadata:
+                name: ($gatewayClassName)
+              spec:
+                controllerName: gateway.networking.datumapis.com/external-global-proxy-controller
+
+    - name: Provision Domain
+      try:
+        - create:
+            cluster: nso-standard
+            resource:
+              apiVersion: networking.datumapis.com/v1alpha
+              kind: Domain
+              metadata:
+                name: test-domain
+              spec:
+                domainName: e2e.env.datum.net
+
+        - description: |
+            Under normal operation, the Domain controller will perform verification
+            via HTTP or DNS, and update the Domain's status.
+          script:
+            content: |
+                kubectl -n $NAMESPACE patch domain test-domain \
+                  --subresource=status --type=merge \
+                  -p '{"status":{"conditions":[{"type": "Verified", "status": "True", "reason": "Test", "message": "test", "lastTransitionTime": "2025-02-24T23:59:09Z"}]}}'
+
+    - name: Provision Gateway
+      try:
+        - create:
+            cluster: nso-standard
+            resource:
+              apiVersion: gateway.networking.k8s.io/v1
+              kind: Gateway
+              metadata:
+                name: test-gateway
+              spec:
+                gatewayClassName: ($gatewayClassName)
+                listeners:
+                - protocol: HTTP
+                  port: 80
+                  name: http-test-e2e
+                  allowedRoutes:
+                    namespaces:
+                      from: Same
+                  hostname: test.e2e.env.datum.net
+                - protocol: HTTPS
+                  port: 443
+                  name: https-test-e2e
+                  allowedRoutes:
+                    namespaces:
+                      from: Same
+                  hostname: test.e2e.env.datum.net
+                  tls:
+                    mode: Terminate
+                    options:
+                      gateway.networking.datumapis.com/certificate-issuer: ($clusterIssuerName)
+
+        - assert:
+            timeout: 120s
+            cluster: nso-standard
+            resource:
+              apiVersion: gateway.networking.k8s.io/v1
+              kind: Gateway
+              metadata:
+                name: test-gateway
+              status:
+                (conditions[?type == 'Accepted']):
+                  - status: "True"
+
+    - name: Provision HTTPRoute and assert it is Accepted
+      try:
+        - create:
+            cluster: nso-standard
+            resource:
+              kind: EndpointSlice
+              metadata:
+                name: test-slice-1
+              addressType: FQDN
+              apiVersion: discovery.k8s.io/v1
+              endpoints:
+              - addresses:
+                - backend-service.default.svc.cluster.local
+                conditions:
+                  ready: true
+                  serving: true
+                  terminating: false
+              ports:
+              - name: http
+                appProtocol: http
+                port: 8080
+
+        - create:
+            cluster: nso-standard
+            resource:
+              apiVersion: gateway.networking.k8s.io/v1
+              kind: HTTPRoute
+              metadata:
+                name: test-route
+              spec:
+                parentRefs:
+                - name: test-gateway
+                  kind: Gateway
+                rules:
+                  - matches:
+                    - path:
+                        type: PathPrefix
+                        value: /
+                    backendRefs:
+                    - group: discovery.k8s.io
+                      kind: EndpointSlice
+                      name: test-slice-1
+                      port: 8080
+
+        - assert:
+            timeout: 120s
+            cluster: nso-standard
+            resource:
+              apiVersion: gateway.networking.k8s.io/v1
+              kind: HTTPRoute
+              metadata:
+                name: test-route
+              status:
+                parents:
+                - conditions:
+                  - reason: Accepted
+                    status: "True"
+                    type: Accepted
+                  parentRef:
+                    name: test-gateway
+                    kind: Gateway
+                    group: gateway.networking.k8s.io
+      catch:
+        - script:
+            cluster: nso-standard
+            content: |
+              kubectl -n network-services-operator-system logs -l app.kubernetes.io/name=network-services-operator
+              kubectl get gateways -n $NAMESPACE -o yaml
+              kubectl get httproutes -n $NAMESPACE -o yaml
+              kubectl get endpointslices -n $NAMESPACE -o yaml

--- a/test/e2e/httproute-accepted/chainsaw-test.yaml
+++ b/test/e2e/httproute-accepted/chainsaw-test.yaml
@@ -201,6 +201,9 @@ spec:
                   - reason: Accepted
                     status: "True"
                     type: Accepted
+                  - reason: ResolvedRefs
+                    status: "True"
+                    type: ResolvedRefs
                   parentRef:
                     name: test-gateway
                     kind: Gateway


### PR DESCRIPTION
## What

Adds an `httproute-accepted` end-to-end test to NSO's local kind harness at `test/e2e/httproute-accepted/`. It provisions a `Gateway` and an `HTTPRoute` and asserts the route reaches `Accepted`, so downstream traffic programming can proceed.

## Why

Per `datum-cloud/infra#3006`, single-service API-contract tests are moving out of the infra live-env Chainsaw suite into their owning repo's local kind harness, run pre-merge. The `gateway.networking.k8s.io` HTTPRoute contract is owned by NSO, so it belongs here. Related: `datum-cloud/infra#3005`.

## Approach

The test mirrors the `gateway` sibling's proven setup on the prod-fidelity harness:

- a self-signed CA on the downstream cluster (`nso-infra`),
- an upstream `GatewayClass`,
- a verified `Domain` (`e2e.env.datum.net`),
- a `Gateway` with HTTP + HTTPS listeners that reaches `Accepted`,
- an `HTTPRoute` + backend `EndpointSlice`, then an assert that the route is `Accepted`.

Two details worth calling out, both learned from CI:

> [!NOTE]
> Route acceptance is asserted on the per-parent condition (`status.parents[].conditions[]`), where the Gateway API surfaces it — the HTTPRoute never populates a top-level `Accepted` condition, so a `kubectl wait --for=condition=Accepted` can't observe it.

> [!NOTE]
> The `conditions` list asserts both `Accepted` and `ResolvedRefs`. Chainsaw matches a bare array positionally and by length, so an expected list carrying only `Accepted` never matches the route's two-entry status.

## Test plan

- `chainsaw lint` passes.
- E2E Tests green end-to-end: `httproute-accepted` passes in ~7s alongside the rest of the suite. This is verified against a running harness, not just linted.
