### PR TITLE
docs: scope 80-char hard-wrap to commit messages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -193,3 +193,7 @@ Key changes:
 - **Commit types**: feat, fix, refactor, docs, test, chore, perf, style, ci
 - **No watermarks** or co-author tags
 - **Focus on what/why**, not how
+- **Scope**: the 80-char hard-wrap applies to commit messages only. PR
+  descriptions, GitHub issues, and comments render as GitHub-flavored markdown —
+  do not hard-wrap them; let prose reflow naturally and only break lines where
+  markdown needs it (lists, tables, code fences).


### PR DESCRIPTION
## Summary

The commit-message format section said "hard wrap at 80 characters" with no stated scope, so the rule got applied to GitHub issue and PR bodies too. Those render as GitHub-flavored markdown and soft-wrap on their own — hard wrapping them produces ragged output in the web UI and fights the editor when someone revises the text.

This states the scope explicitly, matching the equivalent rule already in the infra repo's `CLAUDE.md`.

## Test plan

- [x] Docs-only change; no code paths touched