### PR TITLE
fix(activity-policies): gate create rules on 2xx outcome

### DIFF
--- a/config/milo/activity/policies/backendtlspolicy-policy.yaml
+++ b/config/milo/activity/policies/backendtlspolicy-policy.yaml
@@ -16,12 +16,12 @@ spec:
   auditRules:
     # BackendTLSPolicy creation with spec available
     - name: create
-      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && has(audit.requestObject.spec)"
+      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && has(audit.requestObject.spec) && audit.responseStatus.code >= 200 && audit.responseStatus.code < 300"
       summary: "{{ actor }} created backend TLS policy {{ link(audit.responseObject.metadata.name, audit.objectRef) }}"
 
     # BackendTLSPolicy creation fallback (no spec)
     - name: create-fallback
-      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create'"
+      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && audit.responseStatus.code >= 200 && audit.responseStatus.code < 300"
       summary: "{{ actor }} created {{ link('a backend TLS policy', audit.objectRef) }}"
 
     # BackendTLSPolicy deletion with responseObject.spec available (response contains the deleted resource)

--- a/config/milo/activity/policies/connector-policy.yaml
+++ b/config/milo/activity/policies/connector-policy.yaml
@@ -16,12 +16,12 @@ spec:
   auditRules:
     # Connector creation with spec available
     - name: create
-      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && has(audit.requestObject.spec)"
+      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && has(audit.requestObject.spec) && audit.responseStatus.code >= 200 && audit.responseStatus.code < 300"
       summary: "{{ actor }} created connector {{ link(audit.responseObject.metadata.name, audit.objectRef) }}"
 
     # Connector creation fallback (no spec)
     - name: create-fallback
-      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create'"
+      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && audit.responseStatus.code >= 200 && audit.responseStatus.code < 300"
       summary: "{{ actor }} created {{ link('a connector', audit.objectRef) }}"
 
     # Connector deletion with responseObject.spec available (response contains the deleted resource)

--- a/config/milo/activity/policies/connectoradvertisement-policy.yaml
+++ b/config/milo/activity/policies/connectoradvertisement-policy.yaml
@@ -17,12 +17,12 @@ spec:
   auditRules:
     # ConnectorAdvertisement creation with spec available
     - name: create
-      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && has(audit.requestObject.spec)"
+      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && has(audit.requestObject.spec) && audit.responseStatus.code >= 200 && audit.responseStatus.code < 300"
       summary: "{{ actor }} created connector advertisement {{ link(audit.responseObject.metadata.name, audit.objectRef) }}"
 
     # ConnectorAdvertisement creation fallback (no spec)
     - name: create-fallback
-      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create'"
+      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && audit.responseStatus.code >= 200 && audit.responseStatus.code < 300"
       summary: "{{ actor }} created {{ link('a connector advertisement', audit.objectRef) }}"
 
     # ConnectorAdvertisement deletion with responseObject.spec available (response contains the deleted resource)

--- a/config/milo/activity/policies/domain-policy.yaml
+++ b/config/milo/activity/policies/domain-policy.yaml
@@ -17,12 +17,12 @@ spec:
   auditRules:
     # Domain creation with spec.domainName available - use domain name as display text
     - name: create
-      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && has(audit.requestObject.spec)"
+      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && has(audit.requestObject.spec) && audit.responseStatus.code >= 200 && audit.responseStatus.code < 300"
       summary: "{{ actor }} created domain {{ link(audit.responseObject.spec.domainName, audit.objectRef) }}"
 
     # Domain creation fallback (no spec)
     - name: create-fallback
-      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create'"
+      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && audit.responseStatus.code >= 200 && audit.responseStatus.code < 300"
       summary: "{{ actor }} created {{ link('a domain', audit.objectRef) }}"
 
     # Domain deletion with responseObject.spec available (response contains the deleted resource)

--- a/config/milo/activity/policies/gateway-policy.yaml
+++ b/config/milo/activity/policies/gateway-policy.yaml
@@ -16,12 +16,12 @@ spec:
   auditRules:
     # Gateway creation with spec available
     - name: create
-      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && has(audit.requestObject.spec)"
+      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && has(audit.requestObject.spec) && audit.responseStatus.code >= 200 && audit.responseStatus.code < 300"
       summary: "{{ actor }} created gateway {{ link(audit.responseObject.metadata.name, audit.objectRef) }}"
 
     # Gateway creation fallback (no spec)
     - name: create-fallback
-      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create'"
+      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && audit.responseStatus.code >= 200 && audit.responseStatus.code < 300"
       summary: "{{ actor }} created {{ link('a gateway', audit.objectRef) }}"
 
     # Gateway deletion with responseObject.spec available (response contains the deleted resource)

--- a/config/milo/activity/policies/httpproxy-policy.yaml
+++ b/config/milo/activity/policies/httpproxy-policy.yaml
@@ -17,12 +17,12 @@ spec:
   auditRules:
     # HTTPProxy creation with spec.hostnames available - use first hostname as display text
     - name: create
-      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && has(audit.requestObject.spec) && has(audit.requestObject.spec.hostnames) && size(audit.requestObject.spec.hostnames) > 0"
+      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && has(audit.requestObject.spec) && has(audit.requestObject.spec.hostnames) && size(audit.requestObject.spec.hostnames) > 0 && audit.responseStatus.code >= 200 && audit.responseStatus.code < 300"
       summary: "{{ actor }} created HTTP proxy {{ link(string(audit.requestObject.spec.hostnames[0]), audit.objectRef) }}"
 
     # HTTPProxy creation fallback (no spec or no hostnames)
     - name: create-fallback
-      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create'"
+      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && audit.responseStatus.code >= 200 && audit.responseStatus.code < 300"
       summary: "{{ actor }} created {{ link('an HTTP proxy', audit.objectRef) }}"
 
     # HTTPProxy deletion with responseObject.spec.hostnames available

--- a/config/milo/activity/policies/httproute-policy.yaml
+++ b/config/milo/activity/policies/httproute-policy.yaml
@@ -16,12 +16,12 @@ spec:
   auditRules:
     # HTTPRoute creation with spec.hostnames available - use first hostname as display text
     - name: create
-      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && has(audit.requestObject.spec) && has(audit.requestObject.spec.hostnames) && size(audit.requestObject.spec.hostnames) > 0"
+      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && has(audit.requestObject.spec) && has(audit.requestObject.spec.hostnames) && size(audit.requestObject.spec.hostnames) > 0 && audit.responseStatus.code >= 200 && audit.responseStatus.code < 300"
       summary: "{{ actor }} created HTTP route {{ link(string(audit.requestObject.spec.hostnames[0]), audit.objectRef) }}"
 
     # HTTPRoute creation fallback (no spec or no hostnames)
     - name: create-fallback
-      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create'"
+      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && audit.responseStatus.code >= 200 && audit.responseStatus.code < 300"
       summary: "{{ actor }} created {{ link('an HTTP route', audit.objectRef) }}"
 
     # HTTPRoute deletion with responseObject.spec.hostnames available

--- a/config/milo/activity/policies/trafficprotectionpolicy-policy.yaml
+++ b/config/milo/activity/policies/trafficprotectionpolicy-policy.yaml
@@ -16,12 +16,12 @@ spec:
   auditRules:
     # TrafficProtectionPolicy creation with spec available
     - name: create
-      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && has(audit.requestObject.spec)"
+      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && has(audit.requestObject.spec) && audit.responseStatus.code >= 200 && audit.responseStatus.code < 300"
       summary: "{{ actor }} created traffic protection policy {{ link(audit.responseObject.metadata.name, audit.objectRef) }}"
 
     # TrafficProtectionPolicy creation fallback (no spec)
     - name: create-fallback
-      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create'"
+      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && audit.responseStatus.code >= 200 && audit.responseStatus.code < 300"
       summary: "{{ actor }} created {{ link('a traffic protection policy', audit.objectRef) }}"
 
     # TrafficProtectionPolicy deletion with responseObject.spec available (response contains the deleted resource)


### PR DESCRIPTION
## Summary

Failed create requests (e.g. a `403`) return a `metav1.Status` object as the audit `responseObject`, not the created resource. ActivityPolicy summary templates that dereference `audit.responseObject.metadata.name` therefore threw on those payloads, routing the events to the DLQ (`DLQSlowLeak`). Ungated create rules also emitted false "created" activities for attempts that actually failed.

This gates **every** `create` rule on the request outcome by appending `audit.responseStatus.code >= 200 && audit.responseStatus.code < 300` to the `match` expression, so failed attempts produce no activity. This matches the pattern milo standardized on in commit `2b82751`.

## Changes

All 8 policies in `config/milo/activity/policies/` — both create rules (the primary create + the no-spec `create-fallback`) are gated in each:

- `domain-policy.yaml`
- `httpproxy-policy.yaml`
- `httproute-policy.yaml`
- `gateway-policy.yaml`
- `connector-policy.yaml` — the policy named in the issue; its `create` summary derefs `audit.responseObject.metadata.name`, which was the DLQ trigger
- `connectoradvertisement-policy.yaml`
- `trafficprotectionpolicy-policy.yaml`
- `backendtlspolicy-policy.yaml`

16 create-rule `match` expressions updated total. Create rules with existing trailing `has(...)`/`size(...)` clauses keep those clauses; the outcome guard is appended after them. Delete/update/patch rules are untouched.

Policies ship as raw YAML referenced directly by `kustomization.yaml`; no generate/bundle step applies.

Tracks milo-os/activity#215.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
