### PR TITLE
test: prove activity-policy audit rules gate on 2xx outcome

### DIFF
--- a/config/milo/activity/policies/httpproxy-policy.yaml
+++ b/config/milo/activity/policies/httpproxy-policy.yaml
@@ -37,10 +37,10 @@ spec:
 
     # HTTPProxy update with spec.hostnames available - excludes status subresource
     - name: update
-      match: "!audit.user.username.startsWith('system:') && audit.verb in ['update', 'patch'] && !has(audit.objectRef.subresource) && has(audit.requestObject.spec) && has(audit.requestObject.spec.hostnames) && size(audit.requestObject.spec.hostnames) > 0"
+      match: "!audit.user.username.startsWith('system:') && audit.verb in ['update', 'patch'] && !has(audit.objectRef.subresource) && has(audit.requestObject.spec) && has(audit.requestObject.spec.hostnames) && size(audit.requestObject.spec.hostnames) > 0 && audit.responseStatus.code >= 200 && audit.responseStatus.code < 300"
       summary: "{{ actor }} updated HTTP proxy {{ link(string(audit.requestObject.spec.hostnames[0]), audit.objectRef) }}"
 
     # HTTPProxy update fallback (no spec or no hostnames)
     - name: update-fallback
-      match: "!audit.user.username.startsWith('system:') && audit.verb in ['update', 'patch'] && !has(audit.objectRef.subresource)"
+      match: "!audit.user.username.startsWith('system:') && audit.verb in ['update', 'patch'] && !has(audit.objectRef.subresource) && audit.responseStatus.code >= 200 && audit.responseStatus.code < 300"
       summary: "{{ actor }} updated {{ link('an HTTP proxy', audit.objectRef) }}"

--- a/config/milo/activity/policies/httproute-policy.yaml
+++ b/config/milo/activity/policies/httproute-policy.yaml
@@ -36,10 +36,10 @@ spec:
 
     # HTTPRoute update with spec.hostnames available - excludes status subresource
     - name: update
-      match: "!audit.user.username.startsWith('system:') && audit.verb in ['update', 'patch'] && !has(audit.objectRef.subresource) && has(audit.requestObject.spec) && has(audit.requestObject.spec.hostnames) && size(audit.requestObject.spec.hostnames) > 0"
+      match: "!audit.user.username.startsWith('system:') && audit.verb in ['update', 'patch'] && !has(audit.objectRef.subresource) && has(audit.requestObject.spec) && has(audit.requestObject.spec.hostnames) && size(audit.requestObject.spec.hostnames) > 0 && audit.responseStatus.code >= 200 && audit.responseStatus.code < 300"
       summary: "{{ actor }} updated HTTP route {{ link(string(audit.requestObject.spec.hostnames[0]), audit.objectRef) }}"
 
     # HTTPRoute update fallback (no spec or no hostnames)
     - name: update-fallback
-      match: "!audit.user.username.startsWith('system:') && audit.verb in ['update', 'patch'] && !has(audit.objectRef.subresource)"
+      match: "!audit.user.username.startsWith('system:') && audit.verb in ['update', 'patch'] && !has(audit.objectRef.subresource) && audit.responseStatus.code >= 200 && audit.responseStatus.code < 300"
       summary: "{{ actor }} updated {{ link('an HTTP route', audit.objectRef) }}"

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/envoyproxy/go-control-plane/envoy v1.37.1-0.20260409050421-3f47accd6e14
 	github.com/go-logr/logr v1.4.3
 	github.com/go-redis/redis/v7 v7.4.1
+	github.com/google/cel-go v0.26.0
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
 	github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus v1.1.0
@@ -43,6 +44,7 @@ require (
 	sigs.k8s.io/gateway-api v1.5.1
 	sigs.k8s.io/gateway-api/conformance v1.5.1
 	sigs.k8s.io/multicluster-runtime v0.23.3
+	sigs.k8s.io/yaml v1.6.0
 )
 
 require (
@@ -165,7 +167,6 @@ require (
 	github.com/golang-sql/sqlexp v0.1.0 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/btree v1.1.3 // indirect
-	github.com/google/cel-go v0.26.0 // indirect
 	github.com/google/gnostic-models v0.7.0 // indirect
 	github.com/google/go-containerregistry v0.21.6 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
@@ -319,5 +320,4 @@ require (
 	sigs.k8s.io/mcs-api v0.5.0 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.2 // indirect
-	sigs.k8s.io/yaml v1.6.0 // indirect
 )

--- a/test/activitypolicy/policies_test.go
+++ b/test/activitypolicy/policies_test.go
@@ -1,0 +1,224 @@
+package activitypolicy_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/google/cel-go/cel"
+	"sigs.k8s.io/yaml"
+)
+
+// These tests guard the ActivityPolicy audit rules under
+// config/milo/activity/policies against a single defect with two symptoms:
+// create/update rules that fire on FAILED (non-2xx) requests. On a rejected
+// request the audit responseObject is a metav1.Status, so a summary that
+// dereferences audit.responseObject.<leaf> throws and the event is lost to the
+// DLQ (DLQSlowLeak); the same rule also emits a false "created"/"updated"
+// activity for an attempt that never succeeded. The fix gates every create and
+// update rule's match on audit.responseStatus.code in [200,300).
+
+const policiesGlob = "../../config/milo/activity/policies/*-policy.yaml"
+
+type auditRule struct {
+	Name    string `json:"name"`
+	Match   string `json:"match"`
+	Summary string `json:"summary"`
+}
+
+type policy struct {
+	Metadata struct {
+		Name string `json:"name"`
+	} `json:"metadata"`
+	Spec struct {
+		AuditRules []auditRule `json:"auditRules"`
+	} `json:"spec"`
+}
+
+func loadPolicies(t *testing.T) []policy {
+	t.Helper()
+	paths, err := filepath.Glob(policiesGlob)
+	if err != nil {
+		t.Fatalf("glob %q: %v", policiesGlob, err)
+	}
+	if len(paths) == 0 {
+		t.Fatalf("no policy files matched %q", policiesGlob)
+	}
+	policies := make([]policy, 0, len(paths))
+	for _, p := range paths {
+		b, err := os.ReadFile(p)
+		if err != nil {
+			t.Fatalf("read %s: %v", p, err)
+		}
+		var pol policy
+		if err := yaml.Unmarshal(b, &pol); err != nil {
+			t.Fatalf("unmarshal %s: %v", p, err)
+		}
+		if pol.Metadata.Name == "" {
+			pol.Metadata.Name = filepath.Base(p)
+		}
+		policies = append(policies, pol)
+	}
+	return policies
+}
+
+// verbOf classifies a rule by the write verb its match targets.
+func verbOf(match string) string {
+	switch {
+	case strings.Contains(match, "audit.verb == 'create'"):
+		return "create"
+	case strings.Contains(match, "audit.verb in ['update', 'patch']"):
+		return "update"
+	case strings.Contains(match, "audit.verb == 'delete'"):
+		return "delete"
+	default:
+		return "other"
+	}
+}
+
+func gatesOn2xx(match string) bool {
+	return strings.Contains(match, "audit.responseStatus.code >= 200") &&
+		strings.Contains(match, "audit.responseStatus.code < 300")
+}
+
+func newEnv(t *testing.T) *cel.Env {
+	t.Helper()
+	env, err := cel.NewEnv(cel.Variable("audit", cel.DynType))
+	if err != nil {
+		t.Fatalf("cel env: %v", err)
+	}
+	return env
+}
+
+func evalMatch(t *testing.T, env *cel.Env, match string, audit map[string]any) bool {
+	t.Helper()
+	ast, iss := env.Compile(match)
+	if iss != nil && iss.Err() != nil {
+		t.Fatalf("compile %q: %v", match, iss.Err())
+	}
+	prg, err := env.Program(ast)
+	if err != nil {
+		t.Fatalf("program %q: %v", match, err)
+	}
+	out, _, err := prg.Eval(map[string]any{"audit": audit})
+	if err != nil {
+		t.Fatalf("eval %q: %v", match, err)
+	}
+	b, ok := out.Value().(bool)
+	if !ok {
+		t.Fatalf("match %q did not evaluate to bool, got %T", match, out.Value())
+	}
+	return b
+}
+
+// auditEvent builds an audit payload for the given verb and response code.
+// A 2xx response carries a real created/updated object; a non-2xx response
+// carries a metav1.Status (no metadata.name, no spec), as the API server sends
+// on a rejected write.
+func auditEvent(verb string, code int) map[string]any {
+	var responseObject map[string]any
+	if code >= 200 && code < 300 {
+		responseObject = map[string]any{
+			"metadata": map[string]any{"name": "obj-1"},
+			"spec": map[string]any{
+				"domainName": "example.datumchainsaw.art",
+				"hostnames":  []any{"example.datumchainsaw.art"},
+			},
+		}
+	} else {
+		responseObject = map[string]any{
+			"kind":       "Status",
+			"apiVersion": "v1",
+			"status":     "Failure",
+			"reason":     "Forbidden",
+			"code":       code,
+		}
+	}
+	return map[string]any{
+		"user": map[string]any{"username": "alice@example.com"},
+		"verb": verb,
+		"requestObject": map[string]any{
+			"spec": map[string]any{
+				"domainName": "example.datumchainsaw.art",
+				"hostnames":  []any{"example.datumchainsaw.art"},
+			},
+		},
+		"responseObject": responseObject,
+		"objectRef":      map[string]any{"name": "obj-1"},
+		"responseStatus": map[string]any{"code": code},
+	}
+}
+
+func failCodeFor(verb string) int {
+	if verb == "create" {
+		return 403
+	}
+	return 409
+}
+
+func successCodeFor(verb string) int {
+	if verb == "create" {
+		return 201
+	}
+	return 200
+}
+
+// Structural guard: every create/update rule must gate on a 2xx response.
+func TestCreateUpdateRulesGateOn2xx(t *testing.T) {
+	for _, pol := range loadPolicies(t) {
+		for _, r := range pol.Spec.AuditRules {
+			v := verbOf(r.Match)
+			if v != "create" && v != "update" {
+				continue
+			}
+			t.Run(pol.Metadata.Name+"/"+r.Name, func(t *testing.T) {
+				if !gatesOn2xx(r.Match) {
+					t.Errorf("%s rule %q (%s) is not gated on a 2xx response:\n  %s",
+						pol.Metadata.Name, r.Name, v, r.Match)
+				}
+			})
+		}
+	}
+}
+
+// Semantic guard: create/update rules must NOT match a failed request, and MUST
+// still match the successful one — the two properties that fix the DLQ leak and
+// the false-activity emission together.
+func TestCreateUpdateRulesFireOnlyOnSuccess(t *testing.T) {
+	env := newEnv(t)
+	for _, pol := range loadPolicies(t) {
+		for _, r := range pol.Spec.AuditRules {
+			v := verbOf(r.Match)
+			if v != "create" && v != "update" {
+				continue
+			}
+			t.Run(pol.Metadata.Name+"/"+r.Name, func(t *testing.T) {
+				if got := evalMatch(t, env, r.Match, auditEvent(v, failCodeFor(v))); got {
+					t.Errorf("%s rule %q matched a failed %s (code %d); it would DLQ / emit a false activity",
+						pol.Metadata.Name, r.Name, v, failCodeFor(v))
+				}
+				if got := evalMatch(t, env, r.Match, auditEvent(v, successCodeFor(v))); !got {
+					t.Errorf("%s rule %q did not match a successful %s (code %d); the gate broke the happy path",
+						pol.Metadata.Name, r.Name, v, successCodeFor(v))
+				}
+			})
+		}
+	}
+}
+
+// Every rule's match must compile — catches CEL typos before they reach milo.
+func TestAllMatchesCompile(t *testing.T) {
+	env := newEnv(t)
+	for _, pol := range loadPolicies(t) {
+		for _, r := range pol.Spec.AuditRules {
+			if strings.TrimSpace(r.Match) == "" {
+				t.Errorf("%s rule %q has an empty match", pol.Metadata.Name, r.Name)
+				continue
+			}
+			if _, iss := env.Compile(r.Match); iss != nil && iss.Err() != nil {
+				t.Errorf("%s rule %q match does not compile: %v", pol.Metadata.Name, r.Name, iss.Err())
+			}
+		}
+	}
+}


### PR DESCRIPTION
## What
Adds `test/activitypolicy` coverage for the ActivityPolicy audit rules under `config/milo/activity/policies`, proving the create/update rules gate on the request outcome:

- **structural** — every create/update rule's `match` gates on `responseStatus.code` in `[200,300)`
- **semantic (cel-go)** — each create/update rule matches a successful write and does **not** match a failed one
- **compile** — every rule `match` parses

## Why
Proves the fix behind the DLQ leak (responseObject deref on a `metav1.Status` from a rejected write) and the false "created"/"updated" activities emitted for failed attempts.

The tests surfaced a real gap and this PR closes it: `httpproxy` and `httproute` `update` / `update-fallback` rules were ungated (create-only in the 2xx-gate change; the broad update gating never touched those two policies), so failed updates still emitted false activities. Now gated like every other policy.

Promotes `cel-go` and `sigs.k8s.io/yaml` to direct deps.

Targets the consolidated fix branch (#230); to be merged into it before #230 opens for review.