### PR TITLE
fix: put HTTPProxy Gateway creation on the fast path

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1115,6 +1115,13 @@ type HTTPProxyConfig struct {
 	// underlying Gateway for an HTTPProxy.
 	// +default="datum-external-global-proxy"
 	GatewayClassName gatewayv1.ObjectName `json:"gatewayClassName"`
+
+	// MaxConcurrentReconciles is the maximum number of concurrent HTTPProxy
+	// reconciliations. Higher values allow the controller to process
+	// HTTPProxies across multiple projects in parallel.
+	//
+	// +default=5
+	MaxConcurrentReconciles int `json:"maxConcurrentReconciles,omitempty"`
 }
 
 // +k8s:deepcopy-gen=true

--- a/internal/config/zz_generated.defaults.go
+++ b/internal/config/zz_generated.defaults.go
@@ -239,6 +239,9 @@ func SetObjectDefaults_NetworkServicesOperator(in *NetworkServicesOperator) {
 	if in.HTTPProxy.GatewayClassName == "" {
 		in.HTTPProxy.GatewayClassName = "datum-external-global-proxy"
 	}
+	if in.HTTPProxy.MaxConcurrentReconciles == 0 {
+		in.HTTPProxy.MaxConcurrentReconciles = 5
+	}
 	if in.Connector.LeaseDurationSeconds == 0 {
 		in.Connector.LeaseDurationSeconds = 30
 	}

--- a/internal/controller/httpproxy_controller.go
+++ b/internal/controller/httpproxy_controller.go
@@ -26,6 +26,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -125,7 +126,6 @@ func (r *HTTPProxyReconciler) Reconcile(ctx context.Context, req mcreconcile.Req
 		if err := cl.GetClient().Update(ctx, &httpProxy); err != nil {
 			return ctrl.Result{}, err
 		}
-		return ctrl.Result{}, nil
 	}
 
 	httpProxyCopy := httpProxy.DeepCopy()
@@ -599,7 +599,11 @@ func (r *HTTPProxyReconciler) SetupWithManager(mgr mcmanager.Manager) error {
 		builder = builder.WatchesRawSource(downstreamCertificateClusterSource)
 	}
 
-	return builder.Named("httpproxy").Complete(r)
+	return builder.
+		WithOptions(controller.TypedOptions[mcreconcile.Request]{
+			MaxConcurrentReconciles: r.Config.HTTPProxy.MaxConcurrentReconciles,
+		}).
+		Named("httpproxy").Complete(r)
 }
 
 // enqueueHTTPProxyForDownstreamCertificate returns a watch handler that enqueues


### PR DESCRIPTION
## Summary

When someone creates an HTTPProxy, nothing serves until its Gateway is created — and that first step was slow, and got slower under load. A fresh proxy's Gateway could take far longer to appear than the work itself warranted, and a burst of activity on one project could stall proxy setup for everyone else.

This puts that step on the fast path: proxies are now processed in parallel instead of one at a time, and each proxy's Gateway is created a step sooner.

## Test plan

- [x] Build, lint, and full test suite pass
- [ ] Downstream e2e sees faster, less bursty HTTPProxy setup

Related to #293
