### PR TITLE
docs: delineate cert health-gating from re-issuance

### DIFF
--- a/internal/controller/gateway_controller.go
+++ b/internal/controller/gateway_controller.go
@@ -276,6 +276,11 @@ func (r *GatewayReconciler) ensureDownstreamGateway(
 
 	// Evaluate certificate health once so the listener we propagate and the
 	// status we report to the user can never disagree.
+	//
+	// Deliberately separate from fast-track re-issuance (see
+	// reissueFailedCertificate): this path is read-only and gates on any
+	// unusable cert, re-issuance mutates and fires only on cert-manager
+	// hard-fail (LastFailureTime). See #260.
 	listenerCertHealth := r.evaluateListenerCertHealth(
 		ctx,
 		downstreamClient,
@@ -941,6 +946,11 @@ func (r *GatewayReconciler) ensureListenerCertificates(
 
 		// Check if an existing Certificate is stuck in a failed state and
 		// should be deleted so we can recreate it fresh on the next reconcile.
+		//
+		// Deliberately separate from health-gating (see
+		// evaluateListenerCertHealth): this triggers only on cert-manager
+		// hard-fail (LastFailureTime), not on every unhealthy cert, since
+		// expired/missing certs recover via renewal or the isNew path. See #260.
 		if !isNew {
 			requeueAfter, gwChanged := r.reissueFailedCertificate(ctx, cert, certName, downstreamGateway, downstreamClient)
 			if gwChanged {


### PR DESCRIPTION
## What

Records the boundary between the two cert-failure paths in the gateway controller with a short comment at each call site. No behavior change — comments only.

- **Health-gating** (`evaluateListenerCertHealth`, call site ~line 279): read-only, gates a listener on *any* unusable cert (`Ready!=True`, not-yet-valid, expired, missing secret, corrupt keypair).
- **Fast-track re-issuance** (`reissueFailedCertificate`, call site ~line 950): mutates (delete + gateway annotation bump), fires *only* on cert-manager hard-fail (`LastFailureTime`). Expired/missing certs recover via renewal or the ensure loop's `isNew` path instead.

## Why

Resolves the decision in #260 — keep the two paths delineated rather than unified behind a single failure detector. Full rationale and the stuck-state verification are recorded on that issue. Summary:

- The two paths key off **different signals by design**; only the narrow `LastFailureTime` signal should trigger the destructive delete-recreate.
- Health stays read-only (drives customer-facing status + metrics); re-issuance stays the sole mutator.
- Verified no truly-stuck state exists within NSO's model at the pinned cert-manager v1.17.2 (every unhealthy branch has a recovery owner).

## Test

`go build` + relevant `internal/controller` tests pass; no logic touched.

Closes #260