### PR TITLE
chore: use fork of multicluster-runtime for coordinator fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -321,3 +321,5 @@ require (
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.2 // indirect
 )
+
+replace sigs.k8s.io/multicluster-runtime => github.com/datum-cloud/multicluster-runtime v0.24.2-0.20260723223345-768cd0aa49de

--- a/go.sum
+++ b/go.sum
@@ -158,6 +158,8 @@ github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
 github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=
 github.com/cyphar/filepath-securejoin v0.6.1 h1:5CeZ1jPXEiYt3+Z6zqprSAgSWiggmpVyciv8syjIpVE=
 github.com/cyphar/filepath-securejoin v0.6.1/go.mod h1:A8hd4EnAeyujCJRrICiOWqjS1AX0a9kM5XL+NwKoYSc=
+github.com/datum-cloud/multicluster-runtime v0.24.2-0.20260723223345-768cd0aa49de h1:2GdE8nH3RUfmbg4sBmIKur/jS3it5GVTE692HrkiQgs=
+github.com/datum-cloud/multicluster-runtime v0.24.2-0.20260723223345-768cd0aa49de/go.mod h1:il5JnZbcx4gNtmROaSm+zrXfO5/jZJQwZp1bTrx0i5g=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
@@ -932,8 +934,6 @@ sigs.k8s.io/kustomize/kyaml v0.21.1 h1:IVlbmhC076nf6foyL6Taw4BkrLuEsXUXNpsE+ScX7
 sigs.k8s.io/kustomize/kyaml v0.21.1/go.mod h1:hmxADesM3yUN2vbA5z1/YTBnzLJ1dajdqpQonwBL1FQ=
 sigs.k8s.io/mcs-api v0.5.0 h1:UMgKuFFIRVEy4LR2LQovPnBkV9rgmZMT+sJO7MkaVj4=
 sigs.k8s.io/mcs-api v0.5.0/go.mod h1:zZ5CK8uS6HaLkxY4HqsmcBHfzHuNMrY2uJy8T7jffK4=
-sigs.k8s.io/multicluster-runtime v0.23.3 h1:vrzlXRzHTDsjspUAfoW2rCtr0agoI4q20p9x4Fz4png=
-sigs.k8s.io/multicluster-runtime v0.23.3/go.mod h1:r/UA4GHgFoXCcR4tcvlZz7SiLx3l1kJKDuBAhILNIHs=
 sigs.k8s.io/randfill v1.0.0 h1:JfjMILfT8A6RbawdsK2JXGBR5AQVfd+9TbzrlneTyrU=
 sigs.k8s.io/randfill v1.0.0/go.mod h1:XeLlZ/jmk4i1HRopwe7/aU3H5n1zNUcX6TM94b3QxOY=
 sigs.k8s.io/structured-merge-diff/v6 v6.3.2 h1:kwVWMx5yS1CrnFWA/2QHyRVJ8jM6dBA80uLmm0wJkk8=


### PR DESCRIPTION
## Summary

Interim fix for #319: `sigs.k8s.io/multicluster-runtime`'s `Coordinator` doesn't gate `Manager.GetCluster` or reconcile dispatch by cluster ownership, so a replica can act on a project's resources it was never granted ownership of by the sharded coordinator, even with a correctly-held fence Lease. This was reproduced directly against a real environment (real Milo control plane, real per-project storage isolation, 3 sharded replicas): with a project's fence Lease held by exactly one replica, all three replicas still reconciled the same object.

The fix belongs in the upstream library. We've implemented and validated it in a fork (`datum-cloud/multicluster-runtime`, branch `fix/coordinator-ownership-gate`): adds `Coordinator.Owns()`, gates `Manager.GetCluster` on it, and skips reconcile dispatch for non-owned clusters. Both mechanisms are enabled by default, so this is a pure dependency swap — no application code changes.

This PR points `go.mod` at that fork via a `replace` directive as an interim measure until the fix is proposed and accepted upstream, at which point this should be reverted in favor of a normal version bump.

## Test plan

- [ ] `go build ./...` and `go mod tidy` succeed (verified locally)
- [ ] `make test` passes
- [ ] Re-run the sharded-coordinator repro from #319 and confirm only the owning replica reconciles a project's resources
