### PR TITLE
feat: reject Gateway with unmanaged GatewayClass

### DIFF
--- a/internal/webhook/v1/gateway_webhook.go
+++ b/internal/webhook/v1/gateway_webhook.go
@@ -5,9 +5,11 @@ package v1
 import (
 	"context"
 	"fmt"
+	"sort"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -62,8 +64,10 @@ func (v *GatewayCustomValidator) ValidateCreate(ctx context.Context, gateway *ga
 	}
 	clusterClient := cluster.GetClient()
 
-	if shouldProcess, err := shouldProcess(ctx, clusterClient, v.validationOpts.ControllerName, gateway); !shouldProcess || err != nil {
+	if fieldErr, err := validateManagedGatewayClass(ctx, clusterClient, v.validationOpts.ControllerName, gateway); err != nil {
 		return nil, err
+	} else if fieldErr != nil {
+		return nil, apierrors.NewInvalid(gateway.GetObjectKind().GroupVersionKind().GroupKind(), gateway.GetName(), field.ErrorList{fieldErr})
 	}
 
 	gatewaylog := logf.FromContext(ctx).WithValues("cluster", clusterName)
@@ -92,16 +96,18 @@ func (v *GatewayCustomValidator) ValidateUpdate(ctx context.Context, oldGateway,
 	}
 	clusterClient := cluster.GetClient()
 
-	if shouldProcess, err := shouldProcess(ctx, clusterClient, v.validationOpts.ControllerName, newGateway); !shouldProcess || err != nil {
-		return nil, err
-	}
-
 	gatewaylog := logf.FromContext(ctx).WithValues("cluster", clusterName)
 	gatewaylog.Info("Validating Gateway", "name", newGateway.GetName())
 
 	if dt := newGateway.DeletionTimestamp; !dt.IsZero() {
 		// Gateway is deleting, let it go through
 		return nil, nil
+	}
+
+	if fieldErr, err := validateManagedGatewayClass(ctx, clusterClient, v.validationOpts.ControllerName, newGateway); err != nil {
+		return nil, err
+	} else if fieldErr != nil {
+		return nil, apierrors.NewInvalid(oldGateway.GetObjectKind().GroupVersionKind().GroupKind(), newGateway.GetName(), field.ErrorList{fieldErr})
 	}
 
 	clusterValidationOpts := v.validationOpts
@@ -195,4 +201,31 @@ func shouldProcess(
 	}
 
 	return true, nil
+}
+
+func validateManagedGatewayClass(
+	ctx context.Context,
+	clusterClient client.Client,
+	controllerName gatewayv1.GatewayController,
+	gateway *gatewayv1.Gateway,
+) (*field.Error, error) {
+	var gatewayClasses gatewayv1.GatewayClassList
+	if err := clusterClient.List(ctx, &gatewayClasses); err != nil {
+		return nil, err
+	}
+
+	var managed []string
+	for i := range gatewayClasses.Items {
+		gatewayClass := &gatewayClasses.Items[i]
+		if gatewayClass.Spec.ControllerName != controllerName {
+			continue
+		}
+		managed = append(managed, gatewayClass.Name)
+		if gatewayClass.Name == string(gateway.Spec.GatewayClassName) {
+			return nil, nil
+		}
+	}
+
+	sort.Strings(managed)
+	return field.NotSupported(field.NewPath("spec", "gatewayClassName"), gateway.Spec.GatewayClassName, managed), nil
 }

--- a/internal/webhook/v1/gateway_webhook_test.go
+++ b/internal/webhook/v1/gateway_webhook_test.go
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package v1
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+func TestValidateManagedGatewayClass(t *testing.T) {
+	const controllerName gatewayv1.GatewayController = "gateway.networking.datumapis.com/external-global-proxy-controller"
+
+	managedClass := &gatewayv1.GatewayClass{
+		ObjectMeta: metav1.ObjectMeta{Name: "datum-external-global-proxy"},
+		Spec:       gatewayv1.GatewayClassSpec{ControllerName: controllerName},
+	}
+	foreignClass := &gatewayv1.GatewayClass{
+		ObjectMeta: metav1.ObjectMeta{Name: "some-other-provider"},
+		Spec:       gatewayv1.GatewayClassSpec{ControllerName: "example.com/other-controller"},
+	}
+
+	gatewayFor := func(className string) *gatewayv1.Gateway {
+		return &gatewayv1.Gateway{
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+			Spec:       gatewayv1.GatewaySpec{GatewayClassName: gatewayv1.ObjectName(className)},
+		}
+	}
+
+	tests := []struct {
+		name       string
+		gateway    *gatewayv1.Gateway
+		wantReject bool
+	}{
+		{
+			name:       "managed class is accepted",
+			gateway:    gatewayFor("datum-external-global-proxy"),
+			wantReject: false,
+		},
+		{
+			name:       "class managed by another controller is rejected",
+			gateway:    gatewayFor("some-other-provider"),
+			wantReject: true,
+		},
+		{
+			name:       "nonexistent class is rejected",
+			gateway:    gatewayFor("does-not-exist"),
+			wantReject: true,
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, gatewayv1.Install(scheme))
+
+	clusterClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(managedClass, foreignClass).
+		Build()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fieldErr, err := validateManagedGatewayClass(context.Background(), clusterClient, controllerName, tt.gateway)
+			require.NoError(t, err)
+
+			if !tt.wantReject {
+				assert.Nil(t, fieldErr)
+				return
+			}
+
+			require.NotNil(t, fieldErr)
+			assert.Equal(t, "spec.gatewayClassName", fieldErr.Field)
+			assert.Contains(t, fieldErr.Error(), "datum-external-global-proxy")
+		})
+	}
+}


### PR DESCRIPTION
## Summary

A gateway created with a class name nobody manages — usually a typo or a copied-in value — was accepted and then silently went nowhere: no status, no error, stuck forever. In incident datum-cloud/engineering#258 one sat wedged for 30+ hours with nothing pointing at why.

Now that mistake is caught the moment the gateway is created, with an error that lists the valid class names so it's clear how to fix it.

## Test plan

- [x] Build, lint, and test suite pass
- [x] Test covers accept (valid class), and reject (unmanaged and nonexistent class)

Related to #152
