### PR TITLE
feat: Surface TrafficProtectionPolicy Programmed status

### DIFF
--- a/api/v1alpha/trafficprotectionpolicy_types.go
+++ b/api/v1alpha/trafficprotectionpolicy_types.go
@@ -193,6 +193,10 @@ type TrafficProtectionPolicyStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:shortName=tpp
+// +kubebuilder:printcolumn:name="Mode",type=string,JSONPath=`.spec.mode`
+// +kubebuilder:printcolumn:name="Accepted",type=string,JSONPath=`.status.ancestors[0].conditions[?(@.type=="Accepted")].status`
+// +kubebuilder:printcolumn:name="Programmed",type=string,JSONPath=`.status.ancestors[0].conditions[?(@.type=="Programmed")].status`
+// +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 
 // TrafficProtectionPolicy is the Schema for the trafficprotectionpolicies API.
 type TrafficProtectionPolicy struct {

--- a/config/crd/bases/networking.datumapis.com_trafficprotectionpolicies.yaml
+++ b/config/crd/bases/networking.datumapis.com_trafficprotectionpolicies.yaml
@@ -16,7 +16,20 @@ spec:
     singular: trafficprotectionpolicy
   scope: Namespaced
   versions:
-  - name: v1alpha
+  - additionalPrinterColumns:
+    - jsonPath: .spec.mode
+      name: Mode
+      type: string
+    - jsonPath: .status.ancestors[0].conditions[?(@.type=="Accepted")].status
+      name: Accepted
+      type: string
+    - jsonPath: .status.ancestors[0].conditions[?(@.type=="Programmed")].status
+      name: Programmed
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha
     schema:
       openAPIV3Schema:
         description: TrafficProtectionPolicy is the Schema for the trafficprotectionpolicies

--- a/config/extension-server/rbac/role.yaml
+++ b/config/extension-server/rbac/role.yaml
@@ -29,11 +29,21 @@ rules:
   - apiGroups:
       - networking.datumapis.com
     resources:
-      - trafficprotectionpolicies/status
       - httpproxies/status
       - connectors/status
     verbs:
       - get
+  # Edge-local Programmed feedback for TrafficProtectionPolicy (NSO#266). The
+  # extension server writes status only on the edge replica after a successful
+  # WAF apply; upstream NSO mirrors the Karmada-aggregated value to tenants.
+  - apiGroups:
+      - networking.datumapis.com
+    resources:
+      - trafficprotectionpolicies/status
+    verbs:
+      - get
+      - update
+      - patch
   # The edge re-translation controller patches a trigger annotation onto
   # Gateways to make Envoy Gateway re-translate when a Connector's liveness
   # changes.

--- a/internal/controller/gateway_resource_replicator_controller.go
+++ b/internal/controller/gateway_resource_replicator_controller.go
@@ -138,8 +138,9 @@ func initReplicationResourceConfigs() map[string]replicationResourceConfig {
 	// Policy types whose status is owned by NSO's upstream controllers —
 	// the replicator mirrors spec downstream so the extension server can read
 	// them from the local edge cluster. The replicator must NOT propagate
-	// downstream status back upstream (there is no downstream controller
-	// writing to these objects).
+	// downstream status back upstream wholesale: the extension server writes
+	// edge-local Programmed on TPP (NSO#266), and the upstream TPP reconciler
+	// explicitly mirrors the Karmada-aggregated Programmed condition.
 	policyGVKs := []schema.GroupVersionKind{
 		{Group: groupNetworkingDatumAPIs, Version: versionV1Alpha, Kind: KindTrafficProtectionPolicy},
 		{Group: groupNetworkingDatumAPIs, Version: versionV1Alpha, Kind: KindHTTPProxy},

--- a/internal/controller/tpp_programmed_test.go
+++ b/internal/controller/tpp_programmed_test.go
@@ -1,0 +1,119 @@
+package controller
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+
+	networkingv1alpha "go.datum.net/network-services-operator/api/v1alpha"
+)
+
+func TestProgrammedFromDownstream(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		downstream *networkingv1alpha.TrafficProtectionPolicy
+		missing    bool
+		generation int64
+		status     metav1.ConditionStatus
+		reason     gatewayv1.PolicyConditionReason
+		msgContain string
+	}{
+		{
+			name:       "missing downstream",
+			missing:    true,
+			generation: 2,
+			status:     metav1.ConditionFalse,
+			reason:     PolicyReasonProgrammedPending,
+			msgContain: "generation 2",
+		},
+		{
+			name:       "no programmed condition",
+			downstream: &networkingv1alpha.TrafficProtectionPolicy{},
+			generation: 1,
+			status:     metav1.ConditionFalse,
+			reason:     PolicyReasonProgrammedPending,
+			msgContain: "Waiting",
+		},
+		{
+			name: "stale generation",
+			downstream: &networkingv1alpha.TrafficProtectionPolicy{
+				Status: networkingv1alpha.TrafficProtectionPolicyStatus{
+					PolicyStatus: gatewayv1alpha2.PolicyStatus{
+						Ancestors: []gatewayv1.PolicyAncestorStatus{{
+							Conditions: []metav1.Condition{{
+								Type:               conditionTypeProgrammed,
+								Status:             metav1.ConditionTrue,
+								Reason:             string(PolicyReasonProgrammed),
+								ObservedGeneration: 1,
+								Message:            "1/1 edges programmed generation 1",
+							}},
+						}},
+					},
+				},
+			},
+			generation: 2,
+			status:     metav1.ConditionFalse,
+			reason:     PolicyReasonProgrammedPending,
+			msgContain: "generation 2",
+		},
+		{
+			name: "all edges programmed",
+			downstream: &networkingv1alpha.TrafficProtectionPolicy{
+				Status: networkingv1alpha.TrafficProtectionPolicyStatus{
+					PolicyStatus: gatewayv1alpha2.PolicyStatus{
+						Ancestors: []gatewayv1.PolicyAncestorStatus{{
+							Conditions: []metav1.Condition{{
+								Type:               conditionTypeProgrammed,
+								Status:             metav1.ConditionTrue,
+								Reason:             string(PolicyReasonProgrammed),
+								ObservedGeneration: 3,
+								Message:            "3/3 edges programmed generation 3",
+							}},
+						}},
+					},
+				},
+			},
+			generation: 3,
+			status:     metav1.ConditionTrue,
+			reason:     PolicyReasonProgrammed,
+			msgContain: "3/3",
+		},
+		{
+			name: "partial failure",
+			downstream: &networkingv1alpha.TrafficProtectionPolicy{
+				Status: networkingv1alpha.TrafficProtectionPolicyStatus{
+					PolicyStatus: gatewayv1alpha2.PolicyStatus{
+						Ancestors: []gatewayv1.PolicyAncestorStatus{{
+							Conditions: []metav1.Condition{{
+								Type:               conditionTypeProgrammed,
+								Status:             metav1.ConditionFalse,
+								Reason:             string(PolicyReasonProgrammedPartialFailure),
+								ObservedGeneration: 4,
+								Message:            "2/5 edges programmed generation 4",
+							}},
+						}},
+					},
+				},
+			},
+			generation: 4,
+			status:     metav1.ConditionFalse,
+			reason:     PolicyReasonProgrammedPartialFailure,
+			msgContain: "2/5",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			status, reason, message := programmedFromDownstream(tt.downstream, tt.missing, tt.generation)
+			assert.Equal(t, tt.status, status)
+			assert.Equal(t, tt.reason, reason)
+			assert.Contains(t, message, tt.msgContain)
+		})
+	}
+}

--- a/internal/controller/trafficprotectionpolicy_controller.go
+++ b/internal/controller/trafficprotectionpolicy_controller.go
@@ -16,6 +16,7 @@ import (
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
@@ -60,6 +61,18 @@ const (
 	// PolicyReasonWaitingForListenersProgrammed indicates that the policy is waiting
 	// for HTTPS listeners to be Programmed=True before EnvoyPatchPolicies can be created.
 	PolicyReasonWaitingForListenersProgrammed gatewayv1.PolicyConditionReason = "WaitingForListenersProgrammed"
+
+	// PolicyReasonProgrammed indicates the policy generation has been programmed
+	// on all edges that should serve it.
+	PolicyReasonProgrammed gatewayv1.PolicyConditionReason = "Programmed"
+
+	// PolicyReasonProgrammedPending indicates the policy has been accepted but
+	// edge programming for the current generation has not completed.
+	PolicyReasonProgrammedPending gatewayv1.PolicyConditionReason = "Pending"
+
+	// PolicyReasonProgrammedPartialFailure indicates some but not all edges have
+	// programmed the current policy generation.
+	PolicyReasonProgrammedPartialFailure gatewayv1.PolicyConditionReason = "PartialFailure"
 
 	// tppEnvoyPatchPolicyPrefix is the name prefix for all EnvoyPatchPolicies
 	// written by the TrafficProtectionPolicy controller ("tpp-<gateway-name>").
@@ -242,11 +255,124 @@ func (r *TrafficProtectionPolicyReconciler) Reconcile(ctx context.Context, req N
 		}
 	}
 
+	r.setProgrammedConditionsFromDownstream(ctx, downstreamNamespaceName, trafficProtectionPolicies)
+
 	if err := r.updateTPPAncestorsStatus(ctx, cl.GetClient(), trafficProtectionPolicies, originalTrafficProtectionPolicies); err != nil {
 		return ctrl.Result{}, err
 	}
 
 	return ctrl.Result{}, nil
+}
+
+// setProgrammedConditionsFromDownstream mirrors edge-applied Programmed status
+// from the downstream (Karmada-aggregated) TPP onto each upstream ancestor.
+// Accepted remains attach-only; Programmed means the current generation is live
+// on all edges (AND aggregation encodes M/N in the message when partial).
+func (r *TrafficProtectionPolicyReconciler) setProgrammedConditionsFromDownstream(
+	ctx context.Context,
+	downstreamNamespaceName string,
+	policies []*policyContext,
+) {
+	logger := log.FromContext(ctx)
+	downstreamClient := r.DownstreamCluster.GetClient()
+	controllerName := string(r.Config.Gateway.ControllerName)
+
+	for _, policy := range policies {
+		downstreamTPP := &networkingv1alpha.TrafficProtectionPolicy{}
+		err := downstreamClient.Get(ctx, client.ObjectKey{
+			Namespace: downstreamNamespaceName,
+			Name:      policy.Name,
+		}, downstreamTPP)
+		if client.IgnoreNotFound(err) != nil {
+			logger.Error(err, "failed to get downstream trafficprotectionpolicy", "name", policy.Name, "namespace", downstreamNamespaceName)
+		}
+
+		for _, targetRef := range policy.Spec.TargetRefs {
+			ancestorRef := getAncestorRefForTarget(policy.Namespace, targetRef)
+			accepted := findAncestorCondition(policy.Status.Ancestors, controllerName, ancestorRef, string(gatewayv1.PolicyConditionAccepted))
+			if accepted == nil || accepted.Status != metav1.ConditionTrue {
+				continue
+			}
+
+			status, reason, message := programmedFromDownstream(downstreamTPP, err != nil, policy.Generation)
+			gatewaystatus.SetConditionForPolicyAncestor(
+				&policy.Status.PolicyStatus,
+				ancestorRef,
+				controllerName,
+				gatewayv1.PolicyConditionType(conditionTypeProgrammed),
+				status,
+				reason,
+				message,
+				policy.Generation,
+			)
+		}
+	}
+}
+
+// programmedFromDownstream derives the upstream Programmed condition from the
+// downstream (edge/Karmada-aggregated) TPP status. Karmada AND-aggregation
+// collapses per-edge feedback into ancestor Programmed conditions whose
+// messages carry M/N when partial.
+func programmedFromDownstream(
+	downstreamTPP *networkingv1alpha.TrafficProtectionPolicy,
+	missing bool,
+	desiredGeneration int64,
+) (metav1.ConditionStatus, gatewayv1.PolicyConditionReason, string) {
+	pendingMsg := fmt.Sprintf("Waiting for policy generation %d to be programmed on edges", desiredGeneration)
+	if missing || downstreamTPP == nil {
+		return metav1.ConditionFalse, PolicyReasonProgrammedPending, pendingMsg
+	}
+
+	var best *metav1.Condition
+	for i := range downstreamTPP.Status.Ancestors {
+		cond := apimeta.FindStatusCondition(downstreamTPP.Status.Ancestors[i].Conditions, conditionTypeProgrammed)
+		if cond == nil {
+			continue
+		}
+		if best == nil || cond.Status != metav1.ConditionTrue {
+			best = cond
+		}
+	}
+	if best == nil {
+		return metav1.ConditionFalse, PolicyReasonProgrammedPending, pendingMsg
+	}
+	if best.ObservedGeneration < desiredGeneration {
+		return metav1.ConditionFalse, PolicyReasonProgrammedPending, pendingMsg
+	}
+
+	message := best.Message
+	if message == "" {
+		message = fmt.Sprintf("Policy generation %d programmed on edges", desiredGeneration)
+	}
+
+	if best.Status == metav1.ConditionTrue {
+		return metav1.ConditionTrue, PolicyReasonProgrammed, message
+	}
+
+	reason := PolicyReasonProgrammedPending
+	if best.Reason == string(PolicyReasonProgrammedPartialFailure) {
+		reason = PolicyReasonProgrammedPartialFailure
+	}
+	return metav1.ConditionFalse, reason, message
+}
+
+func findAncestorCondition(
+	ancestors []gatewayv1.PolicyAncestorStatus,
+	controllerName string,
+	ancestorRef *gatewayv1alpha2.ParentReference,
+	conditionType string,
+) *metav1.Condition {
+	for i := range ancestors {
+		ancestor := &ancestors[i]
+		if string(ancestor.ControllerName) != controllerName {
+			continue
+		}
+		if !equality.Semantic.DeepEqual(ancestor.AncestorRef, *ancestorRef) {
+			continue
+		}
+		return apimeta.FindStatusCondition(ancestor.Conditions, conditionType)
+	}
+	return nil
 }
 
 func (r *TrafficProtectionPolicyReconciler) getTrafficProtectionPolicyContexts(
@@ -1338,13 +1464,52 @@ func (r *TrafficProtectionPolicyReconciler) SetupWithManager(mgr mcmanager.Manag
 		r.enqueuePoliciesForCertificate(),
 	)
 
+	// Watch downstream TPP status so edge Programmed feedback requeues upstream.
+	downstreamTPPSource := source.TypedKind(
+		r.DownstreamCluster.GetCache(),
+		&networkingv1alpha.TrafficProtectionPolicy{},
+		r.enqueuePoliciesForDownstreamTPP(),
+	)
+
 	return mcbuilder.TypedControllerManagedBy[NamespaceReconcileRequest](mgr).
 		Watches(&networkingv1alpha.TrafficProtectionPolicy{}, EnqueueRequestForObjectNamespace).
 		Watches(&gatewayv1.Gateway{}, EnqueueRequestForObjectNamespace).
 		Watches(&gatewayv1.HTTPRoute{}, EnqueueRequestForObjectNamespace).
 		WatchesRawSource(downstreamCertificateSource).
+		WatchesRawSource(downstreamTPPSource).
 		Named("trafficprotectionpolicy").
 		Complete(r)
+}
+
+// enqueuePoliciesForDownstreamTPP enqueues the upstream namespace when a
+// downstream TrafficProtectionPolicy status changes (edge Programmed feedback).
+func (r *TrafficProtectionPolicyReconciler) enqueuePoliciesForDownstreamTPP() handler.TypedEventHandler[*networkingv1alpha.TrafficProtectionPolicy, NamespaceReconcileRequest] {
+	return handler.TypedEnqueueRequestsFromMapFunc(func(ctx context.Context, tpp *networkingv1alpha.TrafficProtectionPolicy) []NamespaceReconcileRequest {
+		logger := log.FromContext(ctx)
+
+		downstreamNamespaceName := tpp.GetNamespace()
+		var downstreamNamespace corev1.Namespace
+		if err := r.DownstreamCluster.GetClient().Get(ctx, client.ObjectKey{Name: downstreamNamespaceName}, &downstreamNamespace); err != nil {
+			logger.Error(err, "failed to get downstream namespace for trafficprotectionpolicy", "name", tpp.GetName(), jsonKeyNamespace, downstreamNamespaceName)
+			return nil
+		}
+
+		upstreamNamespace := downstreamNamespace.Labels[downstreamclient.UpstreamOwnerNamespaceLabel]
+		if upstreamNamespace == "" {
+			upstreamNamespace = tpp.Labels[downstreamclient.UpstreamOwnerNamespaceLabel]
+		}
+		if upstreamNamespace == "" {
+			return nil
+		}
+
+		clusterLabel := downstreamNamespace.Labels[downstreamclient.UpstreamOwnerClusterNameLabel]
+		upstreamClusterName := multicluster.ClusterName(downstreamclient.UpstreamClusterNameFromLabel(clusterLabel))
+
+		return []NamespaceReconcileRequest{{
+			Namespace:   upstreamNamespace,
+			ClusterName: upstreamClusterName,
+		}}
+	})
 }
 
 // enqueuePoliciesForCertificate returns an event handler that enqueues a reconcile

--- a/internal/extensionserver/cache/index.go
+++ b/internal/extensionserver/cache/index.go
@@ -16,6 +16,7 @@ import (
 	networkingv1alpha "go.datum.net/network-services-operator/api/v1alpha"
 	networkingv1alpha1 "go.datum.net/network-services-operator/api/v1alpha1"
 	"go.datum.net/network-services-operator/internal/downstreamclient"
+	extmetrics "go.datum.net/network-services-operator/internal/extensionserver/metrics"
 )
 
 // BuildPolicyIndexFromClient constructs the per-call in-memory policy index
@@ -108,11 +109,13 @@ func populateFromClient(ctx context.Context, cl client.Client, idx *PolicyIndex,
 		info := TPPInfo{
 			Namespace:  tpp.Namespace,
 			Name:       tpp.Name,
+			Generation: tpp.Generation,
 			Mode:       tpp.Spec.Mode,
 			TargetRefs: tpp.Spec.TargetRefs,
 			Directives: computeCorazaDirectives(tpp, baseDirectives),
 		}
 		idx.TPPs[effectiveNS] = append(idx.TPPs[effectiveNS], info)
+		extmetrics.TPPCacheGeneration.WithLabelValues(info.Namespace, info.Name).Set(float64(info.Generation))
 	}
 
 	// --- HTTPProxies → ConnectorInfo ---

--- a/internal/extensionserver/cache/index_test.go
+++ b/internal/extensionserver/cache/index_test.go
@@ -454,6 +454,7 @@ func TestBuildPolicyIndexFromClient_TPPFieldsPreserved(t *testing.T) {
 	scheme := indexTestScheme(t)
 
 	tpp := newTPP("test-ns", "my-tpp", func(tpp *networkingv1alpha.TrafficProtectionPolicy) {
+		tpp.Generation = 7
 		tpp.Spec.Mode = networkingv1alpha.TrafficProtectionPolicyEnforce
 		tpp.Spec.RuleSets = []networkingv1alpha.TrafficProtectionPolicyRuleSet{
 			{
@@ -481,6 +482,7 @@ func TestBuildPolicyIndexFromClient_TPPFieldsPreserved(t *testing.T) {
 	info := tpps[0]
 	assert.Equal(t, "test-ns", info.Namespace)
 	assert.Equal(t, "my-tpp", info.Name)
+	assert.Equal(t, int64(7), info.Generation)
 	assert.Equal(t, networkingv1alpha.TrafficProtectionPolicyEnforce, info.Mode)
 	assert.NotEmpty(t, info.Directives, "OWASP CRS rules must generate non-empty directives")
 }

--- a/internal/extensionserver/cache/types.go
+++ b/internal/extensionserver/cache/types.go
@@ -63,6 +63,7 @@ type PolicyIndex struct {
 type TPPInfo struct {
 	Namespace  string
 	Name       string
+	Generation int64
 	Mode       networkingv1alpha.TrafficProtectionPolicyMode
 	TargetRefs []v1alpha2.LocalPolicyTargetReferenceWithSectionName
 	// Directives is the pre-computed list of Coraza simple_directives for

--- a/internal/extensionserver/metrics/metrics.go
+++ b/internal/extensionserver/metrics/metrics.go
@@ -121,6 +121,27 @@ var (
 		},
 	)
 
+	// TPPCacheGeneration is the TrafficProtectionPolicy generation currently in
+	// the extension-server informer cache on this edge. Compare with
+	// TPPAppliedGeneration to see sync vs translate lag.
+	TPPCacheGeneration = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "nso_extension_tpp_cache_generation",
+			Help: "TrafficProtectionPolicy generation currently in the extension-server informer cache on this edge.",
+		},
+		[]string{"namespace", "name"},
+	)
+
+	// TPPAppliedGeneration is the TrafficProtectionPolicy generation last
+	// successfully applied via PostTranslateModify on this edge.
+	TPPAppliedGeneration = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "nso_extension_tpp_applied_generation",
+			Help: "TrafficProtectionPolicy generation last successfully applied via PostTranslateModify on this edge.",
+		},
+		[]string{"namespace", "name"},
+	)
+
 	// ConnectorClustersTotal counts total connector backend cluster replacements
 	// across all hook invocations. One increment = one cluster replaced with a
 	// STATIC internal-upstream cluster.

--- a/internal/extensionserver/mutate/tpp.go
+++ b/internal/extensionserver/mutate/tpp.go
@@ -159,11 +159,15 @@ func InjectCorazaListenerFilters(l *listenerv3.Listener, cfg *CorazaConfig) (int
 //  4. Finds the governing TPP from idx.TPPs (route-level wins over gateway-level).
 //  5. Writes typed_per_filter_config and datum-gateway metadata on governed routes.
 //
+// applied, when non-nil, is populated with "namespace/name" → generation for
+// each TPP successfully applied in this call.
+//
 // Returns the number of routes mutated (WAF-configured routes only).
 func ApplyTPPRouteConfig(
 	rc *routev3.RouteConfiguration,
 	idx *extcache.PolicyIndex,
 	cfg *CorazaConfig,
+	applied map[string]int64,
 ) (int, error) {
 	mutated := 0
 	for _, vh := range rc.GetVirtualHosts() {
@@ -214,6 +218,9 @@ func ApplyTPPRouteConfig(
 
 			if err := applyRouteWAFConfig(rt, governing, projectName, cfg); err != nil {
 				return mutated, fmt.Errorf("apply WAF config to route %q: %w", rt.GetName(), err)
+			}
+			if applied != nil {
+				applied[governing.Namespace+"/"+governing.Name] = governing.Generation
 			}
 			mutated++
 		}
@@ -411,6 +418,7 @@ func buildDatumGatewayMetadata(tpp *extcache.TPPInfo, projectName string) (*stru
 				egMetaFieldNamespace: tpp.Namespace,
 				egMetaFieldName:      tpp.Name,
 				"mode":               string(tpp.Mode),
+				"generation":         tpp.Generation,
 			},
 		},
 	})

--- a/internal/extensionserver/mutate/tpp_test.go
+++ b/internal/extensionserver/mutate/tpp_test.go
@@ -106,9 +106,10 @@ func buildVHWithGatewayMeta(routes ...*routev3.Route) *routev3.VirtualHost {
 // The upstream namespace is fixed as "test-project" — all callers in this package use that value.
 func tppTargetingGateway(tppName, gwName string) extcache.TPPInfo {
 	return extcache.TPPInfo{
-		Namespace: "test-project",
-		Name:      tppName,
-		Mode:      networkingv1alpha.TrafficProtectionPolicyObserve,
+		Namespace:  "test-project",
+		Name:       tppName,
+		Generation: 1,
+		Mode:       networkingv1alpha.TrafficProtectionPolicyObserve,
 		TargetRefs: []gatewayv1alpha2.LocalPolicyTargetReferenceWithSectionName{
 			{
 				LocalPolicyTargetReference: gatewayv1.LocalPolicyTargetReference{
@@ -125,9 +126,10 @@ func tppTargetingGateway(tppName, gwName string) extcache.TPPInfo {
 // tppTargetingHTTPRoute returns a TPPInfo that targets the named HTTPRoute.
 func tppTargetingHTTPRoute(upstreamNS, tppName, routeName string) extcache.TPPInfo {
 	return extcache.TPPInfo{
-		Namespace: upstreamNS,
-		Name:      tppName,
-		Mode:      networkingv1alpha.TrafficProtectionPolicyEnforce,
+		Namespace:  upstreamNS,
+		Name:       tppName,
+		Generation: 1,
+		Mode:       networkingv1alpha.TrafficProtectionPolicyEnforce,
 		TargetRefs: []gatewayv1alpha2.LocalPolicyTargetReferenceWithSectionName{
 			{
 				LocalPolicyTargetReference: gatewayv1.LocalPolicyTargetReference{
@@ -283,7 +285,7 @@ func TestApplyTPPRouteConfig_GoverningGatewayTPP_AnnotatesRoutes(t *testing.T) {
 		VirtualHosts: []*routev3.VirtualHost{vh},
 	}
 
-	n, err := ApplyTPPRouteConfig(rc, idx, cfg)
+	n, err := ApplyTPPRouteConfig(rc, idx, cfg, nil)
 	require.NoError(t, err)
 	assert.Equal(t, 2, n, "both routes should be mutated")
 
@@ -327,7 +329,7 @@ func TestApplyTPPRouteConfig_NoEGMetadata_Skipped(t *testing.T) {
 		},
 	}
 
-	n, err := ApplyTPPRouteConfig(rc, idx, cfg)
+	n, err := ApplyTPPRouteConfig(rc, idx, cfg, nil)
 	require.NoError(t, err)
 	assert.Equal(t, 0, n, "VH without EG metadata must be skipped")
 
@@ -354,7 +356,7 @@ func TestApplyTPPRouteConfig_UnknownDSNamespace_Skipped(t *testing.T) {
 	)
 	rc := &routev3.RouteConfiguration{VirtualHosts: []*routev3.VirtualHost{vh}}
 
-	n, err := ApplyTPPRouteConfig(rc, idx, cfg)
+	n, err := ApplyTPPRouteConfig(rc, idx, cfg, nil)
 	require.NoError(t, err)
 	assert.Equal(t, 0, n, "VH with unknown dsNS must be skipped")
 }
@@ -371,7 +373,7 @@ func TestApplyTPPRouteConfig_NoGoverningTPP_RoutesUntouched(t *testing.T) {
 	)
 	rc := &routev3.RouteConfiguration{VirtualHosts: []*routev3.VirtualHost{vh}}
 
-	n, err := ApplyTPPRouteConfig(rc, idx, cfg)
+	n, err := ApplyTPPRouteConfig(rc, idx, cfg, nil)
 	require.NoError(t, err)
 	assert.Equal(t, 0, n, "route with no governing TPP must be untouched")
 	assert.Nil(t, rc.VirtualHosts[0].Routes[0].GetTypedPerFilterConfig(),
@@ -407,7 +409,7 @@ func TestApplyTPPRouteConfig_EmptyDirectives_RoutesUntouched(t *testing.T) {
 	)
 	rc := &routev3.RouteConfiguration{VirtualHosts: []*routev3.VirtualHost{vh}}
 
-	n, err := ApplyTPPRouteConfig(rc, idx, cfg)
+	n, err := ApplyTPPRouteConfig(rc, idx, cfg, nil)
 	require.NoError(t, err)
 	assert.Equal(t, 0, n, "TPP with no directives must not annotate routes")
 }
@@ -510,7 +512,7 @@ func TestApplyTPPRouteConfig_Disabled_StampsProjectName(t *testing.T) {
 		VirtualHosts: []*routev3.VirtualHost{vh},
 	}
 
-	n, err := ApplyTPPRouteConfig(rc, idx, cfg)
+	n, err := ApplyTPPRouteConfig(rc, idx, cfg, nil)
 	require.NoError(t, err)
 	assert.Equal(t, 0, n, "disabled Coraza must not count any WAF per-route mutations")
 
@@ -561,7 +563,7 @@ func TestApplyTPPRouteConfig_RouteLevelTPPWins(t *testing.T) {
 	vh := buildVHWithGatewayMeta(rt)
 	rc := &routev3.RouteConfiguration{VirtualHosts: []*routev3.VirtualHost{vh}}
 
-	n, err := ApplyTPPRouteConfig(rc, idx, cfg)
+	n, err := ApplyTPPRouteConfig(rc, idx, cfg, nil)
 	require.NoError(t, err)
 	assert.Equal(t, 1, n)
 

--- a/internal/extensionserver/server/programmedset.go
+++ b/internal/extensionserver/server/programmedset.go
@@ -129,8 +129,8 @@ func buildProgrammedSet(
 			for _, rt := range vh.GetRoutes() {
 				// The identity includes the protection policy governing the route,
 				// so a route protected by the wrong policy shows up as a mismatch.
-				if ns, name, mode, ok := datumGatewayTPP(rt); ok {
-					add(FamilyWAFRoute, wafRouteKey(rcName, vhName, rt.GetName(), ns, name, mode))
+				if ns, name, mode, generation, ok := datumGatewayTPP(rt); ok {
+					add(FamilyWAFRoute, wafRouteKey(rcName, vhName, rt.GetName(), ns, name, mode, generation))
 				}
 				if isConnectRoute(rt) {
 					add(FamilyConnectorRoute, connectorRouteKey(rcName, vhName, rt.GetName()))

--- a/internal/extensionserver/server/programmedset_scan.go
+++ b/internal/extensionserver/server/programmedset_scan.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"sort"
+	"strconv"
 	"strings"
 
 	clusterv3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
@@ -19,12 +20,12 @@ const keySep = "##"
 
 // wafRouteKey is the identity of a route protected by a firewall:
 //
-//	<routeConfig>##<virtualHost>##<routeName>##<policyNamespace>/<policyName>/<mode>
+//	<routeConfig>##<virtualHost>##<routeName>##<policyNamespace>/<policyName>/<mode>/<generation>
 //
 // The governing policy is part of the identity, so a route protected by the
 // wrong policy produces a different identity and is caught as a mismatch.
-func wafRouteKey(rc, vh, rt, tppNS, tppName, mode string) string {
-	return strings.Join([]string{rc, vh, rt, tppNS + "/" + tppName + "/" + mode}, keySep)
+func wafRouteKey(rc, vh, rt, tppNS, tppName, mode string, generation int64) string {
+	return strings.Join([]string{rc, vh, rt, tppNS + "/" + tppName + "/" + mode + "/" + strconv.FormatInt(generation, 10)}, keySep)
 }
 
 // connectorRouteKey is the identity of a connector route (online or offline):
@@ -42,25 +43,26 @@ func listenerChainKey(listener, chain string) string {
 }
 
 // datumGatewayTPP returns the protection policy governing a route (namespace,
-// name, mode). ok is false when the route carries no such marker, meaning it is
-// not protected.
-func datumGatewayTPP(rt *routev3.Route) (ns, name, mode string, ok bool) {
+// name, mode, generation). ok is false when the route carries no such marker,
+// meaning it is not protected.
+func datumGatewayTPP(rt *routev3.Route) (ns, name, mode string, generation int64, ok bool) {
 	md := rt.GetMetadata()
 	if md == nil {
-		return "", "", "", false
+		return "", "", "", 0, false
 	}
 	dg := md.GetFilterMetadata()[datumGatewayMetaKey]
 	if dg == nil {
-		return "", "", "", false
+		return "", "", "", 0, false
 	}
 	res := dg.GetFields()["resources"].GetListValue()
 	if res == nil || len(res.GetValues()) == 0 {
-		return "", "", "", false
+		return "", "", "", 0, false
 	}
 	f := res.GetValues()[0].GetStructValue().GetFields()
 	return f["namespace"].GetStringValue(),
 		f["name"].GetStringValue(),
 		f["mode"].GetStringValue(),
+		int64(f["generation"].GetNumberValue()),
 		true
 }
 

--- a/internal/extensionserver/server/programmedset_test.go
+++ b/internal/extensionserver/server/programmedset_test.go
@@ -39,10 +39,11 @@ func mkWAFRoute(t *testing.T, tppNS, tppName string) *routev3.Route {
 	meta, err := structpb.NewStruct(map[string]any{
 		"resources": []any{
 			map[string]any{
-				"kind":      "TrafficProtectionPolicy",
-				"namespace": tppNS,
-				"name":      tppName,
-				"mode":      "Observe",
+				"kind":       "TrafficProtectionPolicy",
+				"namespace":  tppNS,
+				"name":       tppName,
+				"mode":       "Observe",
+				"generation": float64(1),
 			},
 		},
 	})
@@ -130,7 +131,7 @@ func TestBuildProgrammedSet_AllFamilies(t *testing.T) {
 
 	ps := buildProgrammedSet(listeners, routes, clusters, corazaFilter, 2, 1, 0)
 
-	assert.Equal(t, []string{wafRouteKey("gw/https", "vh", "fwd", "proj-ns", "test-tpp", "Observe")},
+	assert.Equal(t, []string{wafRouteKey("gw/https", "vh", "fwd", "proj-ns", "test-tpp", "Observe", 1)},
 		ps.Keys[FamilyWAFRoute])
 	assert.Equal(t, 1, ps.Counts[FamilyWAFRoute])
 
@@ -240,7 +241,7 @@ func TestProgrammedSetHandler_ServesJSON(t *testing.T) {
 	var got ProgrammedSet
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
 	assert.Equal(t, uint64(1), got.BuildID)
-	assert.Equal(t, []string{wafRouteKey("gw/https", "vh", "fwd", "proj-a", "tpp-a", "Observe")},
+	assert.Equal(t, []string{wafRouteKey("gw/https", "vh", "fwd", "proj-a", "tpp-a", "Observe", 1)},
 		got.Keys[FamilyWAFRoute])
 }
 
@@ -343,7 +344,7 @@ func TestPostTranslateModify_RecordsProgrammedSet(t *testing.T) {
 
 	// The WAF route key must name the governing TPP (wrong-keyed oracle).
 	require.Len(t, ps.Keys[FamilyWAFRoute], 1)
-	assert.Contains(t, ps.Keys[FamilyWAFRoute][0], "test-project/test-tpp/Observe")
+	assert.Contains(t, ps.Keys[FamilyWAFRoute][0], "test-project/test-tpp/Observe/")
 }
 
 // TestPostTranslateModify_NoRecordingWhenDisabled proves the production default:

--- a/internal/extensionserver/server/server.go
+++ b/internal/extensionserver/server/server.go
@@ -218,8 +218,9 @@ func (s *Server) PostTranslateModify(
 	tppListenersSpan.End()
 
 	_, tppRoutesSpan := tr.Start(mctx, "tpp.routes")
+	appliedTPPs := map[string]int64{}
 	for _, rc := range routes {
-		n, mutErr := mutate.ApplyTPPRouteConfig(rc, idx, &s.cfg.Coraza)
+		n, mutErr := mutate.ApplyTPPRouteConfig(rc, idx, &s.cfg.Coraza, appliedTPPs)
 		if mutErr != nil {
 			s.log.Error("apply tpp route config", "route_config", rc.GetName(), "err", mutErr)
 			tppRoutesSpan.RecordError(mutErr)
@@ -235,6 +236,15 @@ func (s *Server) PostTranslateModify(
 	}
 	tppRoutesSpan.SetAttributes(attribute.Int("routes.tpp_applied", tppCount))
 	tppRoutesSpan.End()
+
+	for key, gen := range appliedTPPs {
+		ns, name, ok := splitNamespaceName(key)
+		if !ok {
+			continue
+		}
+		extmetrics.TPPAppliedGeneration.WithLabelValues(ns, name).Set(float64(gen))
+	}
+	s.markTPPsProgrammed(ctx, appliedTPPs)
 
 	// --- Connector family ---
 	// Replace clusters BEFORE adding CONNECT routes so route wiring sees the

--- a/internal/extensionserver/server/tpp_status.go
+++ b/internal/extensionserver/server/tpp_status.go
@@ -1,0 +1,90 @@
+package server
+
+import (
+	"context"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+
+	networkingv1alpha "go.datum.net/network-services-operator/api/v1alpha"
+	gatewaystatus "go.datum.net/network-services-operator/internal/gatewayapi/status"
+)
+
+const (
+	// edgeProgrammedControllerName identifies the extension server as the
+	// writer of edge-local Programmed conditions. Upstream NSO mirrors the
+	// Karmada-aggregated value onto the project-CP TPP.
+	edgeProgrammedControllerName = "networking.datumapis.com/envoy-gateway-extension-server"
+
+	conditionTypeProgrammed                     = "Programmed"
+	conditionReasonProgrammed gatewayv1.PolicyConditionReason = "Programmed"
+)
+
+// markTPPsProgrammed writes Programmed=True on each applied TrafficProtectionPolicy's
+// edge-local status with observedGeneration matching the applied generation.
+// Idempotent. Errors are logged and do not fail the xDS hook — the config is
+// already in the snapshot.
+func (s *Server) markTPPsProgrammed(ctx context.Context, applied map[string]int64) {
+	if len(applied) == 0 {
+		return
+	}
+	for key, gen := range applied {
+		ns, name, ok := splitNamespaceName(key)
+		if !ok {
+			continue
+		}
+		if err := s.markTPPProgrammed(ctx, ns, name, gen); err != nil {
+			s.log.Error("mark tpp programmed", "namespace", ns, "name", name, "generation", gen, "err", err)
+		}
+	}
+}
+
+func (s *Server) markTPPProgrammed(ctx context.Context, namespace, name string, generation int64) error {
+	tpp := &networkingv1alpha.TrafficProtectionPolicy{}
+	if err := s.client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, tpp); err != nil {
+		return err
+	}
+
+	original := tpp.Status.DeepCopy()
+	for _, targetRef := range tpp.Spec.TargetRefs {
+		ancestorRef := ancestorRefForTarget(tpp.Namespace, targetRef)
+		gatewaystatus.SetConditionForPolicyAncestor(
+			&tpp.Status.PolicyStatus,
+			ancestorRef,
+			edgeProgrammedControllerName,
+			gatewayv1.PolicyConditionType(conditionTypeProgrammed),
+			metav1.ConditionTrue,
+			conditionReasonProgrammed,
+			"Policy has been programmed on this edge.",
+			generation,
+		)
+	}
+
+	if equality.Semantic.DeepEqual(original, &tpp.Status) {
+		return nil
+	}
+	return s.client.Status().Update(ctx, tpp)
+}
+
+func ancestorRefForTarget(namespace string, targetRef gatewayv1alpha2.LocalPolicyTargetReferenceWithSectionName) *gatewayv1alpha2.ParentReference {
+	return &gatewayv1alpha2.ParentReference{
+		Group:       ptr.To(targetRef.Group),
+		Kind:        ptr.To(targetRef.Kind),
+		Name:        targetRef.Name,
+		Namespace:   ptr.To(gatewayv1.Namespace(namespace)),
+		SectionName: targetRef.SectionName,
+	}
+}
+
+func splitNamespaceName(key string) (namespace, name string, ok bool) {
+	ns, name, found := strings.Cut(key, "/")
+	if !found || ns == "" || name == "" || strings.Contains(name, "/") {
+		return "", "", false
+	}
+	return ns, name, true
+}

--- a/internal/extensionserver/server/tpp_status.go
+++ b/internal/extensionserver/server/tpp_status.go
@@ -21,7 +21,7 @@ const (
 	// Karmada-aggregated value onto the project-CP TPP.
 	edgeProgrammedControllerName = "networking.datumapis.com/envoy-gateway-extension-server"
 
-	conditionTypeProgrammed                     = "Programmed"
+	conditionTypeProgrammed                                   = "Programmed"
 	conditionReasonProgrammed gatewayv1.PolicyConditionReason = "Programmed"
 )
 

--- a/internal/extensionserver/server/tpp_status_test.go
+++ b/internal/extensionserver/server/tpp_status_test.go
@@ -1,0 +1,111 @@
+package server
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+
+	networkingv1alpha "go.datum.net/network-services-operator/api/v1alpha"
+)
+
+func TestMarkTPPsProgrammed_SetsEdgeStatus(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, networkingv1alpha.AddToScheme(scheme))
+
+	tpp := &networkingv1alpha.TrafficProtectionPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "my-tpp",
+			Namespace:  "proj-ns",
+			Generation: 3,
+		},
+		Spec: networkingv1alpha.TrafficProtectionPolicySpec{
+			Mode: networkingv1alpha.TrafficProtectionPolicyEnforce,
+			TargetRefs: []gatewayv1alpha2.LocalPolicyTargetReferenceWithSectionName{{
+				LocalPolicyTargetReference: gatewayv1.LocalPolicyTargetReference{
+					Group: gatewayv1.GroupName,
+					Kind:  "Gateway",
+					Name:  "edge-gw",
+				},
+			}},
+		},
+	}
+
+	cl := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(tpp).
+		WithObjects(tpp).
+		Build()
+
+	s := New(cl, ServerConfig{}, slog.Default())
+	s.markTPPsProgrammed(context.Background(), map[string]int64{"proj-ns/my-tpp": 3})
+
+	got := &networkingv1alpha.TrafficProtectionPolicy{}
+	require.NoError(t, cl.Get(context.Background(), client.ObjectKeyFromObject(tpp), got))
+	require.Len(t, got.Status.Ancestors, 1)
+	require.Len(t, got.Status.Ancestors[0].Conditions, 1)
+
+	cond := got.Status.Ancestors[0].Conditions[0]
+	assert.Equal(t, conditionTypeProgrammed, cond.Type)
+	assert.Equal(t, metav1.ConditionTrue, cond.Status)
+	assert.Equal(t, string(conditionReasonProgrammed), cond.Reason)
+	assert.Equal(t, int64(3), cond.ObservedGeneration)
+	assert.Equal(t, gatewayv1.ObjectName("edge-gw"), got.Status.Ancestors[0].AncestorRef.Name)
+	assert.Equal(t, ptr.To(gatewayv1.Namespace("proj-ns")), got.Status.Ancestors[0].AncestorRef.Namespace)
+}
+
+func TestMarkTPPsProgrammed_Idempotent(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, networkingv1alpha.AddToScheme(scheme))
+
+	tpp := &networkingv1alpha.TrafficProtectionPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-tpp", Namespace: "proj-ns", Generation: 2},
+		Spec: networkingv1alpha.TrafficProtectionPolicySpec{
+			Mode: networkingv1alpha.TrafficProtectionPolicyObserve,
+			TargetRefs: []gatewayv1alpha2.LocalPolicyTargetReferenceWithSectionName{{
+				LocalPolicyTargetReference: gatewayv1.LocalPolicyTargetReference{
+					Group: gatewayv1.GroupName,
+					Kind:  "Gateway",
+					Name:  "edge-gw",
+				},
+			}},
+		},
+	}
+
+	cl := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(tpp).
+		WithObjects(tpp).
+		Build()
+
+	s := New(cl, ServerConfig{}, slog.Default())
+	applied := map[string]int64{"proj-ns/my-tpp": 2}
+	s.markTPPsProgrammed(context.Background(), applied)
+	s.markTPPsProgrammed(context.Background(), applied)
+
+	got := &networkingv1alpha.TrafficProtectionPolicy{}
+	require.NoError(t, cl.Get(context.Background(), client.ObjectKeyFromObject(tpp), got))
+	require.Len(t, got.Status.Ancestors, 1)
+	require.Len(t, got.Status.Ancestors[0].Conditions, 1)
+}
+
+func TestSplitNamespaceName(t *testing.T) {
+	ns, name, ok := splitNamespaceName("a/b")
+	assert.True(t, ok)
+	assert.Equal(t, "a", ns)
+	assert.Equal(t, "b", name)
+
+	_, _, ok = splitNamespaceName("noslash")
+	assert.False(t, ok)
+	_, _, ok = splitNamespaceName("a/b/c")
+	assert.False(t, ok)
+}

--- a/test/e2e/trafficprotectionpolicy-enforce/chainsaw-test.yaml
+++ b/test/e2e/trafficprotectionpolicy-enforce/chainsaw-test.yaml
@@ -136,6 +136,18 @@ spec:
               status:
                 (conditions[?type == 'Programmed']):
                   - status: "True"
+        - assert:
+            # NSO#266: extension server must stamp Programmed on the edge TPP
+            # after a successful WAF apply (observedGeneration matches).
+            timeout: 3m
+            resource:
+              apiVersion: networking.datumapis.com/v1alpha
+              kind: TrafficProtectionPolicy
+              metadata:
+                name: enforce-waf
+              status:
+                (ancestors[?conditions[?type == 'Programmed' && status == 'True']]):
+                  - (length(conditions[?type == 'Programmed' && status == 'True'])): 1
       catch:
         - script:
             timeout: 60s

--- a/test/parity/configdump_test.go
+++ b/test/parity/configdump_test.go
@@ -35,7 +35,11 @@ func buildSyntheticDump(t *testing.T, corazaFilter string) []byte {
 	// --- WAF-governed route + CONNECT route ---
 	wafMeta, err := structpb.NewStruct(map[string]any{
 		"resources": []any{map[string]any{
-			"kind": "TrafficProtectionPolicy", "namespace": "proj-ns", "name": "test-tpp", "mode": "Observe", "generation": float64(1),
+			"kind":       "TrafficProtectionPolicy",
+			"namespace":  "proj-ns",
+			"name":       "test-tpp",
+			"mode":       "Observe",
+			"generation": float64(1),
 		}},
 	})
 	require.NoError(t, err)

--- a/test/parity/configdump_test.go
+++ b/test/parity/configdump_test.go
@@ -35,7 +35,7 @@ func buildSyntheticDump(t *testing.T, corazaFilter string) []byte {
 	// --- WAF-governed route + CONNECT route ---
 	wafMeta, err := structpb.NewStruct(map[string]any{
 		"resources": []any{map[string]any{
-			"kind": "TrafficProtectionPolicy", "namespace": "proj-ns", "name": "test-tpp", "mode": "Observe",
+			"kind": "TrafficProtectionPolicy", "namespace": "proj-ns", "name": "test-tpp", "mode": "Observe", "generation": float64(1),
 		}},
 	})
 	require.NoError(t, err)
@@ -132,7 +132,7 @@ func TestParseAndScan_EndToEnd(t *testing.T) {
 	assert.Equal(t, []string{"good-cert"}, dump.SecretNames)
 
 	act := ScanActual(dump, corazaFilter, nil)
-	assert.Equal(t, []string{wafRouteKey("gw/https", "vh", "fwd", "proj-ns", "test-tpp", "Observe")},
+	assert.Equal(t, []string{wafRouteKey("gw/https", "vh", "fwd", "proj-ns", "test-tpp", "Observe", 1)},
 		normalize(act.Keys[FamilyWAFRoute]))
 	assert.Equal(t, []string{"httproute/proj-ns/proxy/rule/0"}, normalize(act.Keys[FamilyConnectorCluster]))
 	assert.Equal(t, []string{connectorRouteKey("gw/https", "vh", "connector-connect-vh")},
@@ -154,7 +154,7 @@ func TestParseAndScan_FullParity(t *testing.T) {
 	// Expected derived from the same artifact set (as the programmed-set endpoint
 	// would report it).
 	expected := exp(map[Family][]string{
-		FamilyWAFRoute:         {wafRouteKey("gw/https", "vh", "fwd", "proj-ns", "test-tpp", "Observe")},
+		FamilyWAFRoute:         {wafRouteKey("gw/https", "vh", "fwd", "proj-ns", "test-tpp", "Observe", 1)},
 		FamilyConnectorCluster: {"httproute/proj-ns/proxy/rule/0"},
 		FamilyConnectorRoute:   {connectorRouteKey("gw/https", "vh", "connector-connect-vh")},
 		FamilyWAFHCM:           {listenerChainKey("gw/https", "fc")},

--- a/test/parity/scan.go
+++ b/test/parity/scan.go
@@ -95,7 +95,8 @@ func scanListener(l *listenerv3.Listener, corazaFilterName string, act *Actual) 
 // --- identity formats (MUST match the extension server) ---
 
 func wafRouteKey(rc, vh, rt, tppNS, tppName, mode string, generation int64) string {
-	return strings.Join([]string{rc, vh, rt, tppNS + "/" + tppName + "/" + mode + "/" + strconv.FormatInt(generation, 10)}, keySep)
+	tpp := tppNS + "/" + tppName + "/" + mode + "/" + strconv.FormatInt(generation, 10)
+	return strings.Join([]string{rc, vh, rt, tpp}, keySep)
 }
 
 func connectorRouteKey(rc, vh, rt string) string {

--- a/test/parity/scan.go
+++ b/test/parity/scan.go
@@ -1,6 +1,7 @@
 package parity
 
 import (
+	"strconv"
 	"strings"
 
 	clusterv3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
@@ -63,9 +64,9 @@ func scanRouteConfig(rc *routev3.RouteConfiguration, act *Actual) {
 	for _, vh := range rc.GetVirtualHosts() {
 		vhName := vh.GetName()
 		for _, rt := range vh.GetRoutes() {
-			if ns, name, mode, ok := datumGatewayTPP(rt); ok {
+			if ns, name, mode, generation, ok := datumGatewayTPP(rt); ok {
 				act.Keys[FamilyWAFRoute] = append(act.Keys[FamilyWAFRoute],
-					wafRouteKey(rcName, vhName, rt.GetName(), ns, name, mode))
+					wafRouteKey(rcName, vhName, rt.GetName(), ns, name, mode, generation))
 			}
 			if isConnectRoute(rt) {
 				act.Keys[FamilyConnectorRoute] = append(act.Keys[FamilyConnectorRoute],
@@ -93,8 +94,8 @@ func scanListener(l *listenerv3.Listener, corazaFilterName string, act *Actual) 
 
 // --- identity formats (MUST match the extension server) ---
 
-func wafRouteKey(rc, vh, rt, tppNS, tppName, mode string) string {
-	return strings.Join([]string{rc, vh, rt, tppNS + "/" + tppName + "/" + mode}, keySep)
+func wafRouteKey(rc, vh, rt, tppNS, tppName, mode string, generation int64) string {
+	return strings.Join([]string{rc, vh, rt, tppNS + "/" + tppName + "/" + mode + "/" + strconv.FormatInt(generation, 10)}, keySep)
 }
 
 func connectorRouteKey(rc, vh, rt string) string {
@@ -107,23 +108,24 @@ func listenerChainKey(listener, chain string) string {
 
 // --- detectors (mirror, in reverse, how the configuration is written) ---
 
-func datumGatewayTPP(rt *routev3.Route) (ns, name, mode string, ok bool) {
+func datumGatewayTPP(rt *routev3.Route) (ns, name, mode string, generation int64, ok bool) {
 	md := rt.GetMetadata()
 	if md == nil {
-		return "", "", "", false
+		return "", "", "", 0, false
 	}
 	dg := md.GetFilterMetadata()[datumGatewayMetaKey]
 	if dg == nil {
-		return "", "", "", false
+		return "", "", "", 0, false
 	}
 	res := dg.GetFields()["resources"].GetListValue()
 	if res == nil || len(res.GetValues()) == 0 {
-		return "", "", "", false
+		return "", "", "", 0, false
 	}
 	f := res.GetValues()[0].GetStructValue().GetFields()
 	return f["namespace"].GetStringValue(),
 		f["name"].GetStringValue(),
 		f["mode"].GetStringValue(),
+		int64(f["generation"].GetNumberValue()),
 		true
 }
 


### PR DESCRIPTION
## Summary

`Accepted` on a TrafficProtectionPolicy only means the policy attached on the control plane. Tenants and e2e have no way to tell when WAF config is actually live on every edge, so Observe/Enforce can look ready while the previous generation still serves traffic.

This adds an ancestor `Programmed` condition that turns True only after the extension server successfully applies the current generation on the edge, then mirrors Karmada's AND-aggregated status upstream with M/N messaging (`Pending` / `PartialFailure` / `Programmed`). Cache and applied generation gauges plus route metadata `generation` support ops lag checks. `Accepted` stays attach-only; product labels like Protected stay in portal/CLI.

## Test plan

- [x] Unit tests for programmed-set / TPP status / controller mirroring
- [x] e2e `trafficprotectionpolicy-enforce` asserts `Programmed`
- [ ] After deploy: flip Observe→Enforce and confirm `Programmed` goes False then True, with M/N during multi-edge skew
- [ ] Confirm `Accepted` is unchanged on attach-only

## Notes for reviewers

- Needs the staging Karmada aggregation PR in `infra` before hub objects show aggregated `Programmed`.
- Ask #2 (latency SLO / alert) is still open on #266, so this does not close the issue.

Related to #266