### PR TITLE
docs: extend concision rules to GitHub prose

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -197,3 +197,16 @@ Key changes:
   descriptions, GitHub issues, and comments render as GitHub-flavored markdown —
   do not hard-wrap them; let prose reflow naturally and only break lines where
   markdown needs it (lists, tables, code fences).
+
+## GitHub PR / Issue / Comment Conventions
+
+The "Be concise" rule above governs responses and code comments. It applies to
+GitHub prose too.
+
+- **Say it once.** Do not describe the same behaviour in prose and again in a
+  checklist, or restate the summary in the test plan. Reference it instead.
+- **Lead with the problem** in plain language, then what changed and why. Push
+  implementation detail into bullets or a follow-up, not the summary.
+- **Cut every word carrying no fact.** One dense paragraph beats three that
+  re-sell the same point. Brevity must not drop facts — compress, do not omit.
+- **Don't hard-wrap** prose (see the commit section above).


### PR DESCRIPTION
## Summary

`CLAUDE.md` says "Be concise. Always", but scopes it to responses and code comments. PR descriptions and issue bodies fall outside it, and it shows: summaries restated verbatim as test-plan checkboxes, and several paragraphs re-selling the same point.

This extends the rule to GitHub prose and names the failure modes, next to the hard-wrap scope note from #323.

The compress-don't-omit clause is deliberate — the goal is fewer words, not fewer facts.

## Test plan

- [x] Docs-only change; no code paths touched