### PR TITLE
test: e2e for TrafficProtectionPolicy Enforce serving traffic (#243)

### DIFF
--- a/test/e2e/trafficprotectionpolicy-enforce/chainsaw-test.yaml
+++ b/test/e2e/trafficprotectionpolicy-enforce/chainsaw-test.yaml
@@ -22,9 +22,6 @@ spec:
     metadata:
       labels:
         meta.datumapis.com/upstream-cluster-name: e2e
-  bindings:
-    - name: hostname
-      value: (join('.', [$namespace, 'e2e.test']))
   steps:
     - name: Deploy a backend
       try:
@@ -72,6 +69,9 @@ spec:
                 availableReplicas: 1
 
     - name: Route through the WAF gateway with an Enforce policy
+      bindings:
+        - name: hostname
+          value: (join('.', [$namespace, 'e2e.test']))
       try:
         - apply:
             resource:
@@ -141,6 +141,9 @@ spec:
         not sufficient on its own — EG reports Programmed from its own
         translation, independent of Envoy's xDS ACK — so this asserts on the
         wire.
+      bindings:
+        - name: hostname
+          value: (join('.', [$namespace, 'e2e.test']))
       try:
         - script:
             env:

--- a/test/e2e/trafficprotectionpolicy-enforce/chainsaw-test.yaml
+++ b/test/e2e/trafficprotectionpolicy-enforce/chainsaw-test.yaml
@@ -1,0 +1,161 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: trafficprotectionpolicy-enforce-serves-traffic
+# Regression for issue #243: a TrafficProtectionPolicy in Enforce mode must not
+# take the gateway offline. The branded error page NSO injects into Envoy's
+# local_reply_config is a SubstitutionFormatString, so an unescaped '%' in the
+# page (e.g. CSS "height: 100%") makes Envoy reject the whole listener and, with
+# failOpen:false, drops the xDS update fleet-wide — every request then fails
+# with an empty reply instead of the backend's 200.
+#
+# Precondition: the downstream (nso-infra) must have the WAF data plane wired up
+# (extension-server + the extensionManager Envoy Gateway registered on the
+# `datum-downstream-gateway` GatewayClass, with the Coraza filter). The stock
+# `make prepare-infra-cluster` does NOT install this; this test is skipped by
+# CI environments without it (the Gateway never reaches Programmed=True).
+spec:
+  cluster: nso-infra
+  # EG only reconciles namespaces carrying this label.
+  namespaceTemplate:
+    metadata:
+      labels:
+        meta.datumapis.com/upstream-cluster-name: e2e
+  bindings:
+    - name: hostname
+      value: (join('.', [$namespace, 'e2e.test']))
+  steps:
+    - name: Deploy a backend
+      try:
+        - apply:
+            resource:
+              apiVersion: apps/v1
+              kind: Deployment
+              metadata:
+                name: echo
+              spec:
+                replicas: 1
+                selector:
+                  matchLabels:
+                    app: echo
+                template:
+                  metadata:
+                    labels:
+                      app: echo
+                  spec:
+                    containers:
+                      - name: echo
+                        image: hashicorp/http-echo:1.0
+                        args: ["-text=hello from backend", "-listen=:8080"]
+                        ports:
+                          - containerPort: 8080
+        - apply:
+            resource:
+              apiVersion: v1
+              kind: Service
+              metadata:
+                name: echo
+              spec:
+                selector:
+                  app: echo
+                ports:
+                  - port: 80
+                    targetPort: 8080
+        - assert:
+            resource:
+              apiVersion: apps/v1
+              kind: Deployment
+              metadata:
+                name: echo
+              status:
+                availableReplicas: 1
+
+    - name: Route through the WAF gateway with an Enforce policy
+      try:
+        - apply:
+            resource:
+              apiVersion: gateway.networking.k8s.io/v1
+              kind: Gateway
+              metadata:
+                name: waf-gw
+              spec:
+                gatewayClassName: datum-downstream-gateway
+                listeners:
+                  - name: http
+                    protocol: HTTP
+                    port: 80
+                    hostname: ($hostname)
+                    allowedRoutes:
+                      namespaces:
+                        from: Same
+        - apply:
+            resource:
+              apiVersion: gateway.networking.k8s.io/v1
+              kind: HTTPRoute
+              metadata:
+                name: echo
+              spec:
+                parentRefs:
+                  - name: waf-gw
+                hostnames:
+                  - ($hostname)
+                rules:
+                  - matches:
+                      - path:
+                          type: PathPrefix
+                          value: /
+                    backendRefs:
+                      - name: echo
+                        port: 80
+        - apply:
+            resource:
+              apiVersion: networking.datumapis.com/v1alpha
+              kind: TrafficProtectionPolicy
+              metadata:
+                name: enforce-waf
+              spec:
+                mode: Enforce
+                targetRefs:
+                  - group: gateway.networking.k8s.io
+                    kind: Gateway
+                    name: waf-gw
+                ruleSets:
+                  - type: OWASPCoreRuleSet
+                    owaspCoreRuleSet: {}
+        - assert:
+            resource:
+              apiVersion: gateway.networking.k8s.io/v1
+              kind: Gateway
+              metadata:
+                name: waf-gw
+              status:
+                (conditions[?type == 'Programmed']):
+                  - status: "True"
+
+    - name: Benign traffic must reach the backend (not an empty/5xx reply)
+      description: >
+        Probe the downstream Envoy via the kind hostPort (30080). Before the fix
+        the listener is rejected and curl returns 000 / empty reply; after the
+        fix a benign GET returns the backend's 200. Gateway.status.Programmed is
+        not sufficient on its own — EG reports Programmed from its own
+        translation, independent of Envoy's xDS ACK — so this asserts on the
+        wire.
+      try:
+        - script:
+            env:
+              - name: HOSTNAME
+                value: ($hostname)
+            content: |
+              set -u
+              for i in $(seq 1 30); do
+                code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 5 \
+                  -H "Host: ${HOSTNAME}" http://localhost:30080/) || code=000
+                echo "attempt ${i}: HTTP ${code}"
+                if [ "${code}" = "200" ]; then
+                  exit 0
+                fi
+                sleep 3
+              done
+              echo "benign request never returned 200 (issue #243 regression)"
+              exit 1


### PR DESCRIPTION
## What

Chainsaw e2e regression for #243. Deploys a backend, a Gateway on the WAF `datum-downstream-gateway` class with an HTTPRoute, and a `TrafficProtectionPolicy` in `Enforce` mode, then probes the downstream Envoy over the wire and asserts a benign `GET` returns **200** — not the empty/5xx reply the unescaped error-page body produces.

`Gateway.status.Programmed` alone is insufficient: Envoy Gateway reports it from its own translation, independent of Envoy's xDS ACK. So the test asserts on an actual HTTP response.

## Precondition

Requires the WAF data plane on the downstream cluster (extension-server + the extensionManager Envoy Gateway registered on the `datum-downstream-gateway` class + the Coraza filter). Stock `make prepare-infra-cluster` does not install this; environments without it skip via the unmet `Programmed` assertion.

## Proof (this exact test, same fresh-fleet harness, only the operator image differs)

- ❌ **Negative — pre-fix image:** TPP Enforce → `HTTP 000` empty reply, test **FAILS** → https://gist.github.com/ecv/e47733b657475887c4c29cced339512a
- ✅ **Positive — fixed image (#244):** TPP Enforce → `HTTP 200`, test **PASSES** → https://gist.github.com/ecv/4c601d3d96fd5b317c5f3b814bbdd510

The fix is in #244.

Refs #243.
