### PR TITLE
feat: auto-propagate secrets referenced by gateway policies

### DIFF
--- a/internal/controller/gateway_resource_replicator_controller.go
+++ b/internal/controller/gateway_resource_replicator_controller.go
@@ -263,6 +263,12 @@ func (r *GatewayResourceReplicatorReconciler) finalizeResource(
 			return ctrl.Result{}, err
 		}
 
+		if isSecurityPolicyGVK(resource.gvk) {
+			if err := r.reconcileReferencedSecretLabels(ctx, upstreamClient, resource.gvk, upstreamObj.GetNamespace()); err != nil {
+				return ctrl.Result{}, err
+			}
+		}
+
 		controllerutil.RemoveFinalizer(upstreamObj, gatewayResourceReplicatorFinalizer)
 		if err := upstreamClient.Update(ctx, upstreamObj); err != nil {
 			if apierrors.IsNotFound(err) {
@@ -301,6 +307,11 @@ func (r *GatewayResourceReplicatorReconciler) ensureDownstreamResource(
 	}
 
 	if isSecurityPolicyGVK(resource.gvk) {
+		if err := r.reconcileReferencedSecretLabels(ctx, upstreamClient, resource.gvk, upstreamObj.GetNamespace()); err != nil {
+			syncOutcome = syncOutcomeError
+			return err
+		}
+
 		missing, err := r.missingDownstreamSecrets(ctx, upstreamObj, downstreamStrategy)
 		if err != nil {
 			syncOutcome = syncOutcomeError

--- a/internal/controller/gateway_resource_replicator_securitypolicy_propagate.go
+++ b/internal/controller/gateway_resource_replicator_securitypolicy_propagate.go
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package controller
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+const (
+	gatewaySyncLabel             = "networking.datumapis.com/gateway-sync"
+	gatewaySyncManagedAnnotation = "networking.datumapis.com/gateway-sync-managed"
+)
+
+// reconcileReferencedSecretLabels keeps the gateway-sync label on the upstream
+// Secrets a SecurityPolicy references in step with the live policies in the
+// namespace. Labeled Secrets are mirrored downstream by the replicator (and
+// propagated to the edge by Karmada), which is what releases the guard's hold.
+//
+// Only same-namespace references are auto-managed so the refcount stays sound:
+// every managed Secret lives in the namespace whose policies are listed here.
+func (r *GatewayResourceReplicatorReconciler) reconcileReferencedSecretLabels(
+	ctx context.Context,
+	upstreamClient client.Client,
+	securityPolicyGVK schema.GroupVersionKind,
+	namespace string,
+) error {
+	list := &unstructured.UnstructuredList{}
+	list.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   securityPolicyGVK.Group,
+		Version: securityPolicyGVK.Version,
+		Kind:    securityPolicyGVK.Kind + "List",
+	})
+	if err := upstreamClient.List(ctx, list, client.InNamespace(namespace)); err != nil {
+		return fmt.Errorf("failed to list SecurityPolicies in %s: %w", namespace, err)
+	}
+
+	referenced := make(map[string]struct{})
+	for i := range list.Items {
+		policy := &list.Items[i]
+		if !policy.GetDeletionTimestamp().IsZero() {
+			continue
+		}
+		for _, ref := range securityPolicySecretRefs(policy) {
+			if ref.namespace != namespace {
+				continue
+			}
+			referenced[ref.name] = struct{}{}
+		}
+	}
+
+	for name := range referenced {
+		if err := r.ensureSecretSyncLabel(ctx, upstreamClient, namespace, name); err != nil {
+			return err
+		}
+	}
+
+	return r.gcSecretSyncLabels(ctx, upstreamClient, namespace, referenced)
+}
+
+func (r *GatewayResourceReplicatorReconciler) ensureSecretSyncLabel(
+	ctx context.Context,
+	upstreamClient client.Client,
+	namespace, name string,
+) error {
+	var secret corev1.Secret
+	if err := upstreamClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, &secret); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to get referenced secret %s/%s: %w", namespace, name, err)
+	}
+
+	if _, ok := secret.Labels[gatewaySyncLabel]; ok {
+		return nil
+	}
+
+	patch := client.MergeFrom(secret.DeepCopy())
+	if secret.Labels == nil {
+		secret.Labels = map[string]string{}
+	}
+	secret.Labels[gatewaySyncLabel] = "true"
+	if secret.Annotations == nil {
+		secret.Annotations = map[string]string{}
+	}
+	secret.Annotations[gatewaySyncManagedAnnotation] = "true"
+
+	if err := upstreamClient.Patch(ctx, &secret, patch); err != nil {
+		return fmt.Errorf("failed to label referenced secret %s/%s: %w", namespace, name, err)
+	}
+
+	log.FromContext(ctx).Info("labeled referenced secret for propagation", jsonKeyNamespace, namespace, jsonKeyName, name)
+	return nil
+}
+
+func (r *GatewayResourceReplicatorReconciler) gcSecretSyncLabels(
+	ctx context.Context,
+	upstreamClient client.Client,
+	namespace string,
+	referenced map[string]struct{},
+) error {
+	var secrets corev1.SecretList
+	if err := upstreamClient.List(ctx, &secrets, client.InNamespace(namespace), client.HasLabels{gatewaySyncLabel}); err != nil {
+		return fmt.Errorf("failed to list gateway-sync secrets in %s: %w", namespace, err)
+	}
+
+	for i := range secrets.Items {
+		secret := &secrets.Items[i]
+		if secret.Annotations[gatewaySyncManagedAnnotation] != "true" {
+			continue
+		}
+		if _, ok := referenced[secret.Name]; ok {
+			continue
+		}
+
+		patch := client.MergeFrom(secret.DeepCopy())
+		delete(secret.Labels, gatewaySyncLabel)
+		delete(secret.Annotations, gatewaySyncManagedAnnotation)
+		if err := upstreamClient.Patch(ctx, secret, patch); err != nil {
+			return fmt.Errorf("failed to unlabel unreferenced secret %s/%s: %w", namespace, secret.Name, err)
+		}
+
+		log.FromContext(ctx).Info("unlabeled unreferenced secret", jsonKeyNamespace, namespace, jsonKeyName, secret.Name)
+	}
+
+	return nil
+}

--- a/internal/controller/gateway_resource_replicator_securitypolicy_propagate_test.go
+++ b/internal/controller/gateway_resource_replicator_securitypolicy_propagate_test.go
@@ -1,0 +1,188 @@
+package controller
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+// nolint:unparam
+func oidcPolicy(namespace, name, secretName string) *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{}
+	obj.SetGroupVersionKind(testGVK)
+	obj.SetNamespace(namespace)
+	obj.SetName(name)
+	obj.SetFinalizers([]string{gatewayResourceReplicatorFinalizer})
+	obj.Object["spec"] = map[string]any{
+		"targetRefs": []any{
+			map[string]any{
+				"group": "gateway.networking.k8s.io",
+				"kind":  "Gateway",
+				"name":  "shared-gateway",
+			},
+		},
+		"oidc": map[string]any{
+			"clientSecret": map[string]any{"name": secretName},
+		},
+	}
+	return obj
+}
+
+func propagateTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	assert.NoError(t, corev1.AddToScheme(scheme))
+	return scheme
+}
+
+// nolint:unparam
+func getSecret(t *testing.T, c client.Client, namespace, name string) *corev1.Secret {
+	t.Helper()
+	var secret corev1.Secret
+	assert.NoError(t, c.Get(context.Background(), client.ObjectKey{Namespace: namespace, Name: name}, &secret))
+	return &secret
+}
+
+func TestReplicatorLabelsReferencedSecretForPropagation(t *testing.T) {
+	scheme := propagateTestScheme(t)
+	ctx := context.Background()
+
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "tenant", UID: types.UID("ns-uid")}}
+	secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: "tenant", Name: "oidc-secret"}}
+	policy := oidcPolicy("tenant", "p1", "oidc-secret")
+
+	statusTemplate := &unstructured.Unstructured{}
+	statusTemplate.SetGroupVersionKind(testGVK)
+	upstream := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(statusTemplate).
+		WithObjects(ns, secret, policy.DeepCopy()).
+		Build()
+	downstream := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	reconciler := newReplicatorForTest(upstream, downstream, scheme)
+
+	_, err := reconciler.Reconcile(ctx, gvkRequestFor(policy))
+	assert.NoError(t, err)
+
+	got := getSecret(t, upstream, "tenant", "oidc-secret")
+	_, labeled := got.Labels[gatewaySyncLabel]
+	assert.True(t, labeled, "referenced secret must carry the gateway-sync label")
+	assert.Equal(t, "true", got.Annotations[gatewaySyncManagedAnnotation],
+		"operator-applied label must be marked managed")
+}
+
+func TestReplicatorUnlabelsSecretWhenNoLongerReferenced(t *testing.T) {
+	scheme := propagateTestScheme(t)
+	ctx := context.Background()
+
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "tenant", UID: types.UID("ns-uid")}}
+	secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+		Namespace:   "tenant",
+		Name:        "oidc-secret",
+		Labels:      map[string]string{gatewaySyncLabel: "true"},
+		Annotations: map[string]string{gatewaySyncManagedAnnotation: "true"},
+	}}
+	policy := oidcPolicy("tenant", "p1", "oidc-secret")
+
+	statusTemplate := &unstructured.Unstructured{}
+	statusTemplate.SetGroupVersionKind(testGVK)
+	upstream := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(statusTemplate).
+		WithObjects(ns, secret, policy.DeepCopy()).
+		Build()
+	downstream := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	reconciler := newReplicatorForTest(upstream, downstream, scheme)
+
+	fetched := &unstructured.Unstructured{}
+	fetched.SetGroupVersionKind(testGVK)
+	assert.NoError(t, upstream.Get(ctx, client.ObjectKeyFromObject(policy), fetched))
+	assert.NoError(t, unstructured.SetNestedMap(fetched.Object, map[string]any{}, "spec"))
+	assert.NoError(t, unstructured.SetNestedSlice(fetched.Object, []any{}, "spec", "targetRefs"))
+	assert.NoError(t, upstream.Update(ctx, fetched))
+
+	_, err := reconciler.Reconcile(ctx, gvkRequestFor(policy))
+	assert.NoError(t, err)
+
+	got := getSecret(t, upstream, "tenant", "oidc-secret")
+	_, labeled := got.Labels[gatewaySyncLabel]
+	assert.False(t, labeled, "managed label must be removed once unreferenced")
+	_, annotated := got.Annotations[gatewaySyncManagedAnnotation]
+	assert.False(t, annotated, "managed annotation must be removed alongside the label")
+}
+
+func TestReplicatorKeepsSecretLabeledWhileAnotherPolicyReferences(t *testing.T) {
+	scheme := propagateTestScheme(t)
+	ctx := context.Background()
+
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "tenant", UID: types.UID("ns-uid")}}
+	secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+		Namespace:   "tenant",
+		Name:        "shared-secret",
+		Labels:      map[string]string{gatewaySyncLabel: "true"},
+		Annotations: map[string]string{gatewaySyncManagedAnnotation: "true"},
+	}}
+	p1 := oidcPolicy("tenant", "p1", "shared-secret")
+	p2 := oidcPolicy("tenant", "p2", "shared-secret")
+
+	statusTemplate := &unstructured.Unstructured{}
+	statusTemplate.SetGroupVersionKind(testGVK)
+	upstream := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(statusTemplate).
+		WithObjects(ns, secret, p1.DeepCopy(), p2.DeepCopy()).
+		Build()
+	downstream := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	reconciler := newReplicatorForTest(upstream, downstream, scheme)
+
+	assert.NoError(t, upstream.Delete(ctx, p1.DeepCopy()))
+
+	_, err := reconciler.Reconcile(ctx, gvkRequestFor(p1))
+	assert.NoError(t, err)
+
+	got := getSecret(t, upstream, "tenant", "shared-secret")
+	_, labeled := got.Labels[gatewaySyncLabel]
+	assert.True(t, labeled, "secret must stay labeled while another policy references it")
+}
+
+func TestReplicatorLeavesUserAppliedSecretLabel(t *testing.T) {
+	scheme := propagateTestScheme(t)
+	ctx := context.Background()
+
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "tenant", UID: types.UID("ns-uid")}}
+	secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+		Namespace: "tenant",
+		Name:      "user-secret",
+		Labels:    map[string]string{gatewaySyncLabel: "true"},
+	}}
+	policy := oidcPolicy("tenant", "p1", "other-secret")
+
+	statusTemplate := &unstructured.Unstructured{}
+	statusTemplate.SetGroupVersionKind(testGVK)
+	upstream := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(statusTemplate).
+		WithObjects(ns, secret, policy.DeepCopy()).
+		Build()
+	downstream := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	reconciler := newReplicatorForTest(upstream, downstream, scheme)
+
+	_, err := reconciler.Reconcile(ctx, gvkRequestFor(policy))
+	assert.NoError(t, err)
+
+	got := getSecret(t, upstream, "tenant", "user-secret")
+	_, labeled := got.Labels[gatewaySyncLabel]
+	assert.True(t, labeled, "user-applied label must never be stripped by the operator")
+}


### PR DESCRIPTION
Closes #95.

A SecurityPolicy that references a Secret (OIDC, BasicAuth, API-key) now works without the user hand-labeling the secret for edge sync. The operator propagates referenced secrets to the edge automatically, un-propagates them when no longer referenced, and (via the #304 guard) holds a policy off the shared gateway while a referenced secret is missing — surfacing the misconfiguration in status.

## What changed
- On reconcile, the replicator labels the referenced upstream Secrets with `networking.datumapis.com/gateway-sync` plus a `gateway-sync-managed` ownership annotation. The existing replicator + Karmada path carries them downstream and releases the #304 hold.
- GC refcounts each secret across all live SecurityPolicies in the namespace — on reconcile and on finalize — and strips the label only when no live policy references it.
- Unit tests: label-on-reference, unlabel-on-deref, refcount keeps a shared secret while a second policy references it, user-applied labels never stripped.

## Design decisions
1. **Propagate by labeling, not direct-mirror.** Reuses the opt-in `gateway-sync` label path. No new mirror path, no new RBAC.
2. **Refcount + ownership.** GC removes a label only if it is operator-managed AND no live policy in the namespace references the secret. User-applied labels (no managed annotation) are never touched.
3. **Scope: SecurityPolicy only.** Matches the #304 guard scaffolding. BackendTLSPolicy / ClientTrafficPolicy / BackendTrafficPolicy refs are follow-up.
4. **No new webhook.** Existing secret → labeled → mirrored → hold releases. Missing secret can't propagate, so the guard keeps `Accepted=False/PendingSecret`.

## Known limitation
Auto-management is **same-namespace** only, which keeps the namespace-scoped refcount sound. Cross-namespace refs still need a manual label (the guard holds until the secret appears). Cross-namespace + other policy kinds are follow-up.

## Tests
`make manifests generate fmt vet` clean (no CRD/RBAC diff). `make lint` 0 issues. `make test` (envtest) passes, incl. the four new tests in `gateway_resource_replicator_securitypolicy_propagate_test.go`.
