### PR TITLE
fix: flag inverted TrafficProtectionPolicy paranoia levels via status condition

### DIFF
--- a/internal/controller/trafficprotectionpolicy_controller.go
+++ b/internal/controller/trafficprotectionpolicy_controller.go
@@ -796,6 +796,17 @@ func (r *TrafficProtectionPolicyReconciler) processTrafficProtectionPolicyForHTT
 		route.attachedToRouteRules.Insert(routeRuleName)
 	}
 
+	if resolveErr := paranoiaLevelsResolveError(policy); resolveErr != nil {
+		gatewaystatus.SetResolveErrorForPolicyAncestor(
+			&policy.Status.PolicyStatus,
+			ancestorRef,
+			string(r.Config.Gateway.ControllerName),
+			policy.Generation,
+			resolveErr,
+		)
+		return policyAttachments
+	}
+
 	gatewaystatus.SetConditionForPolicyAncestor(&policy.Status.PolicyStatus,
 		ancestorRef,
 		string(r.Config.Gateway.ControllerName),
@@ -931,6 +942,17 @@ func (r *TrafficProtectionPolicyReconciler) processTrafficProtectionPolicyForGat
 			gateway.attachedToListeners = make(sets.Set[string])
 		}
 		gateway.attachedToListeners.Insert(listenerName)
+	}
+
+	if resolveErr := paranoiaLevelsResolveError(policy); resolveErr != nil {
+		gatewaystatus.SetResolveErrorForPolicyAncestor(
+			&policy.Status.PolicyStatus,
+			ancestorRef,
+			string(r.Config.Gateway.ControllerName),
+			policy.Generation,
+			resolveErr,
+		)
+		return policyAttachments
 	}
 
 	gatewaystatus.SetConditionForPolicyAncestor(&policy.Status.PolicyStatus,
@@ -1206,6 +1228,28 @@ func getVHostConstraintForGateway(namespace string, gateway *gatewayv1.Gateway) 
 		namespace,
 		gateway.Name,
 	)
+}
+
+// paranoiaLevelsResolveError returns a resolve error when a policy's OWASP CRS
+// paranoia levels are inverted (detection below blocking). CRS rule 901500 fails
+// closed on this configuration and denies every request with HTTP 500 before any
+// attack evaluation, so the policy must not be attached.
+func paranoiaLevelsResolveError(policy *policyContext) *gatewaystatus.PolicyResolveError {
+	for _, ruleSet := range policy.Spec.RuleSets {
+		if ruleSet.Type != networkingv1alpha.TrafficProtectionPolicyOWASPCoreRuleSet {
+			continue
+		}
+		levels := ruleSet.OWASPCoreRuleSet.ParanoiaLevels
+		if levels.Detection < levels.Blocking {
+			return &gatewaystatus.PolicyResolveError{
+				Reason: gatewayv1.PolicyReasonInvalid,
+				Message: fmt.Sprintf(
+					"OWASPCoreRuleSet detection paranoia level (%d) must be greater than or equal to blocking paranoia level (%d); this is an illegal CRS configuration that would deny all traffic with HTTP 500",
+					levels.Detection, levels.Blocking),
+			}
+		}
+	}
+	return nil
 }
 
 func (r *TrafficProtectionPolicyReconciler) getCorazaDirectivesForTrafficProtectionPolicy(

--- a/internal/controller/trafficprotectionpolicy_controller_test.go
+++ b/internal/controller/trafficprotectionpolicy_controller_test.go
@@ -518,6 +518,43 @@ func TestProcessTrafficProtectionPolicyForHTTPRoute(t *testing.T) {
 				}
 			},
 		},
+		{
+			name: "inverted paranoia levels rejected",
+			policy: &policyContext{
+				TrafficProtectionPolicy: ptr.To(newTrafficProtectionPolicy("default", "tpp-1", func(tpp *networkingv1alpha.TrafficProtectionPolicy) {
+					tpp.Spec.RuleSets[0].OWASPCoreRuleSet.ParanoiaLevels = networkingv1alpha.ParanoiaLevels{
+						Blocking:  2,
+						Detection: 1,
+					}
+				})),
+			},
+			routeMap: map[client.ObjectKey]*policyRouteTargetContext{
+				{Namespace: "default", Name: "route-1"}: {
+					HTTPRoute: newHTTPRoute("default", "route-1"),
+				},
+			},
+			gatewayMap: map[client.ObjectKey]*policyGatewayTargetContext{
+				{Namespace: "default", Name: "gateway-1"}: {
+					Gateway: ptr.To(newGatewayFunc("default", "gateway-1")),
+				},
+			},
+			targetRef: gatewayv1alpha2.LocalPolicyTargetReferenceWithSectionName{
+				LocalPolicyTargetReference: gatewayv1.LocalPolicyTargetReference{
+					Kind: "HTTPRoute",
+					Name: "route-1",
+				},
+			},
+			assert: func(t *testContext, policyAttachments []policyAttachment) {
+				assert.Empty(t, policyAttachments, "invalid policy must not be attached")
+				if assert.Len(t, t.policy.Status.Ancestors, 1) {
+					if assert.Len(t, t.policy.Status.Ancestors[0].Conditions, 1) {
+						cond := t.policy.Status.Ancestors[0].Conditions[0]
+						assert.Equal(t, string(gatewayv1.PolicyReasonInvalid), cond.Reason, "expected invalid reason")
+						assert.Equal(t, metav1.ConditionFalse, cond.Status, "expected Accepted=False")
+					}
+				}
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -649,6 +686,38 @@ func TestProcessTrafficProtectionPolicyForGateway(t *testing.T) {
 				}
 			},
 		},
+		{
+			name: "inverted paranoia levels rejected",
+			policy: &policyContext{
+				TrafficProtectionPolicy: ptr.To(newTrafficProtectionPolicy("default", "tpp-1", func(tpp *networkingv1alpha.TrafficProtectionPolicy) {
+					tpp.Spec.RuleSets[0].OWASPCoreRuleSet.ParanoiaLevels = networkingv1alpha.ParanoiaLevels{
+						Blocking:  2,
+						Detection: 1,
+					}
+				})),
+			},
+			gatewayMap: map[client.ObjectKey]*policyGatewayTargetContext{
+				{Namespace: "default", Name: "gateway-1"}: {
+					Gateway: ptr.To(newGatewayFunc("default", "gateway-1")),
+				},
+			},
+			targetRef: gatewayv1alpha2.LocalPolicyTargetReferenceWithSectionName{
+				LocalPolicyTargetReference: gatewayv1.LocalPolicyTargetReference{
+					Kind: "Gateway",
+					Name: "gateway-1",
+				},
+			},
+			assert: func(t *testContext, policyAttachments []policyAttachment) {
+				assert.Empty(t, policyAttachments, "invalid policy must not be attached")
+				if assert.Len(t, t.policy.Status.Ancestors, 1) {
+					if assert.Len(t, t.policy.Status.Ancestors[0].Conditions, 1) {
+						cond := t.policy.Status.Ancestors[0].Conditions[0]
+						assert.Equal(t, string(gatewayv1.PolicyReasonInvalid), cond.Reason, "expected invalid reason")
+						assert.Equal(t, metav1.ConditionFalse, cond.Status, "expected Accepted=False")
+					}
+				}
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -671,6 +740,42 @@ func TestProcessTrafficProtectionPolicyForGateway(t *testing.T) {
 
 			tt.assert(testCtx, attachments)
 
+		})
+	}
+}
+
+func TestParanoiaLevelsResolveError(t *testing.T) {
+	tests := []struct {
+		name      string
+		blocking  int
+		detection int
+		wantError bool
+	}{
+		{name: "equal levels", blocking: 2, detection: 2, wantError: false},
+		{name: "higher detection", blocking: 1, detection: 3, wantError: false},
+		{name: "detection below blocking", blocking: 2, detection: 1, wantError: true},
+		{name: "defaulted detection below blocking", blocking: 4, detection: 1, wantError: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			policy := &policyContext{
+				TrafficProtectionPolicy: ptr.To(newTrafficProtectionPolicy("default", "tpp-1", func(tpp *networkingv1alpha.TrafficProtectionPolicy) {
+					tpp.Spec.RuleSets[0].OWASPCoreRuleSet.ParanoiaLevels = networkingv1alpha.ParanoiaLevels{
+						Blocking:  tt.blocking,
+						Detection: tt.detection,
+					}
+				})),
+			}
+
+			resolveErr := paranoiaLevelsResolveError(policy)
+			if tt.wantError {
+				if assert.NotNil(t, resolveErr) {
+					assert.Equal(t, gatewayv1.PolicyReasonInvalid, resolveErr.Reason)
+				}
+			} else {
+				assert.Nil(t, resolveErr)
+			}
 		})
 	}
 }


### PR DESCRIPTION
## Summary

Addresses #250 via **option 3** (controller status condition, defense-in-depth) from the issue's root-cause comment.

A `TrafficProtectionPolicy` whose OWASP CRS **detection** paranoia level is below its **blocking** paranoia level is illegal: CRS rule **901500** fails closed and denies every request at phase 1 with **HTTP 500** before any attack evaluation. Such a policy silently 500s 100% of traffic with no signal to the tenant about why.

## Change

Reject the policy during reconciliation:
- Set `Accepted=False` with reason `Invalid` on the affected ancestor.
- **Skip attachment** so the broken directives are never emitted to the data plane.
- Also surfaces already-persisted policies carrying the inverted configuration.

## Test

- `TestParanoiaLevelsResolveError` — guard, 4 cases (equal / higher detection / inverted / defaulted inverted).
- inverted-paranoia case added to both `TestProcessTrafficProtectionPolicyForHTTPRoute` and `TestProcessTrafficProtectionPolicyForGateway`, asserting `Accepted=False/Invalid` and no attachment.

## Companion PR

Companion to #251, which implements **option 1** (CEL admission validation, the preferred fail-closed fix). CEL only validates on write; this guard catches policies already stored with the bad config and gives tenants an actionable `Accepted=False` reason. The two are complementary and can merge independently.