### PR TITLE
fix: grant status RBAC for Envoy Gateway policies

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -175,6 +175,17 @@ rules:
   verbs:
   - update
 - apiGroups:
+  - gateway.envoyproxy.io
+  resources:
+  - backends/status
+  - backendtrafficpolicies/status
+  - httproutefilters/status
+  - securitypolicies/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
   - gateway.networking.k8s.io
   resources:
   - backendtlspolicies

--- a/internal/controller/gateway_resource_replicator_controller.go
+++ b/internal/controller/gateway_resource_replicator_controller.go
@@ -56,8 +56,9 @@ const gatewayResourceReplicatorFinalizer = "gateway.networking.datumapis.com/gat
 // resource (including TrafficProtectionPolicy/HTTPProxy/Connector). See config.go
 // SetDefaults_GatewayResourceReplicatorConfig.
 // +kubebuilder:rbac:groups="",resources=configmaps;secrets,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=gateway.envoyproxy.io,resources=backends;backendtrafficpolicies;securitypolicies,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=gateway.envoyproxy.io,resources=backends;backendtrafficpolicies;httproutefilters;securitypolicies,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=gateway.envoyproxy.io,resources=backends/finalizers;backendtrafficpolicies/finalizers;securitypolicies/finalizers,verbs=update
+// +kubebuilder:rbac:groups=gateway.envoyproxy.io,resources=backends/status;backendtrafficpolicies/status;httproutefilters/status;securitypolicies/status,verbs=get;update;patch
 
 type statusTransformFunc func(ctx context.Context, upstreamNamespace string, controllerName string, status map[string]any) (map[string]any, error)
 


### PR DESCRIPTION
## Summary

The manager's role grants no `status` subresource on any `gateway.envoyproxy.io` type, so every upstream status write the gateway resource replicator attempts is denied — logging an error on every reconcile, indefinitely.

Two symptoms for tenants:

- A tenant whose OIDC `SecurityPolicy` references a missing secret gets no reason back. The operator correctly holds the broken policy off the shared gateway but cannot write `Accepted=False, reason=PendingSecret` onto the tenant's resource, so login silently fails with nothing to act on.
- `SecurityPolicy`, `BackendTrafficPolicy`, `Backend`, and `HTTPRouteFilter` never reflect edge status, and stale status is never cleared.

Three write paths were denied: the held-policy condition (`gateway_resource_replicator_securitypolicy_guard.go:176`), the downstream→upstream sync (`gateway_resource_replicator_controller.go:487`), and the status clear (`:526`). The last two run for every replicated GVK without `skipUpstreamStatusSync`, so the gap was never limited to held SecurityPolicies. `BackendTLSPolicy` was unaffected — `gateway.networking.k8s.io/*/status` is already granted.

This adds the missing marker and regenerates the role. It also names `httproutefilters` in the replicator's own marker, which previously relied on an unrelated HTTPProxy controller marker for access; the generated role is unchanged by that.

> [!NOTE]
> Unit tests cannot catch this: the replicator tests use a fake client that does not enforce RBAC. The real gate is #312.

## Test plan

- [x] `make manifests` regenerates `config/rbac/role.yaml` with the four `/status` rules; no CRD churn
- [x] `go build ./...`
- [x] `make test`
- [ ] On a real cluster: a held SecurityPolicy reports `Accepted=False, reason=PendingSecret`
- [ ] On a real cluster: edge status for a replicated `BackendTrafficPolicy` appears upstream
- [ ] No `failed to record held status` or `failed to update upstream status` in manager logs
- [ ] #312 (`oidc-missing-secret-isolation`) reaches Arm 2 and passes

Related to #322
