### PR TITLE
feat: add forwardIDToken to oidc config in SecurityPolicy

### DIFF
--- a/config/crd/gateway/kustomization.yaml
+++ b/config/crd/gateway/kustomization.yaml
@@ -20,6 +20,13 @@ patches:
       kind: CustomResourceDefinition
       metadata:
         name: referencegrants.gateway.networking.k8s.io
+  # Backports fields from EG v1.8.1. Re-evaluate this when upgrading the gateway CRDs.
+  - path: patch-securitypolicy-forward-id-token.yaml
+    target:
+      group: apiextensions.k8s.io
+      version: v1
+      kind: CustomResourceDefinition
+      name: securitypolicies.gateway.envoyproxy.io
   # Envoy gateway resources
   - patch: |
       $patch: delete

--- a/config/crd/gateway/patch-securitypolicy-forward-id-token.yaml
+++ b/config/crd/gateway/patch-securitypolicy-forward-id-token.yaml
@@ -1,0 +1,23 @@
+- op: add
+  path: /spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/oidc/properties/forwardIDToken
+  value:
+    description: |-
+      ForwardIDToken configures forwarding of the OIDC ID token to the upstream.
+
+      If the configured header is "Authorization", EG forwards the ID token using
+      the "Bearer " prefix. For any other header, EG forwards the raw token value.
+      If not specified, the ID token will not be forwarded.
+    properties:
+      header:
+        description: Header is the upstream request header that will carry the ID token.
+        minLength: 1
+        type: string
+    required:
+      - header
+    type: object
+- op: add
+  path: /spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/oidc/x-kubernetes-validations/-
+  value:
+    message: forwardAccessToken cannot be true when forwardIDToken.header is Authorization
+    rule: "!(has(self.forwardAccessToken) && self.forwardAccessToken && has(self.forwardIDToken)\
+      \ && self.forwardIDToken.header.lowerAscii() == 'authorization')"


### PR DESCRIPTION
The Milo control plane installs EG CRDs from v1.5.1, while edge clusters run v1.8.1. The `forwardIDToken` OIDC field was added after v1.5 release, so it cannot be set on a SecurityPolicy even though the downstream cluster would accept it.

A full version bump from v1.5.1 -> v1.8.1 would expose 50+ new fields - several (TLS cipher control, admission control, dynamic Wasm modules, IP geo filtering) need to be validated before being made available on the control plane. This PR adds just the field that is required by the datum wiki deployment.

Key changes:
- Add a kustomize JSON patch that injects `forwardIDToken` into the SecurityPolicy OIDC schema, keeping v1.5.1 as the base
- Include the companion CEL rule from v1.8.1 that prevents setting `forwardAccessToken: true` alongside `forwardIDToken.header: Authorization` — without it, that combination would be silently accepted upstream then rejected by the downstream v1.8.1 CRD
