### PR TITLE
fix: clone RouteBaseDirectives before per-policy append (#246)

### DIFF
--- a/internal/controller/trafficprotectionpolicy_controller.go
+++ b/internal/controller/trafficprotectionpolicy_controller.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"slices"
 	"sort"
 	"strings"
 
@@ -1229,7 +1230,7 @@ func (r *TrafficProtectionPolicyReconciler) getCorazaDirectivesForTrafficProtect
 		secRuleEngine = "Off"
 	}
 
-	directives := r.Config.Gateway.Coraza.RouteBaseDirectives
+	directives := slices.Clone(r.Config.Gateway.Coraza.RouteBaseDirectives)
 
 	directives = append(directives, fmt.Sprintf("SecRuleEngine %s", secRuleEngine))
 

--- a/internal/controller/trafficprotectionpolicy_controller_test.go
+++ b/internal/controller/trafficprotectionpolicy_controller_test.go
@@ -992,6 +992,36 @@ func TestGetCorazaDirectivesForTrafficProtectionPolicy(t *testing.T) {
 	}
 }
 
+func TestGetCorazaDirectivesDoesNotAliasRouteBaseDirectives(t *testing.T) {
+	base := make([]string, 2, 8)
+	base[0] = "Include @crs-setup-conf"
+	base[1] = "Include @recommended-conf"
+
+	operatorConfig := config.NetworkServicesOperator{
+		Gateway: config.GatewayConfig{
+			Coraza: config.CorazaConfig{RouteBaseDirectives: base},
+		},
+	}
+	reconciler := &TrafficProtectionPolicyReconciler{Config: operatorConfig}
+
+	enforce := reconciler.getCorazaDirectivesForTrafficProtectionPolicy(&policyContext{ptr.To(
+		newTrafficProtectionPolicy("default", "tpp-enforce", func(tpp *networkingv1alpha.TrafficProtectionPolicy) {
+			tpp.Spec.Mode = networkingv1alpha.TrafficProtectionPolicyEnforce
+		}),
+	)})
+	assert.Contains(t, enforce, "SecRuleEngine On")
+
+	reconciler.getCorazaDirectivesForTrafficProtectionPolicy(&policyContext{ptr.To(
+		newTrafficProtectionPolicy("default", "tpp-observe"),
+	)})
+
+	assert.Contains(t, enforce, "SecRuleEngine On",
+		"second policy leaked into the first via a shared RouteBaseDirectives backing array")
+	assert.EqualValues(t, []string{"Include @crs-setup-conf", "Include @recommended-conf"},
+		reconciler.Config.Gateway.Coraza.RouteBaseDirectives,
+		"shared base directives were mutated")
+}
+
 // nolint:unparam
 func newTrafficProtectionPolicy(
 	namespace,


### PR DESCRIPTION
## What

`getCorazaDirectivesForTrafficProtectionPolicy` seeded its per-policy directive list by **aliasing** the shared `RouteBaseDirectives` slice, then `append`ed to it. With spare capacity (`cap > len`) the append writes into the shared backing array — per-policy directives leak into the base seen by other policies.

## Fix

```go
directives := slices.Clone(r.Config.Gateway.Coraza.RouteBaseDirectives)
```

Defensive copy before appending, matching the existing safe precedent at `internal/extensionserver/cache/index.go:248` (`make`+`copy`).

## Impact

Latent/dormant today — the builder is reached only under `IsEPPEmissionEnabled()`, off by default (Coraza injected via the extension server's `PostTranslateModify`, not EnvoyPatchPolicies). Fixes the corruption pre-emptively so enabling EPP emission doesn't ship a cross-policy config bug: `SecRuleEngine On/DetectionOnly/Off`, score thresholds, and rule removals could bleed across policies (order- and capacity-dependent).

## Tests

`TestGetCorazaDirectivesDoesNotAliasRouteBaseDirectives` — seeds the shared base slice with spare capacity, builds an Enforce policy, then builds a second Observe policy and asserts the first's `SecRuleEngine On` was not overwritten to `DetectionOnly`.

Confirmed to fail on the aliased code (the leak reproduces exactly) and pass with `slices.Clone`:

```
--- FAIL: TestGetCorazaDirectivesDoesNotAliasRouteBaseDirectives
    ... does not contain "SecRuleEngine On"
    second policy leaked into the first via a shared RouteBaseDirectives backing array
```

## Verification

- `go build ./internal/controller/...` — clean
- `go vet ./internal/controller/...` — clean
- `go test ./internal/controller/ -run TestGetCorazaDirectives` — ok

Fixes #246. Related: #242.
