### PR TITLE
fix: pin e2e coraza-waf to a pullable fixed image

### DIFF
--- a/config/dev/downstream_resources/downstream-gateway.yaml
+++ b/config/dev/downstream_resources/downstream-gateway.yaml
@@ -63,7 +63,7 @@ spec:
               mountPath: /opt/coraza-waf
         initContainers:
           - name: coraza-waf
-            image: coraza-waf:v1.1.1-dev2
+            image: ghcr.io/datum-labs/coraza-envoy-go-filter/coraza-waf:v1.3.0-alpha10
             imagePullPolicy: IfNotPresent
             command:
               - cp


### PR DESCRIPTION
## What

Point the downstream-gateway e2e coraza-waf initContainer at a real, published,
fixed image:

```diff
- image: coraza-waf:v1.1.1-dev2
+ image: ghcr.io/datum-labs/coraza-envoy-go-filter/coraza-waf:v1.3.0-alpha10
```

## Why

The old pin was a **bare** tag (`coraza-waf:v1.1.1-dev2`) — no registry, so CI
can't pull it — and predates the TPP Enforce fixes. The downstream Envoy
listener never programs:

```
status.(conditions[?type == 'Programmed'])[0].status: Invalid value: "Unknown": Expected value: "True"
```

So `chainsaw/trafficprotectionpolicy-enforce-serves-traffic` fails on `main`
and gates **every** open PR (the whole `E2E Tests` workflow is red).

`v1.3.0-alpha10` carries the response-phase / listener fixes tracked in the
edge repo (https://github.com/datum-cloud/infra/issues/3319,
https://github.com/datum-cloud/infra/issues/3324,
https://github.com/datum-cloud/infra/issues/3329).

## Verification

- [ ] `E2E Tests` green
- [ ] `trafficprotectionpolicy-enforce-serves-traffic` passes; downstream Gateway `Programmed=True`

Tracked by #263. Root bug #242.