### PR TITLE
fix: reject inverted TrafficProtectionPolicy paranoia levels at admission

### DIFF
--- a/api/v1alpha/trafficprotectionpolicy_types.go
+++ b/api/v1alpha/trafficprotectionpolicy_types.go
@@ -110,6 +110,7 @@ type OWASPCRS struct {
 	RuleExclusions *OWASPRuleExclusions `json:"ruleExclusions,omitempty"`
 }
 
+// +kubebuilder:validation:XValidation:message="detection paranoia level must be greater than or equal to blocking paranoia level",rule="self.detection >= self.blocking"
 type ParanoiaLevels struct {
 	// Blocking specifies the paranoia level for blocking requests or responses.
 	//

--- a/config/crd/bases/networking.datumapis.com_trafficprotectionpolicies.yaml
+++ b/config/crd/bases/networking.datumapis.com_trafficprotectionpolicies.yaml
@@ -89,6 +89,10 @@ spec:
                               minimum: 1
                               type: integer
                           type: object
+                          x-kubernetes-validations:
+                          - message: detection paranoia level must be greater than
+                              or equal to blocking paranoia level
+                            rule: self.detection >= self.blocking
                         ruleExclusions:
                           description: |-
                             RuleExclusions can be used to disable specific OWASP ModSecurity Rules.

--- a/docs/api/trafficprotectionpolicies.md
+++ b/docs/api/trafficprotectionpolicies.md
@@ -191,6 +191,7 @@ Core Rule Set (CRS).
           ParanoiaLevels specifies the OWASP ModSecurity Core Rule Set (CRS)
 paranoia levels to use.<br/>
           <br/>
+            <i>Validations</i>:<li>self.detection >= self.blocking: detection paranoia level must be greater than or equal to blocking paranoia level</li>
             <i>Default</i>: map[]<br/>
         </td>
         <td>false</td>

--- a/test/e2e/trafficprotectionpolicy-paranoia-validation/chainsaw-test.yaml
+++ b/test/e2e/trafficprotectionpolicy-paranoia-validation/chainsaw-test.yaml
@@ -1,0 +1,92 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: trafficprotectionpolicy-paranoia-validation
+# Regression for issue #250: a TrafficProtectionPolicy whose blocking paranoia
+# level exceeds its detection paranoia level is an illegal CRS configuration
+# (CRS rule 901500 denies every request with HTTP 500). The CRD now carries a
+# CEL rule requiring detection >= blocking, so the illegal combination must be
+# rejected at admission rather than silently 500ing all traffic.
+spec:
+  cluster: nso-standard
+  steps:
+    - name: Reject blocking > detection at admission
+      try:
+        - apply:
+            expect:
+              - check:
+                  ($error != null): true
+            resource:
+              apiVersion: networking.datumapis.com/v1alpha
+              kind: TrafficProtectionPolicy
+              metadata:
+                name: inverted-paranoia
+              spec:
+                mode: Enforce
+                targetRefs:
+                  - group: gateway.networking.k8s.io
+                    kind: Gateway
+                    name: waf-gw
+                ruleSets:
+                  - type: OWASPCoreRuleSet
+                    owaspCoreRuleSet:
+                      paranoiaLevels:
+                        blocking: 2
+                        detection: 1
+
+    - name: Reject blocking set with detection defaulted at admission
+      try:
+        - apply:
+            expect:
+              - check:
+                  ($error != null): true
+            resource:
+              apiVersion: networking.datumapis.com/v1alpha
+              kind: TrafficProtectionPolicy
+              metadata:
+                name: default-detection-paranoia
+              spec:
+                mode: Enforce
+                targetRefs:
+                  - group: gateway.networking.k8s.io
+                    kind: Gateway
+                    name: waf-gw
+                ruleSets:
+                  - type: OWASPCoreRuleSet
+                    owaspCoreRuleSet:
+                      paranoiaLevels:
+                        blocking: 2
+
+    - name: Accept detection >= blocking
+      try:
+        - apply:
+            resource:
+              apiVersion: networking.datumapis.com/v1alpha
+              kind: TrafficProtectionPolicy
+              metadata:
+                name: valid-paranoia
+              spec:
+                mode: Enforce
+                targetRefs:
+                  - group: gateway.networking.k8s.io
+                    kind: Gateway
+                    name: waf-gw
+                ruleSets:
+                  - type: OWASPCoreRuleSet
+                    owaspCoreRuleSet:
+                      paranoiaLevels:
+                        blocking: 2
+                        detection: 3
+      catch:
+        - delete:
+            ref:
+              apiVersion: networking.datumapis.com/v1alpha
+              kind: TrafficProtectionPolicy
+              name: valid-paranoia
+      finally:
+        - delete:
+            ref:
+              apiVersion: networking.datumapis.com/v1alpha
+              kind: TrafficProtectionPolicy
+              name: valid-paranoia


### PR DESCRIPTION
## Summary

Fixes #250 via **option 1** (CEL admission validation) from the issue's root-cause comment.

A `TrafficProtectionPolicy` whose OWASP CRS **blocking** paranoia level exceeds its **detection** paranoia level is an illegal CRS configuration. CRS rule **901500** fails closed and denies every request at phase 1 with **HTTP 500** before any attack evaluation, so a misconfigured policy silently 500s 100% of traffic to the protected route. Because `blocking` and `detection` were validated independently (each `1..4`, default `1`), setting `blocking: 2` while leaving `detection` at its default `1` was admissible.

## Change

- Add a CEL `XValidation` rule on `ParanoiaLevels` requiring `self.detection >= self.blocking`, so the illegal combination is **rejected at write time** (fail-closed, no runtime surprise).
- Regenerate CRD and API reference docs.

## Test

- e2e regression `test/e2e/trafficprotectionpolicy-paranoia-validation/` asserts admission:
  - rejects `blocking: 2 / detection: 1`
  - rejects `blocking: 2` with `detection` defaulted
  - accepts `detection >= blocking`

CEL not live-tested locally (kind clusters were stopped); chainsaw test guards CI.

## Companion PR

This is the preferred fail-closed fix. Companion #252 implements **option 3** (controller status condition) as defense-in-depth for already-persisted policies CEL cannot re-validate. The two are complementary and can merge independently.