### PR TITLE
test: add Network and NetworkContext lifecycle e2e

### DIFF
--- a/test/e2e/network-context-lifecycle/chainsaw-test.yaml
+++ b/test/e2e/network-context-lifecycle/chainsaw-test.yaml
@@ -1,0 +1,114 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: network-context-lifecycle
+spec:
+  cluster: nso-standard
+  steps:
+    - name: Create Network
+      try:
+        - create:
+            resource:
+              apiVersion: networking.datumapis.com/v1alpha
+              kind: Network
+              metadata:
+                name: test-cascade-network
+                namespace: default
+              spec:
+                ipam:
+                  mode: Auto
+
+    - name: Create NetworkBinding and assert NetworkContext is created
+      description: |
+        The binding controller creates a NetworkContext owned by the Network.
+        This ownership is what the Network finalizer relies on to garbage-collect
+        the context on delete.
+      try:
+        - create:
+            resource:
+              apiVersion: networking.datumapis.com/v1alpha
+              kind: NetworkBinding
+              metadata:
+                name: test-cascade-binding
+                namespace: default
+              spec:
+                network:
+                  name: test-cascade-network
+                location:
+                  name: test-location
+                  namespace: default
+        - assert:
+            resource:
+              apiVersion: networking.datumapis.com/v1alpha
+              kind: NetworkContext
+              metadata:
+                name: test-cascade-network-default-test-location
+                namespace: default
+                (length(ownerReferences[?kind == 'Network' && controller == `true`]) == `1`): true
+
+    - name: Mark NetworkContext as Programmed
+      description: |
+        A plugin is expected to program the context at its backend and set the
+        Programmed condition. No such plugin runs in the local harness, so the
+        condition is set directly. A kubectl command is used because Chainsaw
+        does not support updating subresources.
+        See https://github.com/kyverno/chainsaw/issues/300.
+      try:
+        - script:
+            content: |
+              kubectl -n default patch networkcontext test-cascade-network-default-test-location \
+                --subresource=status --type=merge \
+                -p '{"status":{"conditions":[{"type": "Programmed", "status": "True", "reason": "Test", "message": "test", "lastTransitionTime": "2025-02-24T23:59:09Z"}]}}'
+
+    - name: Assert NetworkContext becomes Ready
+      description: |
+        The networkcontext controller derives Ready from Programmed. This asserts
+        that transition, which no other e2e exercises.
+      try:
+        - assert:
+            timeout: 1m
+            resource:
+              apiVersion: networking.datumapis.com/v1alpha
+              kind: NetworkContext
+              metadata:
+                name: test-cascade-network-default-test-location
+                namespace: default
+              status:
+                (length(conditions[?type == 'Ready' && status == 'True']) == `1`): true
+
+    - name: Assert NetworkBinding becomes Ready
+      try:
+        - wait:
+            apiVersion: networking.datumapis.com/v1alpha
+            kind: NetworkBinding
+            name: test-cascade-binding
+            namespace: default
+            timeout: 1m
+            for:
+              condition:
+                name: Ready
+                value: 'true'
+
+    - name: Delete Network and assert cascade cleanup
+      description: |
+        Deleting the Network drives its finalizer to garbage-collect the owned
+        NetworkContext before releasing. The delete blocks until the Network is
+        gone, which can only happen after the context is removed; the script then
+        confirms the context is absent.
+      try:
+        - delete:
+            timeout: 1m
+            ref:
+              apiVersion: networking.datumapis.com/v1alpha
+              kind: Network
+              name: test-cascade-network
+              namespace: default
+        - script:
+            content: |
+              set -e
+              if kubectl -n default get networkcontext test-cascade-network-default-test-location 2>/dev/null; then
+                echo "NetworkContext still exists after Network deletion" >&2
+                exit 1
+              fi
+              echo "NetworkContext garbage-collected"

--- a/test/e2e/network-crud/chainsaw-test.yaml
+++ b/test/e2e/network-crud/chainsaw-test.yaml
@@ -1,0 +1,51 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: network-crud
+spec:
+  cluster: nso-standard
+  steps:
+    - name: Create Network
+      try:
+        - create:
+            resource:
+              apiVersion: networking.datumapis.com/v1alpha
+              kind: Network
+              metadata:
+                name: test-network-crud
+                namespace: default
+              spec:
+                ipam:
+                  mode: Auto
+
+    - name: Assert Network is admitted and finalized
+      description: |
+        NSO's network controller writes no readiness condition on a bare
+        Network; readiness is provider-driven and no provider runs in the local
+        kind harness. What NSO owns here is admission and the finalizer
+        lifecycle, so that is what this asserts.
+      try:
+        - assert:
+            timeout: 30s
+            resource:
+              apiVersion: networking.datumapis.com/v1alpha
+              kind: Network
+              metadata:
+                name: test-network-crud
+                namespace: default
+                finalizers:
+                  - networking.datumapis.com/network-controller
+
+    - name: Delete Network
+      description: |
+        Delete blocks until the object is gone, asserting the network controller
+        releases its finalizer (no NetworkContexts exist to garbage-collect).
+      try:
+        - delete:
+            timeout: 1m
+            ref:
+              apiVersion: networking.datumapis.com/v1alpha
+              kind: Network
+              name: test-network-crud
+              namespace: default


### PR DESCRIPTION
Rebase of #236 onto current `main`. The original branch was 57 commits behind and its green checks predate the prod-fidelity env (#276); this re-runs the same two tests against the current `task test-infra:test-e2e` two-cluster env.

## What

- `test/e2e/network-crud` — bare `Network` lifecycle: admission, the `networking.datumapis.com/network-controller` finalizer, clean deletion.
- `test/e2e/network-context-lifecycle` — builds the `Network` → `NetworkBinding` → `NetworkContext` chain, drives the context `Programmed`, asserts the controller derives `Ready`, asserts the `NetworkBinding` reaches `Ready`, then deletes the `Network` and asserts its finalizer cascade-deletes the owned `NetworkContext`.

## Compatibility with the current env

Both scenarios are control-plane-only and bind to the upstream alias `nso-standard` the env maps at invocation — no data-plane, no retired-bridge assumptions, nothing to provision downstream. `Programmed` is patched directly to stand in for the absent provider (same pattern as `networkbinding/ready-when-context-is-ready`). The `NetworkBinding` references `test-location` without creating a Location object; that is correct — `networkbinding_controller.go` copies the location reference into the `NetworkContext` and derives its name, it does not look up a Location.

## Verification

- Both tests `chainsaw lint` clean.
- E2E on this PR runs them against the current prod-fidelity env (the original #236 checks were from the pre-#276 harness).

Supersedes #236.