### PR TITLE
fix: Backfill TPP Programmed on extension rollout

### DIFF
--- a/internal/extensionserver/retrigger/tpp.go
+++ b/internal/extensionserver/retrigger/tpp.go
@@ -23,6 +23,15 @@
 // delete or a targetRef edit, clears the trigger annotation on every Gateway that
 // dropped out of the set. Removing the annotation is itself a Gateway change, so
 // EG re-translates against the now-empty cache and drops the orphaned WAF config.
+//
+// Programmed status is stamped only inside PostTranslateModify after a real EG
+// re-translate. A rollout of that status writer would otherwise leave idle
+// proxies stuck with an empty Programmed condition forever: Create reconciles
+// on startup re-stamp the same "<gen>" annotation value, which is a server-side
+// no-op, so EG never re-runs the hook. When edge-local Programmed is missing or
+// behind metadata.generation, the trigger value gains a per-process suffix so
+// the annotation actually changes once and existing proxies backfill without a
+// manual edit.
 
 package retrigger
 
@@ -31,8 +40,11 @@ import (
 	"fmt"
 	"strconv"
 	"sync"
+	"time"
 
 	"github.com/go-logr/logr"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -44,6 +56,8 @@ import (
 
 	networkingv1alpha "go.datum.net/network-services-operator/api/v1alpha"
 )
+
+const conditionTypeProgrammed = "Programmed"
 
 // tppTriggerAnnotationPrefix is the annotation key prefix patched onto a Gateway
 // to make Envoy Gateway re-translate after a TPP spec change. The owning TPP's
@@ -59,6 +73,11 @@ const tppTriggerAnnotationPrefix = "networking.datumapis.com/tpp-generation-"
 // out of the policy's target set so EG re-translates and drops the orphaned WAF.
 type TPPReconciler struct {
 	Client client.Client
+
+	// bootID disambiguates Programmed-backfill trigger values across process
+	// starts so a pre-existing "<gen>.programmed.*" annotation still changes
+	// when status has not yet been written.
+	bootID string
 
 	// mu guards lastTargets. Reconciles for distinct TPPs run concurrently, so
 	// the previous-target map needs its own lock (controller-runtime only
@@ -78,6 +97,44 @@ func tppTriggerAnnotationKey(tppName string) string {
 	return tppTriggerAnnotationPrefix + tppName
 }
 
+// triggerValue returns the annotation value stamped onto owning Gateways.
+// Steady state is the bare generation string. When edge-local Programmed is
+// missing or observedGeneration lags metadata.generation, a per-process suffix
+// forces the annotation to change even if it already equals the generation —
+// the Create-on-startup path that would otherwise be a no-op after a status
+// writer rollout.
+func (r *TPPReconciler) triggerValue(tpp *networkingv1alpha.TrafficProtectionPolicy) string {
+	gen := strconv.FormatInt(tpp.Generation, 10)
+	if tppProgrammedForGeneration(tpp) {
+		return gen
+	}
+	return gen + ".programmed." + r.ensureBootID()
+}
+
+func (r *TPPReconciler) ensureBootID() string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.bootID == "" {
+		r.bootID = strconv.FormatInt(time.Now().UnixNano(), 36)
+	}
+	return r.bootID
+}
+
+// tppProgrammedForGeneration reports whether any ancestor already has
+// Programmed=True for at least this object's generation.
+func tppProgrammedForGeneration(tpp *networkingv1alpha.TrafficProtectionPolicy) bool {
+	for i := range tpp.Status.Ancestors {
+		cond := apimeta.FindStatusCondition(tpp.Status.Ancestors[i].Conditions, conditionTypeProgrammed)
+		if cond == nil {
+			continue
+		}
+		if cond.Status == metav1.ConditionTrue && cond.ObservedGeneration >= tpp.Generation {
+			return true
+		}
+	}
+	return false
+}
+
 // Reconcile stamps the TPP's observed generation onto the trigger annotation of
 // every Gateway it targets, and clears the annotation on every Gateway that
 // dropped out of its target set since the last reconcile (a removed targetRef,
@@ -88,9 +145,10 @@ func tppTriggerAnnotationKey(tppName string) string {
 // Gateway name), so the TPP→Gateway mapping is local and name-derived.
 //
 // Each Gateway patch is a merge patch with no preceding Get: an unchanged
-// generation (or clearing an already-absent annotation) is a server-side no-op
-// (no resourceVersion bump, no EG event), so it is naturally idempotent and
-// never triggers a spurious re-translation.
+// trigger value (or clearing an already-absent annotation) is a server-side
+// no-op (no resourceVersion bump, no EG event), so steady-state reconciles are
+// naturally idempotent. When Programmed is behind, triggerValue adds a
+// per-process suffix so the annotation changes once and EG re-translates.
 func (r *TPPReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 	annotationKey := tppTriggerAnnotationKey(req.Name)
@@ -105,7 +163,7 @@ func (r *TPPReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 		return ctrl.Result{}, r.clearGateways(ctx, logger, req.NamespacedName, annotationKey, r.takeTargets(req.NamespacedName), "delete")
 	}
 
-	value := strconv.FormatInt(tpp.Generation, 10)
+	value := r.triggerValue(&tpp)
 
 	seen := make(map[string]struct{}, len(tpp.Spec.TargetRefs))
 	current := make([]string, 0, len(tpp.Spec.TargetRefs))
@@ -131,7 +189,7 @@ func (r *TPPReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 			continue
 		}
 		logger.Info("touched gateway to trigger EG re-translation",
-			"gateway", gwKey, "tpp", tpp.Name, "generation", value)
+			"gateway", gwKey, "tpp", tpp.Name, "trigger", value)
 	}
 
 	// Clear Gateways that were targeted last time but are not now. On any error
@@ -241,8 +299,10 @@ func removedTargets(prev []string, current map[string]struct{}) []string {
 // SetupWithManager registers the controller. It reconciles a TPP only when its
 // spec changes (generation bump) or it is deleted — the extension server reads
 // spec fields only (mode, targetRefs, ruleSets, sampling), so status/metadata
-// churn is ignored.
+// churn is ignored. Create-on-startup also drives Programmed backfill for idle
+// proxies whose trigger annotation already matches the current generation.
 func (r *TPPReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	_ = r.ensureBootID()
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&networkingv1alpha.TrafficProtectionPolicy{}, builder.WithPredicates(tppSpecChangedPredicate())).
 		Named("extension-server-gateway-retrigger-tpp").
@@ -250,10 +310,11 @@ func (r *TPPReconciler) SetupWithManager(mgr ctrl.Manager) error {
 }
 
 // tppSpecChangedPredicate admits creates (so TPPs already present when the
-// controller starts stamp their Gateways, and their target set is learned before
-// any later edit or delete), updates that bump the generation (any spec change:
-// mode flip, targetRef edit, ruleset/sampling change), and deletes (so a removed
-// policy's Gateways are re-translated against the now-empty cache).
+// controller starts stamp their Gateways — including a Programmed backfill
+// nudge when status is empty — and their target set is learned before any later
+// edit or delete), updates that bump the generation (any spec change: mode flip,
+// targetRef edit, ruleset/sampling change), and deletes (so a removed policy's
+// Gateways are re-translated against the now-empty cache).
 func tppSpecChangedPredicate() predicate.Predicate {
 	return predicate.Funcs{
 		CreateFunc: func(event.CreateEvent) bool { return true },

--- a/internal/extensionserver/retrigger/tpp_test.go
+++ b/internal/extensionserver/retrigger/tpp_test.go
@@ -4,11 +4,13 @@ package retrigger
 
 import (
 	"context"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -19,7 +21,10 @@ import (
 	networkingv1alpha "go.datum.net/network-services-operator/api/v1alpha"
 )
 
-const testTPP = "tpp-1"
+const (
+	testTPP    = "tpp-1"
+	testBootID = "boot"
+)
 
 func gatewayTargetRef(name string) gatewayv1alpha2.LocalPolicyTargetReferenceWithSectionName {
 	return gatewayv1alpha2.LocalPolicyTargetReferenceWithSectionName{
@@ -45,9 +50,35 @@ func tpp(mode networkingv1alpha.TrafficProtectionPolicyMode, generation int64, g
 	}
 }
 
+func withProgrammed(policy *networkingv1alpha.TrafficProtectionPolicy, observedGeneration int64) *networkingv1alpha.TrafficProtectionPolicy {
+	policy = policy.DeepCopy()
+	policy.Status.Ancestors = []gatewayv1.PolicyAncestorStatus{{
+		AncestorRef: gatewayv1.ParentReference{
+			Group:     ptr.To(gatewayv1.Group(gatewayv1.GroupName)),
+			Kind:      ptr.To(gatewayv1.Kind("Gateway")),
+			Namespace: ptr.To(gatewayv1.Namespace(testNS)),
+			Name:      gatewayv1.ObjectName(testProxy),
+		},
+		ControllerName: "networking.datumapis.com/envoy-gateway-extension-server",
+		Conditions: []metav1.Condition{{
+			Type:               conditionTypeProgrammed,
+			Status:             metav1.ConditionTrue,
+			Reason:             "Programmed",
+			Message:            "Policy has been programmed on this edge.",
+			ObservedGeneration: observedGeneration,
+			LastTransitionTime: metav1.Now(),
+		}},
+	}}
+	return policy
+}
+
+func newTPPReconciler(cl client.Client) *TPPReconciler {
+	return &TPPReconciler{Client: cl, bootID: testBootID}
+}
+
 func reconcileTPP(t *testing.T, cl client.Client) {
 	t.Helper()
-	reconcileTPPWith(t, &TPPReconciler{Client: cl})
+	reconcileTPPWith(t, newTPPReconciler(cl))
 }
 
 // reconcileTPPWith reconciles through a caller-owned reconciler so its in-memory
@@ -68,13 +99,19 @@ func gatewayTPPTrigger(t *testing.T, cl client.Client, gwName string) string {
 	return gw.Annotations[tppTriggerAnnotationKey(testTPP)]
 }
 
-// TestTPPReconcile_StampsTargetedGateway: reconciling a TPP stamps its
-// generation onto the trigger annotation of the Gateway it targets, so EG
-// re-translates against the fresh cache.
+func backfillTrigger(generation int64) string {
+	return strconv.FormatInt(generation, 10) + ".programmed." + testBootID
+}
+
+// TestTPPReconcile_StampsTargetedGateway: reconciling a programmed TPP stamps
+// its bare generation onto the trigger annotation of the Gateway it targets.
 func TestTPPReconcile_StampsTargetedGateway(t *testing.T) {
 	scheme := testScheme(t)
 	cl := fake.NewClientBuilder().WithScheme(scheme).
-		WithObjects(tpp(networkingv1alpha.TrafficProtectionPolicyEnforce, 7, testProxy), gateway()).
+		WithObjects(
+			withProgrammed(tpp(networkingv1alpha.TrafficProtectionPolicyEnforce, 7, testProxy), 7),
+			gateway(),
+		).
 		Build()
 
 	reconcileTPP(t, cl)
@@ -83,12 +120,70 @@ func TestTPPReconcile_StampsTargetedGateway(t *testing.T) {
 		"a targeted Gateway must be stamped with the TPP generation")
 }
 
+// TestTPPReconcile_BackfillWhenProgrammedMissing: a Create-on-startup reconcile
+// must change the trigger even when the annotation already equals the
+// generation, so EG re-translates and the extension can stamp Programmed.
+func TestTPPReconcile_BackfillWhenProgrammedMissing(t *testing.T) {
+	scheme := testScheme(t)
+	gw := gateway()
+	gw.Annotations = map[string]string{tppTriggerAnnotationKey(testTPP): "7"}
+	cl := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(tpp(networkingv1alpha.TrafficProtectionPolicyEnforce, 7, testProxy), gw).
+		Build()
+
+	reconcileTPP(t, cl)
+
+	assert.Equal(t, backfillTrigger(7), gatewayTPPTrigger(t, cl, testProxy),
+		"missing Programmed must force a distinct trigger so EG re-translates")
+}
+
+// TestTPPReconcile_BackfillWhenObservedGenerationStale: Programmed=True for an
+// older generation still needs a nudge for the current generation.
+func TestTPPReconcile_BackfillWhenObservedGenerationStale(t *testing.T) {
+	scheme := testScheme(t)
+	gw := gateway()
+	gw.Annotations = map[string]string{tppTriggerAnnotationKey(testTPP): "7"}
+	cl := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(
+			withProgrammed(tpp(networkingv1alpha.TrafficProtectionPolicyEnforce, 7, testProxy), 6),
+			gw,
+		).
+		Build()
+
+	reconcileTPP(t, cl)
+
+	assert.Equal(t, backfillTrigger(7), gatewayTPPTrigger(t, cl, testProxy),
+		"stale Programmed observedGeneration must force a backfill trigger")
+}
+
+// TestTPPReconcile_NoBackfillWhenProgrammedCurrent: once Programmed matches
+// the generation, the bare generation stamp stays idempotent.
+func TestTPPReconcile_NoBackfillWhenProgrammedCurrent(t *testing.T) {
+	scheme := testScheme(t)
+	gw := gateway()
+	gw.Annotations = map[string]string{tppTriggerAnnotationKey(testTPP): "7"}
+	cl := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(
+			withProgrammed(tpp(networkingv1alpha.TrafficProtectionPolicyEnforce, 7, testProxy), 7),
+			gw,
+		).
+		Build()
+
+	reconcileTPP(t, cl)
+
+	assert.Equal(t, "7", gatewayTPPTrigger(t, cl, testProxy),
+		"current Programmed must keep the bare generation trigger (no-op patch)")
+}
+
 // TestTPPReconcile_ModeFlipChangesTrigger: a mode flip bumps the generation, so
 // the trigger annotation value changes and EG re-translates.
 func TestTPPReconcile_ModeFlipChangesTrigger(t *testing.T) {
 	scheme := testScheme(t)
 	cl := fake.NewClientBuilder().WithScheme(scheme).
-		WithObjects(tpp(networkingv1alpha.TrafficProtectionPolicyObserve, 3, testProxy), gateway()).
+		WithObjects(
+			withProgrammed(tpp(networkingv1alpha.TrafficProtectionPolicyObserve, 3, testProxy), 3),
+			gateway(),
+		).
 		Build()
 
 	reconcileTPP(t, cl)
@@ -98,11 +193,13 @@ func TestTPPReconcile_ModeFlipChangesTrigger(t *testing.T) {
 	require.NoError(t, cl.Get(context.Background(), client.ObjectKey{Namespace: testNS, Name: testTPP}, &current))
 	current.Spec.Mode = networkingv1alpha.TrafficProtectionPolicyEnforce
 	current.Generation = 4
+	// Spec change invalidates prior Programmed for generation 3.
+	current.Status = networkingv1alpha.TrafficProtectionPolicyStatus{}
 	require.NoError(t, cl.Update(context.Background(), &current))
 	reconcileTPP(t, cl)
 
-	assert.Equal(t, "4", gatewayTPPTrigger(t, cl, testProxy),
-		"a spec change must bump the trigger annotation so EG re-translates")
+	assert.Equal(t, backfillTrigger(4), gatewayTPPTrigger(t, cl, testProxy),
+		"a spec change without Programmed yet must use the backfill trigger")
 }
 
 // TestTPPReconcile_NoGateway_NoError: a missing Gateway is ignored — EG reads
@@ -121,7 +218,11 @@ func TestTPPReconcile_MultipleTargets(t *testing.T) {
 	scheme := testScheme(t)
 	gwB := &gatewayv1.Gateway{ObjectMeta: metav1.ObjectMeta{Name: "proxy-2", Namespace: testNS}}
 	cl := fake.NewClientBuilder().WithScheme(scheme).
-		WithObjects(tpp(networkingv1alpha.TrafficProtectionPolicyEnforce, 2, testProxy, "proxy-2"), gateway(), gwB).
+		WithObjects(
+			withProgrammed(tpp(networkingv1alpha.TrafficProtectionPolicyEnforce, 2, testProxy, "proxy-2"), 2),
+			gateway(),
+			gwB,
+		).
 		Build()
 
 	reconcileTPP(t, cl)
@@ -143,9 +244,12 @@ func TestTPPReconcile_PerTPPKey(t *testing.T) {
 func TestTPPReconcile_DeletionClearsGateways(t *testing.T) {
 	scheme := testScheme(t)
 	cl := fake.NewClientBuilder().WithScheme(scheme).
-		WithObjects(tpp(networkingv1alpha.TrafficProtectionPolicyEnforce, 5, testProxy), gateway()).
+		WithObjects(
+			withProgrammed(tpp(networkingv1alpha.TrafficProtectionPolicyEnforce, 5, testProxy), 5),
+			gateway(),
+		).
 		Build()
-	r := &TPPReconciler{Client: cl}
+	r := newTPPReconciler(cl)
 
 	reconcileTPPWith(t, r)
 	require.Equal(t, "5", gatewayTPPTrigger(t, cl, testProxy))
@@ -166,9 +270,13 @@ func TestTPPReconcile_TargetRefRemovalClearsDropped(t *testing.T) {
 	scheme := testScheme(t)
 	gwB := &gatewayv1.Gateway{ObjectMeta: metav1.ObjectMeta{Name: "proxy-2", Namespace: testNS}}
 	cl := fake.NewClientBuilder().WithScheme(scheme).
-		WithObjects(tpp(networkingv1alpha.TrafficProtectionPolicyEnforce, 2, testProxy, "proxy-2"), gateway(), gwB).
+		WithObjects(
+			withProgrammed(tpp(networkingv1alpha.TrafficProtectionPolicyEnforce, 2, testProxy, "proxy-2"), 2),
+			gateway(),
+			gwB,
+		).
 		Build()
-	r := &TPPReconciler{Client: cl}
+	r := newTPPReconciler(cl)
 
 	reconcileTPPWith(t, r)
 	require.Equal(t, "2", gatewayTPPTrigger(t, cl, testProxy))
@@ -178,11 +286,12 @@ func TestTPPReconcile_TargetRefRemovalClearsDropped(t *testing.T) {
 	require.NoError(t, cl.Get(context.Background(), client.ObjectKey{Namespace: testNS, Name: testTPP}, &current))
 	current.Spec.TargetRefs = []gatewayv1alpha2.LocalPolicyTargetReferenceWithSectionName{gatewayTargetRef(testProxy)}
 	current.Generation = 3
+	current.Status = networkingv1alpha.TrafficProtectionPolicyStatus{}
 	require.NoError(t, cl.Update(context.Background(), &current))
 	reconcileTPPWith(t, r)
 
-	assert.Equal(t, "3", gatewayTPPTrigger(t, cl, testProxy),
-		"a retained target must be re-stamped with the new generation")
+	assert.Equal(t, backfillTrigger(3), gatewayTPPTrigger(t, cl, testProxy),
+		"a retained target must be re-stamped for the new generation")
 	assert.Empty(t, gatewayTPPTrigger(t, cl, "proxy-2"),
 		"a dropped target must have its trigger annotation cleared")
 }
@@ -206,4 +315,10 @@ func TestTPPSpecChangedPredicate(t *testing.T) {
 	noSpecChange.ResourceVersion = "999"
 	assert.False(t, p.Update(event.UpdateEvent{ObjectOld: observe, ObjectNew: noSpecChange}),
 		"a status/metadata-only update (same generation) must NOT reconcile")
+}
+
+func TestTPPProgrammedForGeneration(t *testing.T) {
+	assert.False(t, tppProgrammedForGeneration(tpp(networkingv1alpha.TrafficProtectionPolicyEnforce, 3, testProxy)))
+	assert.False(t, tppProgrammedForGeneration(withProgrammed(tpp(networkingv1alpha.TrafficProtectionPolicyEnforce, 3, testProxy), 2)))
+	assert.True(t, tppProgrammedForGeneration(withProgrammed(tpp(networkingv1alpha.TrafficProtectionPolicyEnforce, 3, testProxy), 3)))
 }


### PR DESCRIPTION
## Summary

`Programmed` is only written inside `PostTranslateModify` after a real Envoy Gateway re-translate. After rolling out that status writer, Create-on-startup re-stamped the bare generation trigger annotation — and when it already matched, the patch was a no-op. Idle proxies therefore stayed without `Programmed` until something (or someone) forced a re-translate.

This makes the startup/reconcile path force a one-shot distinct trigger (`<gen>.programmed.<bootID>`) whenever edge-local `Programmed` is missing or `observedGeneration` lags `metadata.generation`, so existing proxies backfill automatically on extension rollout. Once status is current, the bare generation stamp stays idempotent.

## Test plan

- [x] Unit tests for missing / stale / current Programmed trigger values
- [ ] After deploy to staging: confirm previously-empty TPPs gain `Programmed` without a manual spec edit
- [ ] Confirm already-`Programmed` proxies do not churn on subsequent reconciles

Related to #266