### PR TITLE
feat: reject duplicate domain names on create

### DIFF
--- a/internal/webhook/v1alpha/domain_webhook.go
+++ b/internal/webhook/v1alpha/domain_webhook.go
@@ -64,19 +64,26 @@ func (v *DomainCustomValidator) ValidateCreate(ctx context.Context, domain *netw
 		return nil, fmt.Errorf("failed to list Domains in namespace %q: %w", domain.GetNamespace(), err)
 	}
 
-	target := normalizeHostname(domain.Spec.DomainName)
-	for _, d := range domains.Items {
-		if normalizeHostname(d.Spec.DomainName) == target {
-			gr := schema.GroupResource{Group: networkingv1alpha.GroupVersion.Group, Resource: domainResource}
-			return nil, apierrors.NewConflict(
-				gr,
-				domain.GetName(),
-				fmt.Errorf("domain resource with .spec.domainName %q already exists", domain.Spec.DomainName),
-			)
-		}
+	if duplicateDomainName(domains.Items, domain.Spec.DomainName) {
+		gr := schema.GroupResource{Group: networkingv1alpha.GroupVersion.Group, Resource: domainResource}
+		return nil, apierrors.NewConflict(
+			gr,
+			domain.GetName(),
+			fmt.Errorf("domain resource with .spec.domainName %q already exists", domain.Spec.DomainName),
+		)
 	}
 
 	return nil, nil
+}
+
+func duplicateDomainName(existing []networkingv1alpha.Domain, candidate string) bool {
+	target := normalizeHostname(candidate)
+	for _, d := range existing {
+		if normalizeHostname(d.Spec.DomainName) == target {
+			return true
+		}
+	}
+	return false
 }
 
 // ValidateUpdate implements admission.Validator so a webhook will be registered for the type Domain.

--- a/internal/webhook/v1alpha/domain_webhook_test.go
+++ b/internal/webhook/v1alpha/domain_webhook_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	networkingv1alpha "go.datum.net/network-services-operator/api/v1alpha"
 )
 
 const (
@@ -53,6 +55,34 @@ func TestHostnameCoveredByDomain(t *testing.T) {
 		if got := hostnameCoveredByDomain(tt.domain, tt.host); got != tt.want {
 			t.Fatalf("hostnameCoveredByDomain(%q, %q) = %v, want %v", tt.domain, tt.host, got, tt.want)
 		}
+	}
+}
+
+func TestDuplicateDomainName(t *testing.T) {
+	existing := []networkingv1alpha.Domain{
+		{Spec: networkingv1alpha.DomainSpec{DomainName: testDomainExampleCom}},
+		{Spec: networkingv1alpha.DomainSpec{DomainName: testDomainAPIAutouserRun}},
+	}
+
+	tests := []struct {
+		name      string
+		candidate string
+		want      bool
+	}{
+		{"unique domain accepted", testDomainAutouserRun, false},
+		{"exact duplicate rejected", testDomainExampleCom, true},
+		{"case-insensitive duplicate rejected", "ExAmPlE.CoM", true},
+		{"trailing-dot duplicate rejected", "example.com.", true},
+		{"whitespace duplicate rejected", "  api.autouser.run  ", true},
+		{"subdomain is not a duplicate", "www.example.com", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := duplicateDomainName(existing, tt.candidate); got != tt.want {
+				t.Fatalf("duplicateDomainName(_, %q) = %v, want %v", tt.candidate, got, tt.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

Two domains with the same name could be created side by side, leaving it ambiguous which one actually owns the name for DNS and routing.

Creating a domain whose name is already taken in the same namespace is now rejected, with a message saying so. Matching ignores case and a trailing dot, so `Example.com.` and `example.com` count as the same; a subdomain like `www.example.com` does not.

This mirrors the duplicate guard already on domain deletion.

## Test plan

- [x] Build, lint, and test suite pass
- [x] Test covers accept (new name), reject (same name in case / trailing-dot / whitespace forms), and a subdomain that must still be allowed

Related to #86
