### PR TITLE
feat: aggregate SecurityPolicy status from edge

### DIFF
--- a/config/federation/resourceinterpreters.yaml
+++ b/config/federation/resourceinterpreters.yaml
@@ -232,3 +232,35 @@ spec:
           end
           return desiredObj
         end
+---
+apiVersion: config.karmada.io/v1alpha1
+kind: ResourceInterpreterCustomization
+metadata:
+  name: gateway.envoyproxy.io-securitypolicy
+spec:
+  target:
+    apiVersion: gateway.envoyproxy.io/v1alpha1
+    kind: SecurityPolicy
+  customizations:
+    statusAggregation:
+      luaScript: >
+        function AggregateStatus(desiredObj, statusItems)
+          if statusItems == nil or #statusItems == 0 then
+            return desiredObj
+          end
+          if desiredObj.status == nil then
+            desiredObj.status = {}
+          end
+
+          local item = statusItems[1]
+          if item == nil or item.status == nil then
+            return desiredObj
+          end
+
+          -- TODO(jreese) implement proper aggregation logic. Would be good to
+          -- think through how to represent propagation status across clusters.
+          if item.status.ancestors ~= nil then
+            desiredObj.status.ancestors = item.status.ancestors
+          end
+          return desiredObj
+        end


### PR DESCRIPTION
Adds a Karmada `ResourceInterpreterCustomization` that aggregates `gateway.envoyproxy.io/v1alpha1` SecurityPolicy status from member clusters back to the hub, so SecurityPolicies in project control planes surface their edge status condition.

SecurityPolicy uses the Gateway API `PolicyStatus` shape (`status.ancestors[].conditions`), identical to BackendTrafficPolicy, so the new block is modeled verbatim on the existing BackendTrafficPolicy interpreter and copies `status.ancestors`.

Closes #97