### PR TITLE
fix: requeue gateway when its GatewayClass is unavailable

### DIFF
--- a/internal/controller/gateway_controller.go
+++ b/internal/controller/gateway_controller.go
@@ -61,6 +61,9 @@ const certificateIssuerTLSOption = "gateway.networking.datumapis.com/certificate
 // TLS listener on this gateway specified" — see resolveAutoIssuer.
 const autoIssuerSentinel = "auto"
 const annotationReissuanceCount = "networking.datumapis.com/reissuance-count"
+
+const gatewayClassRequeueInterval = 30 * time.Second
+
 const KindGateway = "Gateway"
 const KindHTTPRoute = "HTTPRoute"
 const KindService = "Service"
@@ -125,16 +128,16 @@ func (r *GatewayReconciler) Reconcile(ctx context.Context, req mcreconcile.Reque
 	var upstreamGatewayClass gatewayv1.GatewayClass
 	if err := cl.GetClient().Get(ctx, types.NamespacedName{Name: string(gateway.Spec.GatewayClassName)}, &upstreamGatewayClass); err != nil {
 		if apierrors.IsNotFound(err) {
-			logger.Info("gateway class not found, skipping")
-			return ctrl.Result{}, nil
+			logger.Info("gateway class not found, requeueing", "requeueAfter", gatewayClassRequeueInterval)
+			return ctrl.Result{RequeueAfter: gatewayClassRequeueInterval}, nil
 		}
 		logger.Error(err, "failed to get gateway class")
 		return ctrl.Result{}, err
 	}
 
 	if upstreamGatewayClass.Spec.ControllerName != r.Config.Gateway.ControllerName {
-		logger.Info("gateway class controller name mismatch, skipping", "expected", r.Config.Gateway.ControllerName, "actual", upstreamGatewayClass.Spec.ControllerName)
-		return ctrl.Result{}, nil
+		logger.Info("gateway class controller name mismatch, requeueing", "expected", r.Config.Gateway.ControllerName, "actual", upstreamGatewayClass.Spec.ControllerName, "requeueAfter", gatewayClassRequeueInterval)
+		return ctrl.Result{RequeueAfter: gatewayClassRequeueInterval}, nil
 	}
 
 	downstreamStrategy := downstreamclient.NewMappedNamespaceResourceStrategy(string(req.ClusterName), cl.GetClient(), r.DownstreamCluster.GetClient())

--- a/internal/controller/gateway_controller_test.go
+++ b/internal/controller/gateway_controller_test.go
@@ -35,7 +35,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	mcreconcile "sigs.k8s.io/multicluster-runtime/pkg/reconcile"
 
 	networkingv1alpha "go.datum.net/network-services-operator/api/v1alpha"
 	"go.datum.net/network-services-operator/internal/config"
@@ -2200,4 +2202,83 @@ func TestReissueFailedCertificate(t *testing.T) {
 			assert.Equal(t, time.Duration(0), requeueAfter, "call %d: should not requeue", i)
 		}
 	})
+}
+
+func TestReconcileRequeuesWhenGatewayClassUnavailable(t *testing.T) {
+	testScheme := runtime.NewScheme()
+	require.NoError(t, scheme.AddToScheme(testScheme))
+	require.NoError(t, gatewayv1.Install(testScheme))
+
+	const controllerName = gatewayv1.GatewayController("gateway.networking.datumapis.com/external-global-proxy-controller")
+	const gatewayClassName = "datum-external-global-proxy"
+
+	newGateway := func() *gatewayv1.Gateway {
+		return &gatewayv1.Gateway{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "test",
+				Name:      "test-gateway",
+			},
+			Spec: gatewayv1.GatewaySpec{
+				GatewayClassName: gatewayClassName,
+			},
+		}
+	}
+
+	tests := []struct {
+		name            string
+		existingObjects func() []client.Object
+	}{
+		{
+			name: "gateway class not found",
+			existingObjects: func() []client.Object {
+				return []client.Object{newGateway()}
+			},
+		},
+		{
+			name: "gateway class controller name mismatch",
+			existingObjects: func() []client.Object {
+				return []client.Object{
+					newGateway(),
+					&gatewayv1.GatewayClass{
+						ObjectMeta: metav1.ObjectMeta{Name: gatewayClassName},
+						Spec: gatewayv1.GatewayClassSpec{
+							ControllerName: gatewayv1.GatewayController("other.example.com/some-controller"),
+						},
+					},
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := log.IntoContext(context.Background(), zap.New(zap.UseFlagOptions(&zap.Options{Development: true})))
+
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(testScheme).
+				WithObjects(tt.existingObjects()...).
+				Build()
+
+			reconciler := &GatewayReconciler{
+				mgr: &fakeMockManager{cl: fakeClient},
+				Config: config.NetworkServicesOperator{
+					Gateway: config.GatewayConfig{
+						ControllerName: controllerName,
+					},
+				},
+				DownstreamCluster: &fakeCluster{cl: fakeClient},
+			}
+
+			result, err := reconciler.Reconcile(ctx, mcreconcile.Request{
+				ClusterName: "test",
+				Request: reconcile.Request{
+					NamespacedName: types.NamespacedName{Namespace: "test", Name: "test-gateway"},
+				},
+			})
+
+			require.NoError(t, err)
+			assert.Positive(t, result.RequeueAfter,
+				"initial reconcile must requeue so the gateway is retried once its GatewayClass is fixed")
+		})
+	}
 }


### PR DESCRIPTION
## Summary

A gateway could get permanently stuck the first time it was set up: if its class wasn't ready yet, the gateway was never looked at again and sat pending forever — the only way out was to delete and recreate it. In incident datum-cloud/engineering#258 a gateway stayed stuck even after the underlying problem was fixed.

Now it retries on its own and recovers once the class is in place.

This is the recovery half of the problem; it complements #298, which stops a bad class name from getting in at creation.

## Test plan

- [x] Build, lint, and test suite pass
- [x] Test covers retry for both the missing-class and not-yet-matching-class cases

Related to #153
