### PR TITLE
fix: requeue HTTPProxy promptly on write conflict

### DIFF
--- a/internal/controller/httpproxy_controller.go
+++ b/internal/controller/httpproxy_controller.go
@@ -124,6 +124,9 @@ func (r *HTTPProxyReconciler) Reconcile(ctx context.Context, req mcreconcile.Req
 	if !controllerutil.ContainsFinalizer(&httpProxy, httpProxyFinalizer) {
 		controllerutil.AddFinalizer(&httpProxy, httpProxyFinalizer)
 		if err := cl.GetClient().Update(ctx, &httpProxy); err != nil {
+			if apierrors.IsConflict(err) {
+				return ctrl.Result{RequeueAfter: retryAfterConflict}, nil
+			}
 			return ctrl.Result{}, err
 		}
 	}
@@ -219,6 +222,9 @@ func (r *HTTPProxyReconciler) Reconcile(ctx context.Context, req mcreconcile.Req
 			programmedCondition.Message = fmt.Sprintf("Underlying Gateway with the name %q already exists and is owned by a different resource.", gateway.Name)
 			return ctrl.Result{}, nil
 		}
+		if apierrors.IsConflict(err) {
+			return ctrl.Result{RequeueAfter: retryAfterConflict}, nil
+		}
 		return ctrl.Result{}, fmt.Errorf("failed updating gateway resource: %w", err)
 	}
 
@@ -241,6 +247,9 @@ func (r *HTTPProxyReconciler) Reconcile(ctx context.Context, req mcreconcile.Req
 				return nil
 			})
 			if err != nil {
+				if apierrors.IsConflict(err) {
+					return ctrl.Result{RequeueAfter: retryAfterConflict}, nil
+				}
 				return ctrl.Result{}, fmt.Errorf("failed updating httproutefilter resource: %w", err)
 			}
 			logger.Info("processed httproutefilter", jsonKeyName, httpRouteFilter.Name, "result", result)
@@ -271,6 +280,9 @@ func (r *HTTPProxyReconciler) Reconcile(ctx context.Context, req mcreconcile.Req
 			programmedCondition.Message = fmt.Sprintf("Underlying HTTPRoute with the name %q already exists and is owned by a different resource.", httpRoute.Name)
 			return ctrl.Result{}, nil
 		}
+		if apierrors.IsConflict(err) {
+			return ctrl.Result{RequeueAfter: retryAfterConflict}, nil
+		}
 		return ctrl.Result{}, fmt.Errorf("failed updating httproute resource: %w", err)
 	}
 
@@ -288,6 +300,9 @@ func (r *HTTPProxyReconciler) Reconcile(ctx context.Context, req mcreconcile.Req
 		case existingEndpointSlice.AddressType != desiredEndpointSlice.AddressType &&
 			!hasControllerConflict(existingEndpointSlice, &httpProxy):
 			if err := cl.GetClient().Delete(ctx, existingEndpointSlice); err != nil && !apierrors.IsNotFound(err) {
+				if apierrors.IsConflict(err) {
+					return ctrl.Result{RequeueAfter: retryAfterConflict}, nil
+				}
 				return ctrl.Result{}, fmt.Errorf("failed to delete endpointslice for address type change: %w", err)
 			}
 		}
@@ -328,6 +343,10 @@ func (r *HTTPProxyReconciler) Reconcile(ctx context.Context, req mcreconcile.Req
 				programmedCondition.Reason = networkingv1alpha.HTTPProxyReasonConflict
 				programmedCondition.Message = fmt.Sprintf("Underlying EndpointSlice with the name %q already exists and is owned by a different resource.", endpointSlice.Name)
 				return ctrl.Result{}, nil
+			}
+
+			if apierrors.IsConflict(err) {
+				return ctrl.Result{RequeueAfter: retryAfterConflict}, nil
 			}
 
 			return ctrl.Result{}, fmt.Errorf("failed to create or update endpointslice: %w", err)

--- a/internal/controller/httpproxy_controller_test.go
+++ b/internal/controller/httpproxy_controller_test.go
@@ -2224,6 +2224,97 @@ func TestHTTPProxyReconcileEndpointSliceAddressTypeChange(t *testing.T) {
 	assert.Equal(t, discoveryv1.AddressTypeIPv4, updatedSlice.AddressType)
 }
 
+func TestHTTPProxyReconcileRequeuesPromptlyOnConflict(t *testing.T) {
+	logger := zap.New(zap.UseFlagOptions(&zap.Options{Development: true}))
+	ctx := log.IntoContext(context.Background(), logger)
+
+	testScheme := runtime.NewScheme()
+	assert.NoError(t, scheme.AddToScheme(testScheme))
+	assert.NoError(t, gatewayv1.Install(testScheme))
+	assert.NoError(t, envoygatewayv1alpha1.AddToScheme(testScheme))
+	assert.NoError(t, discoveryv1.AddToScheme(testScheme))
+	assert.NoError(t, networkingv1alpha.AddToScheme(testScheme))
+	assert.NoError(t, networkingv1alpha1.AddToScheme(testScheme))
+
+	testConfig := config.NetworkServicesOperator{
+		HTTPProxy: config.HTTPProxyConfig{
+			GatewayClassName: "test-gateway-class",
+		},
+		Gateway: config.GatewayConfig{
+			ControllerName: gatewayv1.GatewayController("test-gateway-class"),
+			TargetDomain:   "example.com",
+			ListenerTLSOptions: map[gatewayv1.AnnotationKey]gatewayv1.AnnotationValue{
+				gatewayv1.AnnotationKey("gateway.networking.datumapis.com/certificate-issuer"): gatewayv1.AnnotationValue("test-issuer"),
+			},
+		},
+	}
+
+	httpProxy := newHTTPProxy(func(h *networkingv1alpha.HTTPProxy) {
+		controllerutil.AddFinalizer(h, httpProxyFinalizer)
+	})
+
+	existingGateway := &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              httpProxy.Name,
+			Namespace:         httpProxy.Namespace,
+			CreationTimestamp: metav1.Now(),
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: "networking.datumapis.com/v1alpha",
+					Kind:       "HTTPProxy",
+					Name:       httpProxy.Name,
+					UID:        httpProxy.UID,
+					Controller: ptr.To(true),
+				},
+			},
+		},
+		Spec: gatewayv1.GatewaySpec{
+			GatewayClassName: "stale-gateway-class",
+		},
+	}
+
+	upstreamNamespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: httpProxy.Namespace}}
+	upstreamNamespace.SetUID(uuid.NewUUID())
+
+	gatewayUpdateConflicts := 0
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(testScheme).
+		WithObjects(httpProxy, upstreamNamespace, existingGateway).
+		WithStatusSubresource(httpProxy).
+		WithStatusSubresource(&gatewayv1.Gateway{}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Update: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+				if _, ok := obj.(*gatewayv1.Gateway); ok && gatewayUpdateConflicts == 0 {
+					gatewayUpdateConflicts++
+					return apierrors.NewConflict(
+						gatewayv1.Resource("gateways"),
+						obj.GetName(),
+						fmt.Errorf("the object has been modified; please apply your changes and try again"),
+					)
+				}
+				return c.Update(ctx, obj, opts...)
+			},
+		}).
+		Build()
+
+	reconciler := &HTTPProxyReconciler{
+		mgr:    &fakeMockManager{cl: fakeClient},
+		Config: testConfig,
+	}
+
+	req := mcreconcile.Request{
+		Request: reconcile.Request{
+			NamespacedName: client.ObjectKeyFromObject(httpProxy),
+		},
+		ClusterName: "test-cluster",
+	}
+
+	result, err := reconciler.Reconcile(ctx, req)
+	require.NoError(t, err)
+	assert.Equal(t, 1, gatewayUpdateConflicts)
+	assert.Equal(t, retryAfterConflict, result.RequeueAfter)
+}
+
 // TestHTTPProxyFinalizerCleanupEPPEmissionDisabled verifies that when
 // gateway.eppEmissionEnabled is false, the HTTPProxy finalizer cleanup does NOT
 // delete the connector EnvoyPatchPolicy from the downstream cluster (NSO did not


### PR DESCRIPTION
## Summary

A newly created tunnel took 3-4 minutes before its toggle turned green, because the controller stalled on a retry backoff at creation instead of completing the setup right away. It now retries promptly, so a fresh tunnel programs in seconds rather than minutes.

## Test plan

- [x] New regression test forces the contended write to fail once and asserts the reconcile retries promptly instead of backing off; it fails on the pre-fix code.
- [x] `go build ./...`, `make lint`, and `make test` all pass.

Related to #166