### PR TITLE
fix: stop controller error-ratio alerts flapping

### DIFF
--- a/.github/workflows/test-prometheus-rules.yaml
+++ b/.github/workflows/test-prometheus-rules.yaml
@@ -1,0 +1,32 @@
+name: Prometheus Rules Tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test-prometheus-rules:
+    name: Run on Ubuntu
+    runs-on: ubuntu-latest
+    env:
+      PROMETHEUS_VERSION: 3.13.2
+    steps:
+      - name: Clone the code
+        uses: actions/checkout@v4
+
+      - name: Install Task
+        uses: arduino/setup-task@v2
+        with:
+          version: 3.x
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install promtool
+        run: |
+          curl -fsSL -o /tmp/prometheus.tar.gz \
+            "https://github.com/prometheus/prometheus/releases/download/v${PROMETHEUS_VERSION}/prometheus-${PROMETHEUS_VERSION}.linux-amd64.tar.gz"
+          tar -xzf /tmp/prometheus.tar.gz -C /tmp
+          sudo install -m 0755 "/tmp/prometheus-${PROMETHEUS_VERSION}.linux-amd64/promtool" /usr/local/bin/promtool
+          promtool --version
+
+      - name: Running Tests
+        run: task test-prometheus-rules

--- a/config/telemetry/alerts/controller-health.yaml
+++ b/config/telemetry/alerts/controller-health.yaml
@@ -9,26 +9,36 @@ spec:
   # reconciler is failing to apply its intent. A high error ratio means writes
   # are being rejected (invalid objects, admission errors, permissions), the
   # controller is hot-looping, and the last successfully written state stays
-  # programmed. The `controller` label names the offending reconciler.
+  # programmed. The `controller` label names the offending reconciler, and
+  # `cluster`/`namespace` name where it is running.
+  #
+  # A controller reconciling only a handful of objects produces no samples at
+  # all in a short window: the denominator goes to zero, the series disappears,
+  # and the alert resolves and re-fires every time `for` elapses again. The
+  # 30-minute range keeps the series continuous at low reconcile volume, and
+  # `keep_firing_for` holds the alert through the remaining gaps and through
+  # brief dips under the threshold, so a persistently failing controller pages
+  # once instead of flapping.
   - name: nso-controller-health
     interval: 30s
     rules:
     # Fires when more than 20% of a controller's reconcile attempts fail over a
-    # 10-minute window, sustained for 15 minutes. Grouped by controller so each
-    # reconciler is evaluated independently and the alert names which one.
+    # 30-minute window, sustained for 15 minutes. Each reconciler is evaluated
+    # independently per cluster and namespace.
     - alert: ControllerReconcileErrorRatioHigh
       expr: |
         (
-          sum by (controller) (rate(controller_runtime_reconcile_total{result="error"}[10m]))
+          sum by (cluster, namespace, controller) (rate(controller_runtime_reconcile_total{result="error"}[30m]))
           /
-          sum by (controller) (rate(controller_runtime_reconcile_total[10m]))
+          sum by (cluster, namespace, controller) (rate(controller_runtime_reconcile_total[30m]))
         ) > 0.2
       for: 15m
+      keep_firing_for: 30m
       labels:
         severity: warning
       annotations:
-        summary: "Controller {{ $labels.controller }} reconcile error ratio is {{ $value | humanizePercentage }} (threshold 20%)"
-        description: "More than 20% of the '{{ $labels.controller }}' controller's reconcile attempts are failing. It cannot apply its intent — changes are not reaching their target and the last successfully written state stays programmed. Common causes: an object fails CRD validation, an API server admission error, or a permissions regression. Check controller logs for 'Reconciler error' entries on the '{{ $labels.controller }}' controller."
+        summary: "Controller {{ $labels.controller }} in {{ $labels.cluster }}/{{ $labels.namespace }} reconcile error ratio is {{ $value | humanizePercentage }} (threshold 20%)"
+        description: "More than 20% of the '{{ $labels.controller }}' controller's reconcile attempts are failing in cluster '{{ $labels.cluster }}', namespace '{{ $labels.namespace }}'. It cannot apply its intent — changes are not reaching their target and the last successfully written state stays programmed. Common causes: an object fails CRD validation, an API server admission error, or a permissions regression. Check controller logs for 'Reconciler error' entries on the '{{ $labels.controller }}' controller."
         runbook_url: "https://github.com/datum-cloud/network-services-operator/blob/main/docs/runbooks/controller-health.md#controllerreconcileerrorratiohigh"
 
     # Fires at a critical threshold when more than 50% of a controller's
@@ -37,14 +47,15 @@ spec:
     - alert: ControllerReconcileErrorRatioCritical
       expr: |
         (
-          sum by (controller) (rate(controller_runtime_reconcile_total{result="error"}[10m]))
+          sum by (cluster, namespace, controller) (rate(controller_runtime_reconcile_total{result="error"}[30m]))
           /
-          sum by (controller) (rate(controller_runtime_reconcile_total[10m]))
+          sum by (cluster, namespace, controller) (rate(controller_runtime_reconcile_total[30m]))
         ) > 0.5
       for: 10m
+      keep_firing_for: 30m
       labels:
         severity: critical
       annotations:
-        summary: "Controller {{ $labels.controller }} reconcile error ratio is {{ $value | humanizePercentage }} (threshold 50%) — reconciliation is stalled"
-        description: "More than 50% of the '{{ $labels.controller }}' controller's reconcile attempts are failing — it has effectively stopped applying changes. Treat as an active outage for anything this controller programs. Check controller logs for 'Reconciler error' entries. See ControllerReconcileErrorRatioHigh for initial diagnosis."
+        summary: "Controller {{ $labels.controller }} in {{ $labels.cluster }}/{{ $labels.namespace }} reconcile error ratio is {{ $value | humanizePercentage }} (threshold 50%) — reconciliation is stalled"
+        description: "More than 50% of the '{{ $labels.controller }}' controller's reconcile attempts are failing in cluster '{{ $labels.cluster }}', namespace '{{ $labels.namespace }}' — it has effectively stopped applying changes. Treat as an active outage for anything this controller programs. Check controller logs for 'Reconciler error' entries. See ControllerReconcileErrorRatioHigh for initial diagnosis."
         runbook_url: "https://github.com/datum-cloud/network-services-operator/blob/main/docs/runbooks/controller-health.md#controllerreconcileerrorratiocritical"

--- a/docs/runbooks/controller-health.md
+++ b/docs/runbooks/controller-health.md
@@ -9,17 +9,24 @@ target.
 
 Every controller in the operator emits the standard controller-runtime counter
 `controller_runtime_reconcile_total`, labelled with `controller` (the reconciler
-name) and `result` (`error` / `success`). These alerts group by `controller`, so
-each reconciler is evaluated independently and the firing alert names the
-offending one in its `controller` label.
+name) and `result` (`error` / `success`). These alerts group by `cluster`,
+`namespace` and `controller`, so each reconciler is evaluated independently per
+deployment and the firing alert names both the offending reconciler and where it
+is running.
+
+The counter is emitted by every controller-runtime binary scraped into the same
+Prometheus, not only by this operator. A firing alert may therefore name a
+controller belonging to another component — read the `namespace` label before
+assuming the problem is in NSO.
 
 ## Shared diagnosis
 
-The `controller` label on the alert tells you which reconciler is failing. Find
-the specific objects and error messages in the controller logs:
+The `cluster` and `namespace` labels tell you where to look; the `controller`
+label tells you which reconciler is failing. Find the specific objects and error
+messages in the controller logs:
 
 ```sh
-kubectl -n <nso-ns> logs -l <controller-selector> | grep 'Reconciler error' | grep '"controller":"<controller>"'
+kubectl -n <namespace> logs -l <controller-selector> | grep 'Reconciler error' | grep '"controller":"<controller>"'
 ```
 
 Each error line names the namespace and name of the object that failed and the
@@ -40,6 +47,12 @@ Common error classes:
   RBAC for that resource.
 - `conflict` / `ResourceVersion` — transient write conflicts that resolve on
   their own and should not sustain a high error rate.
+- `not found` for a parent or cluster that no longer exists — the object is
+  orphaned and can never reconcile, so it retries forever and pins the ratio at
+  100% with no successes to dilute it. This is dead data rather than a live
+  outage: confirm the referenced parent is really gone, then remove the orphan.
+  Seen in prod for the `instance-projector` controller —
+  [datum-cloud/compute#194](https://github.com/datum-cloud/compute/issues/194).
 
 ## ControllerReconcileErrorRatioHigh
 

--- a/docs/runbooks/controller-health.md
+++ b/docs/runbooks/controller-health.md
@@ -19,6 +19,20 @@ Prometheus, not only by this operator. A firing alert may therefore name a
 controller belonging to another component — read the `namespace` label before
 assuming the problem is in NSO.
 
+## Alert timing
+
+Both alerts evaluate a 30-minute rate window and hold with `keep_firing_for: 30m`.
+Two consequences while you are working an incident:
+
+- **A fix does not clear the page immediately.** The alert keeps firing for up to
+  30 minutes after reconciles start succeeding again. A still-firing alert shortly
+  after a fix is expected and is not evidence the fix failed — confirm recovery
+  from the error ratio itself, not from the alert state.
+- **A new failure takes longer to page.** A controller that was healthy and then
+  fails outright reaches the critical threshold in roughly 26 minutes rather than
+  16. The wide window is what stops a low-volume controller flapping; detection
+  latency is the price.
+
 ## Shared diagnosis
 
 The `cluster` and `namespace` labels tell you where to look; the `controller`
@@ -49,10 +63,17 @@ Common error classes:
   their own and should not sustain a high error rate.
 - `not found` for a parent or cluster that no longer exists — the object is
   orphaned and can never reconcile, so it retries forever and pins the ratio at
-  100% with no successes to dilute it. This is dead data rather than a live
-  outage: confirm the referenced parent is really gone, then remove the orphan.
-  Seen in prod for the `instance-projector` controller —
-  [datum-cloud/compute#194](https://github.com/datum-cloud/compute/issues/194).
+  100% with no successes to dilute it. Project deletion is the usual trigger
+  ([milo-os/milo#750](https://github.com/milo-os/milo/issues/750)). **Do not
+  assume an orphan is inert** — it depends on what the controller programs:
+  - Compute orphans are dead data; an orphaned Instance drives no workload
+    ([datum-cloud/compute#194](https://github.com/datum-cloud/compute/issues/194)).
+  - Gateway orphans are not. Mirrored Gateways and DNS records keep propagating
+    through Karmada, so a deleted project's listener can still serve live traffic
+    ([#338](https://github.com/datum-cloud/network-services-operator/pull/338)).
+
+  Establish which case you have before calling the alert benign, then remove the
+  orphan.
 
 ## ControllerReconcileErrorRatioHigh
 
@@ -69,7 +90,8 @@ diagnosis) and identify the failing objects and the rejection reason.
 **Remediate.** Fix the root cause identified in the logs — correct the object
 that fails validation, restore the missing permission, or roll back the change
 that introduced the regression. The error ratio recovers automatically once
-writes succeed again.
+writes succeed again, though the alert itself holds for up to 30 minutes longer
+(see [Alert timing](#alert-timing)).
 
 ## ControllerReconcileErrorRatioCritical
 
@@ -95,4 +117,6 @@ kubectl get --raw /healthz
 **Remediate.** Fix the root cause as for the warning tier. If one object's
 validation failure is blocking the rest, correcting it unblocks the queue. If an
 API server or permissions change caused a broad failure, roll it back and verify
-the controller regains a healthy reconcile ratio before resolving the alert.
+the controller regains a healthy reconcile ratio. Judge recovery by the ratio,
+not the alert state — the alert holds for up to 30 minutes after the ratio
+recovers (see [Alert timing](#alert-timing)).

--- a/test/prometheus-rules/controllers/controller-health-rules.yaml
+++ b/test/prometheus-rules/controllers/controller-health-rules.yaml
@@ -1,23 +1,38 @@
 groups:
+# Per-controller reconcile-error alerts detect when any controller-runtime
+# reconciler is failing to apply its intent. A high error ratio means writes
+# are being rejected (invalid objects, admission errors, permissions), the
+# controller is hot-looping, and the last successfully written state stays
+# programmed. The `controller` label names the offending reconciler, and
+# `cluster`/`namespace` name where it is running.
+#
+# A controller reconciling only a handful of objects produces no samples at
+# all in a short window: the denominator goes to zero, the series disappears,
+# and the alert resolves and re-fires every time `for` elapses again. The
+# 30-minute range keeps the series continuous at low reconcile volume, and
+# `keep_firing_for` holds the alert through the remaining gaps and through
+# brief dips under the threshold, so a persistently failing controller pages
+# once instead of flapping.
 - name: nso-controller-health
   interval: 30s
   rules:
   # Fires when more than 20% of a controller's reconcile attempts fail over a
-  # 10-minute window, sustained for 15 minutes. Grouped by controller so each
-  # reconciler is evaluated independently and the alert names which one.
+  # 30-minute window, sustained for 15 minutes. Each reconciler is evaluated
+  # independently per cluster and namespace.
   - alert: ControllerReconcileErrorRatioHigh
     expr: |
       (
-        sum by (controller) (rate(controller_runtime_reconcile_total{result="error"}[10m]))
+        sum by (cluster, namespace, controller) (rate(controller_runtime_reconcile_total{result="error"}[30m]))
         /
-        sum by (controller) (rate(controller_runtime_reconcile_total[10m]))
+        sum by (cluster, namespace, controller) (rate(controller_runtime_reconcile_total[30m]))
       ) > 0.2
     for: 15m
+    keep_firing_for: 30m
     labels:
       severity: warning
     annotations:
-      summary: "Controller {{ $labels.controller }} reconcile error ratio is {{ $value | humanizePercentage }} (threshold 20%)"
-      description: "More than 20% of the '{{ $labels.controller }}' controller's reconcile attempts are failing. It cannot apply its intent — changes are not reaching their target and the last successfully written state stays programmed. Common causes: an object fails CRD validation, an API server admission error, or a permissions regression. Check controller logs for 'Reconciler error' entries on the '{{ $labels.controller }}' controller."
+      summary: "Controller {{ $labels.controller }} in {{ $labels.cluster }}/{{ $labels.namespace }} reconcile error ratio is {{ $value | humanizePercentage }} (threshold 20%)"
+      description: "More than 20% of the '{{ $labels.controller }}' controller's reconcile attempts are failing in cluster '{{ $labels.cluster }}', namespace '{{ $labels.namespace }}'. It cannot apply its intent — changes are not reaching their target and the last successfully written state stays programmed. Common causes: an object fails CRD validation, an API server admission error, or a permissions regression. Check controller logs for 'Reconciler error' entries on the '{{ $labels.controller }}' controller."
       runbook_url: "https://github.com/datum-cloud/network-services-operator/blob/main/docs/runbooks/controller-health.md#controllerreconcileerrorratiohigh"
 
   # Fires at a critical threshold when more than 50% of a controller's
@@ -26,14 +41,15 @@ groups:
   - alert: ControllerReconcileErrorRatioCritical
     expr: |
       (
-        sum by (controller) (rate(controller_runtime_reconcile_total{result="error"}[10m]))
+        sum by (cluster, namespace, controller) (rate(controller_runtime_reconcile_total{result="error"}[30m]))
         /
-        sum by (controller) (rate(controller_runtime_reconcile_total[10m]))
+        sum by (cluster, namespace, controller) (rate(controller_runtime_reconcile_total[30m]))
       ) > 0.5
     for: 10m
+    keep_firing_for: 30m
     labels:
       severity: critical
     annotations:
-      summary: "Controller {{ $labels.controller }} reconcile error ratio is {{ $value | humanizePercentage }} (threshold 50%) — reconciliation is stalled"
-      description: "More than 50% of the '{{ $labels.controller }}' controller's reconcile attempts are failing — it has effectively stopped applying changes. Treat as an active outage for anything this controller programs. Check controller logs for 'Reconciler error' entries. See ControllerReconcileErrorRatioHigh for initial diagnosis."
+      summary: "Controller {{ $labels.controller }} in {{ $labels.cluster }}/{{ $labels.namespace }} reconcile error ratio is {{ $value | humanizePercentage }} (threshold 50%) — reconciliation is stalled"
+      description: "More than 50% of the '{{ $labels.controller }}' controller's reconcile attempts are failing in cluster '{{ $labels.cluster }}', namespace '{{ $labels.namespace }}' — it has effectively stopped applying changes. Treat as an active outage for anything this controller programs. Check controller logs for 'Reconciler error' entries. See ControllerReconcileErrorRatioHigh for initial diagnosis."
       runbook_url: "https://github.com/datum-cloud/network-services-operator/blob/main/docs/runbooks/controller-health.md#controllerreconcileerrorratiocritical"

--- a/test/prometheus-rules/controllers/controller-health-tests.yaml
+++ b/test/prometheus-rules/controllers/controller-health-tests.yaml
@@ -179,6 +179,58 @@ tests:
         alertname: ControllerReconcileErrorRatioCritical
         exp_alerts: []
 
+  # Sparse controller at the warning tier: the same mechanism as the critical
+  # case above, verified against `for: 15m` rather than `for: 10m`.
+  - interval: 1m
+    input_series:
+      - series: 'controller_runtime_reconcile_total{controller="instance-projector",result="error",cluster="prod",namespace="compute-system"}'
+        values: '0+0x19 4+0x19 8+0x19 12+0x19 16+0x19'
+    alert_rule_test:
+      - eval_time: 45m
+        alertname: ControllerReconcileErrorRatioHigh
+        exp_alerts: &sparse_firing_warning
+          - exp_labels:
+              severity: warning
+              controller: instance-projector
+              cluster: prod
+              namespace: compute-system
+            exp_annotations:
+              summary: "Controller instance-projector in prod/compute-system reconcile error ratio is 100% (threshold 20%)"
+              description: "More than 20% of the 'instance-projector' controller's reconcile attempts are failing in cluster 'prod', namespace 'compute-system'. It cannot apply its intent — changes are not reaching their target and the last successfully written state stays programmed. Common causes: an object fails CRD validation, an API server admission error, or a permissions regression. Check controller logs for 'Reconciler error' entries on the 'instance-projector' controller."
+              runbook_url: "https://github.com/datum-cloud/network-services-operator/blob/main/docs/runbooks/controller-health.md#controllerreconcileerrorratiohigh"
+      - eval_time: 59m
+        alertname: ControllerReconcileErrorRatioHigh
+        exp_alerts: *sparse_firing_warning
+      - eval_time: 99m
+        alertname: ControllerReconcileErrorRatioHigh
+        exp_alerts: *sparse_firing_warning
+
+  # Reconcile period longer than the old evaluation window — the Grafana operator
+  # CRs in datum-cloud/infra#3742, which reconcile about every 15 minutes and have
+  # failed 100% with zero successes for over a month without ever firing. Under a
+  # 10-minute range `for:` reset on every reconcile and the rule could never latch;
+  # the 30-minute range is what makes this condition alertable at all.
+  - interval: 1m
+    input_series:
+      - series: 'controller_runtime_reconcile_total{controller="grafanaalertrulegroup",result="error",cluster="prod",namespace="telemetry-system"}'
+        values: '0+0x14 1+0x14 2+0x14 3+0x14 4+0x14 5+0x14 6+0x14 7+0x14'
+    alert_rule_test:
+      - eval_time: 60m
+        alertname: ControllerReconcileErrorRatioCritical
+        exp_alerts: &grafana_firing
+          - exp_labels:
+              severity: critical
+              controller: grafanaalertrulegroup
+              cluster: prod
+              namespace: telemetry-system
+            exp_annotations:
+              summary: "Controller grafanaalertrulegroup in prod/telemetry-system reconcile error ratio is 100% (threshold 50%) — reconciliation is stalled"
+              description: "More than 50% of the 'grafanaalertrulegroup' controller's reconcile attempts are failing in cluster 'prod', namespace 'telemetry-system' — it has effectively stopped applying changes. Treat as an active outage for anything this controller programs. Check controller logs for 'Reconciler error' entries. See ControllerReconcileErrorRatioHigh for initial diagnosis."
+              runbook_url: "https://github.com/datum-cloud/network-services-operator/blob/main/docs/runbooks/controller-health.md#controllerreconcileerrorratiocritical"
+      - eval_time: 90m
+        alertname: ControllerReconcileErrorRatioCritical
+        exp_alerts: *grafana_firing
+
   # Healthy controller (10% errors) never crosses the warning threshold.
   - interval: 1m
     input_series:

--- a/test/prometheus-rules/controllers/controller-health-tests.yaml
+++ b/test/prometheus-rules/controllers/controller-health-tests.yaml
@@ -9,20 +9,21 @@ tests:
   #   domain  — 3 errors + 7 success = 30% error ratio (warning only)
   #   subnet  — 1 error  + 9 success = 10% error ratio (healthy, fires nothing)
   # At 16m the warning alert fires for the two offending controllers, each
-  # carrying its own `controller` label; the healthy controller is absent.
+  # carrying its own `controller` label plus the cluster and namespace it runs
+  # in; the healthy controller is absent.
   - interval: 1m
     input_series:
-      - series: 'controller_runtime_reconcile_total{controller="gateway",result="error"}'
+      - series: 'controller_runtime_reconcile_total{controller="gateway",result="error",cluster="prod",namespace="nso-system"}'
         values: '0+9x20'
-      - series: 'controller_runtime_reconcile_total{controller="gateway",result="success"}'
+      - series: 'controller_runtime_reconcile_total{controller="gateway",result="success",cluster="prod",namespace="nso-system"}'
         values: '0+1x20'
-      - series: 'controller_runtime_reconcile_total{controller="domain",result="error"}'
+      - series: 'controller_runtime_reconcile_total{controller="domain",result="error",cluster="prod",namespace="nso-system"}'
         values: '0+3x20'
-      - series: 'controller_runtime_reconcile_total{controller="domain",result="success"}'
+      - series: 'controller_runtime_reconcile_total{controller="domain",result="success",cluster="prod",namespace="nso-system"}'
         values: '0+7x20'
-      - series: 'controller_runtime_reconcile_total{controller="subnet",result="error"}'
+      - series: 'controller_runtime_reconcile_total{controller="subnet",result="error",cluster="prod",namespace="nso-system"}'
         values: '0+1x20'
-      - series: 'controller_runtime_reconcile_total{controller="subnet",result="success"}'
+      - series: 'controller_runtime_reconcile_total{controller="subnet",result="success",cluster="prod",namespace="nso-system"}'
         values: '0+9x20'
     alert_rule_test:
       - eval_time: 16m
@@ -31,33 +32,37 @@ tests:
           - exp_labels:
               severity: warning
               controller: gateway
+              cluster: prod
+              namespace: nso-system
             exp_annotations:
-              summary: "Controller gateway reconcile error ratio is 90% (threshold 20%)"
-              description: "More than 20% of the 'gateway' controller's reconcile attempts are failing. It cannot apply its intent — changes are not reaching their target and the last successfully written state stays programmed. Common causes: an object fails CRD validation, an API server admission error, or a permissions regression. Check controller logs for 'Reconciler error' entries on the 'gateway' controller."
+              summary: "Controller gateway in prod/nso-system reconcile error ratio is 90% (threshold 20%)"
+              description: "More than 20% of the 'gateway' controller's reconcile attempts are failing in cluster 'prod', namespace 'nso-system'. It cannot apply its intent — changes are not reaching their target and the last successfully written state stays programmed. Common causes: an object fails CRD validation, an API server admission error, or a permissions regression. Check controller logs for 'Reconciler error' entries on the 'gateway' controller."
               runbook_url: "https://github.com/datum-cloud/network-services-operator/blob/main/docs/runbooks/controller-health.md#controllerreconcileerrorratiohigh"
           - exp_labels:
               severity: warning
               controller: domain
+              cluster: prod
+              namespace: nso-system
             exp_annotations:
-              summary: "Controller domain reconcile error ratio is 30% (threshold 20%)"
-              description: "More than 20% of the 'domain' controller's reconcile attempts are failing. It cannot apply its intent — changes are not reaching their target and the last successfully written state stays programmed. Common causes: an object fails CRD validation, an API server admission error, or a permissions regression. Check controller logs for 'Reconciler error' entries on the 'domain' controller."
+              summary: "Controller domain in prod/nso-system reconcile error ratio is 30% (threshold 20%)"
+              description: "More than 20% of the 'domain' controller's reconcile attempts are failing in cluster 'prod', namespace 'nso-system'. It cannot apply its intent — changes are not reaching their target and the last successfully written state stays programmed. Common causes: an object fails CRD validation, an API server admission error, or a permissions regression. Check controller logs for 'Reconciler error' entries on the 'domain' controller."
               runbook_url: "https://github.com/datum-cloud/network-services-operator/blob/main/docs/runbooks/controller-health.md#controllerreconcileerrorratiohigh"
 
   # Same multi-controller input at the critical tier: only the controller above
   # 50% (gateway, 90%) fires; the 30% and 10% controllers do not.
   - interval: 1m
     input_series:
-      - series: 'controller_runtime_reconcile_total{controller="gateway",result="error"}'
+      - series: 'controller_runtime_reconcile_total{controller="gateway",result="error",cluster="prod",namespace="nso-system"}'
         values: '0+9x20'
-      - series: 'controller_runtime_reconcile_total{controller="gateway",result="success"}'
+      - series: 'controller_runtime_reconcile_total{controller="gateway",result="success",cluster="prod",namespace="nso-system"}'
         values: '0+1x20'
-      - series: 'controller_runtime_reconcile_total{controller="domain",result="error"}'
+      - series: 'controller_runtime_reconcile_total{controller="domain",result="error",cluster="prod",namespace="nso-system"}'
         values: '0+3x20'
-      - series: 'controller_runtime_reconcile_total{controller="domain",result="success"}'
+      - series: 'controller_runtime_reconcile_total{controller="domain",result="success",cluster="prod",namespace="nso-system"}'
         values: '0+7x20'
-      - series: 'controller_runtime_reconcile_total{controller="subnet",result="error"}'
+      - series: 'controller_runtime_reconcile_total{controller="subnet",result="error",cluster="prod",namespace="nso-system"}'
         values: '0+1x20'
-      - series: 'controller_runtime_reconcile_total{controller="subnet",result="success"}'
+      - series: 'controller_runtime_reconcile_total{controller="subnet",result="success",cluster="prod",namespace="nso-system"}'
         values: '0+9x20'
     alert_rule_test:
       - eval_time: 11m
@@ -66,17 +71,120 @@ tests:
           - exp_labels:
               severity: critical
               controller: gateway
+              cluster: prod
+              namespace: nso-system
             exp_annotations:
-              summary: "Controller gateway reconcile error ratio is 90% (threshold 50%) — reconciliation is stalled"
-              description: "More than 50% of the 'gateway' controller's reconcile attempts are failing — it has effectively stopped applying changes. Treat as an active outage for anything this controller programs. Check controller logs for 'Reconciler error' entries. See ControllerReconcileErrorRatioHigh for initial diagnosis."
+              summary: "Controller gateway in prod/nso-system reconcile error ratio is 90% (threshold 50%) — reconciliation is stalled"
+              description: "More than 50% of the 'gateway' controller's reconcile attempts are failing in cluster 'prod', namespace 'nso-system' — it has effectively stopped applying changes. Treat as an active outage for anything this controller programs. Check controller logs for 'Reconciler error' entries. See ControllerReconcileErrorRatioHigh for initial diagnosis."
               runbook_url: "https://github.com/datum-cloud/network-services-operator/blob/main/docs/runbooks/controller-health.md#controllerreconcileerrorratiocritical"
+
+  # Two clusters running the same controller at different health: the alert is
+  # per-cluster, so the unhealthy one fires alone and the notification names the
+  # cluster it came from.
+  - interval: 1m
+    input_series:
+      - series: 'controller_runtime_reconcile_total{controller="gateway",result="error",cluster="staging",namespace="nso-system"}'
+        values: '0+9x20'
+      - series: 'controller_runtime_reconcile_total{controller="gateway",result="success",cluster="staging",namespace="nso-system"}'
+        values: '0+1x20'
+      - series: 'controller_runtime_reconcile_total{controller="gateway",result="error",cluster="prod",namespace="nso-system"}'
+        values: '0+1x20'
+      - series: 'controller_runtime_reconcile_total{controller="gateway",result="success",cluster="prod",namespace="nso-system"}'
+        values: '0+9x20'
+    alert_rule_test:
+      - eval_time: 11m
+        alertname: ControllerReconcileErrorRatioCritical
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              controller: gateway
+              cluster: staging
+              namespace: nso-system
+            exp_annotations:
+              summary: "Controller gateway in staging/nso-system reconcile error ratio is 90% (threshold 50%) — reconciliation is stalled"
+              description: "More than 50% of the 'gateway' controller's reconcile attempts are failing in cluster 'staging', namespace 'nso-system' — it has effectively stopped applying changes. Treat as an active outage for anything this controller programs. Check controller logs for 'Reconciler error' entries. See ControllerReconcileErrorRatioHigh for initial diagnosis."
+              runbook_url: "https://github.com/datum-cloud/network-services-operator/blob/main/docs/runbooks/controller-health.md#controllerreconcileerrorratiocritical"
+
+  # Sparse, permanently-failing controller — the prod `instance-projector` case
+  # (datum-cloud/compute#194). Every reconcile fails and there are no successes,
+  # but the controller only wakes every ~20 minutes, so a short evaluation window
+  # contains no increments at all: the denominator goes to zero, the ratio series
+  # disappears, and the alert resolves and re-fires on a loop. It must instead
+  # stay continuously firing across the quiet stretches.
+  - interval: 1m
+    input_series:
+      - series: 'controller_runtime_reconcile_total{controller="instance-projector",result="error",cluster="prod",namespace="compute-system"}'
+        values: '0+0x19 4+0x19 8+0x19 12+0x19 16+0x19'
+    alert_rule_test:
+      - eval_time: 45m
+        alertname: ControllerReconcileErrorRatioCritical
+        exp_alerts: &sparse_firing
+          - exp_labels:
+              severity: critical
+              controller: instance-projector
+              cluster: prod
+              namespace: compute-system
+            exp_annotations:
+              summary: "Controller instance-projector in prod/compute-system reconcile error ratio is 100% (threshold 50%) — reconciliation is stalled"
+              description: "More than 50% of the 'instance-projector' controller's reconcile attempts are failing in cluster 'prod', namespace 'compute-system' — it has effectively stopped applying changes. Treat as an active outage for anything this controller programs. Check controller logs for 'Reconciler error' entries. See ControllerReconcileErrorRatioHigh for initial diagnosis."
+              runbook_url: "https://github.com/datum-cloud/network-services-operator/blob/main/docs/runbooks/controller-health.md#controllerreconcileerrorratiocritical"
+      # Mid-gap, immediately before the next batch of failures lands.
+      - eval_time: 59m
+        alertname: ControllerReconcileErrorRatioCritical
+        exp_alerts: *sparse_firing
+      - eval_time: 75m
+        alertname: ControllerReconcileErrorRatioCritical
+        exp_alerts: *sparse_firing
+      - eval_time: 99m
+        alertname: ControllerReconcileErrorRatioCritical
+        exp_alerts: *sparse_firing
+
+  # Fixed error rate against a varying success rate — the `dnsrecordset-powerdns`
+  # and staging `gateway` case. A constant 4 errors/min sits above the threshold
+  # while success runs at 1/min, then a burst of 100 successes/min from t=60
+  # dilutes the ratio to ~4% without the error rate changing at all. The
+  # controller is no healthier than before, so `keep_firing_for` must hold the
+  # alert through the dilution rather than resolving and re-firing when the burst
+  # passes.
+  - interval: 1m
+    input_series:
+      - series: 'controller_runtime_reconcile_total{controller="dnsrecordset-powerdns",result="error",cluster="prod",namespace="nso-system"}'
+        values: '0+4x120'
+      - series: 'controller_runtime_reconcile_total{controller="dnsrecordset-powerdns",result="success",cluster="prod",namespace="nso-system"}'
+        values: '0+1x59 159+100x60'
+    alert_rule_test:
+      # Above threshold on its own merits, before the success burst.
+      - eval_time: 45m
+        alertname: ControllerReconcileErrorRatioCritical
+        exp_alerts: &diluted_firing
+          - exp_labels:
+              severity: critical
+              controller: dnsrecordset-powerdns
+              cluster: prod
+              namespace: nso-system
+            exp_annotations:
+              summary: "Controller dnsrecordset-powerdns in prod/nso-system reconcile error ratio is 80% (threshold 50%) — reconciliation is stalled"
+              description: "More than 50% of the 'dnsrecordset-powerdns' controller's reconcile attempts are failing in cluster 'prod', namespace 'nso-system' — it has effectively stopped applying changes. Treat as an active outage for anything this controller programs. Check controller logs for 'Reconciler error' entries. See ControllerReconcileErrorRatioHigh for initial diagnosis."
+              runbook_url: "https://github.com/datum-cloud/network-services-operator/blob/main/docs/runbooks/controller-health.md#controllerreconcileerrorratiocritical"
+      # Ratio diluted well under the threshold; held by keep_firing_for.
+      - eval_time: 70m
+        alertname: ControllerReconcileErrorRatioCritical
+        exp_alerts: *diluted_firing
+      - eval_time: 80m
+        alertname: ControllerReconcileErrorRatioCritical
+        exp_alerts: *diluted_firing
+      # keep_firing_for has lapsed: the hold is bounded, so a controller that
+      # really does stay under the threshold still resolves.
+      - eval_time: 110m
+        alertname: ControllerReconcileErrorRatioCritical
+        exp_alerts: []
 
   # Healthy controller (10% errors) never crosses the warning threshold.
   - interval: 1m
     input_series:
-      - series: 'controller_runtime_reconcile_total{controller="domain",result="error"}'
+      - series: 'controller_runtime_reconcile_total{controller="domain",result="error",cluster="prod",namespace="nso-system"}'
         values: '0+1x20'
-      - series: 'controller_runtime_reconcile_total{controller="domain",result="success"}'
+      - series: 'controller_runtime_reconcile_total{controller="domain",result="success",cluster="prod",namespace="nso-system"}'
         values: '0+9x20'
     alert_rule_test:
       - eval_time: 20m
@@ -86,9 +194,9 @@ tests:
   # Above the warning threshold (90%) but checked before for: 15m elapses.
   - interval: 1m
     input_series:
-      - series: 'controller_runtime_reconcile_total{controller="gateway",result="error"}'
+      - series: 'controller_runtime_reconcile_total{controller="gateway",result="error",cluster="prod",namespace="nso-system"}'
         values: '0+9x20'
-      - series: 'controller_runtime_reconcile_total{controller="gateway",result="success"}'
+      - series: 'controller_runtime_reconcile_total{controller="gateway",result="success",cluster="prod",namespace="nso-system"}'
         values: '0+1x20'
     alert_rule_test:
       - eval_time: 14m
@@ -98,9 +206,9 @@ tests:
   # Above the critical threshold (80%) but checked before for: 10m elapses.
   - interval: 1m
     input_series:
-      - series: 'controller_runtime_reconcile_total{controller="gateway",result="error"}'
+      - series: 'controller_runtime_reconcile_total{controller="gateway",result="error",cluster="prod",namespace="nso-system"}'
         values: '0+8x20'
-      - series: 'controller_runtime_reconcile_total{controller="gateway",result="success"}'
+      - series: 'controller_runtime_reconcile_total{controller="gateway",result="success",cluster="prod",namespace="nso-system"}'
         values: '0+2x20'
     alert_rule_test:
       - eval_time: 9m


### PR DESCRIPTION
## Summary

`ControllerReconcileErrorRatioCritical` has been firing and resolving on a loop rather than latching — roughly 100 fire/resolve pairs into `#alerts-production-critical` in 14h for a single unchanged fault, and because `severity: critical` also matches the `grafana-oncall` route, it pages on-call on every cycle. The underlying fault deserves one page, not a hundred.

Measuring prod turned up two independent flap mechanisms, not one:

- **Sparse series.** `instance-projector` reconciles a median of 4 objects per 10 minutes. 28 of 85 windows contained no increments at all, so the denominator went to zero, `0/0` dropped the series, and Alertmanager resolved — then the next reconcile restarted `for: 10m` and it fired again. It never once crossed back under the threshold (0 of 57 data-bearing windows), so this is not the ratio dipping. A 30-minute range keeps the series continuous at that volume.
- **Dilution.** A constant error rate against a variable success rate crosses the threshold in both directions as unrelated healthy traffic rises and falls, with the controller no healthier either way — the `dnsrecordset-powerdns` and staging `gateway` case already described on #326. `keep_firing_for: 30m` holds the alert through those dips.

Both changes are load-bearing and independently guarded: reverting the range fails the sparse fixture, and removing `keep_firing_for` fails the dilution fixture.

The wider range costs detection latency on a genuinely new fault: a controller that was healthy and then fails outright reaches the critical threshold in about 26 minutes instead of 16, and the warning tier moves about 4 minutes. That is the deliberate trade — on this metric a low-volume controller cannot be both instantly detectable and non-flapping.

The sparse-series half is not only a noise fix. datum-cloud/infra#3742 diagnosed the same mechanism from the opposite end: `GrafanaAlertRuleGroup`, `GrafanaContactPoint`, `GrafanaFolder` and `GrafanaNotificationPolicy` on prod reconcile about once every 15 minutes and have been failing **100% with zero successes for over 30 days**, yet `ControllerReconcileErrorRatioCritical` sits permanently in `pending` for them and has never fired — a reconcile period longer than the evaluation window means `for:` resets on every reconcile and the rule cannot latch. Every alert-rule, contact-point and notification-routing change committed to Git in that window silently never reached Grafana. The 30-minute range is what makes that condition alertable at all, so the same change that quiets a flapping controller also surfaces a month-old silent failure.

> [!WARNING]
> This raises the unalertable threshold from a 10-minute to a 30-minute reconcile period; it does not remove it. A controller reconciling less often than every 30 minutes is still invisible to this rule. The general class infra#3742 describes stays open.

Grouping now includes `cluster` and `namespace`, so a page says where the failing controller runs instead of only naming the reconciler — #326's second ask.

> [!NOTE]
> The rule still has no job or namespace selector, so it evaluates every controller-runtime binary scraped into the cluster. That is how an `nso-slo`-owned alert ends up paging about `instance-projector`, which runs in `compute-system`. Scoping it to NSO would strand the controllers above with no coverage at all, so that ownership question is left open on #326 rather than settled here.

The fault behind the current pages is 3 orphaned Instances in one project namespace (datum-cloud/compute#194) — dead data in that instance. Orphans are not inert in general: the same project-purge trigger (milo-os/milo#750, fixed by milo-os/milo#752) strands mirrored Gateways that keep serving edge traffic for a deleted project, which #338 cleans up. This PR stops the paging pattern; it fixes neither. The runbook now splits the orphan case by what the controller programs rather than calling it benign.

`task test-prometheus-rules` was not referenced by any workflow, so the fixtures this issue asks for would not have guarded anything. Added a job that runs them.

## Test plan

- [x] `task test-prometheus-rules` — all three suites pass
- [x] Sparse-series fixture fails when the range is reverted to `10m`
- [x] Dilution fixture fails when `keep_firing_for` is removed
- [x] `promtool` confirms a held alert retains its last annotations, and that the hold is bounded (resolves once `keep_firing_for` lapses)
- [x] Sparse fixture at the warning tier and a 15-minute reconcile period fixture for the infra#3742 case, both failing when the range is reverted
- [x] New CI job runs green on this PR

Related to #326


