### PR TITLE
fix: Alert when TPP edge apply lag exceeds 30s

### DIFF
--- a/config/telemetry/alerts/gateways.yaml
+++ b/config/telemetry/alerts/gateways.yaml
@@ -50,6 +50,19 @@ spec:
         summary: "Gateway {{ $labels.resource_name }} has been degraded for over 60 seconds"
         description: "Gateway {{ $labels.resource_name }} in namespace {{ $labels.resource_namespace }} has been in a degraded state for over 60 seconds without recovering, which exceeds the 60-second SLO threshold."
 
+    - alert: TrafficProtectionPolicyApplyLagSLOViolation
+      expr: |
+        max by (cluster, name, exported_namespace) (nso_extension_tpp_cache_generation)
+          >
+        max by (cluster, name, exported_namespace) (nso_extension_tpp_applied_generation)
+      for: 30s
+      labels:
+        severity: critical
+        slo_violation: "true"
+      annotations:
+        summary: "TrafficProtectionPolicy {{ $labels.name }} apply lag on {{ $labels.cluster }} exceeds 30s"
+        description: "Edge {{ $labels.cluster }} has TrafficProtectionPolicy {{ $labels.exported_namespace }}/{{ $labels.name }} cached at a generation ahead of the last applied generation for over 30 seconds. The edge may be serving stale WAF config for this policy."
+
   # TLS certificate health alerts fire on nso_* metrics emitted directly by the
   # NSO operator and extension server. They are available in the same Prometheus
   # that loads this rule, alongside the envoy_gateway_* metrics above.

--- a/test/prometheus-rules/gateways/nso-slo-rules.yaml
+++ b/test/prometheus-rules/gateways/nso-slo-rules.yaml
@@ -33,3 +33,15 @@ groups:
     annotations:
       summary: "Gateway {{ $labels.resource_name }} has been degraded for over 60 seconds"
       description: "Gateway {{ $labels.resource_name }} in namespace {{ $labels.resource_namespace }} has been in a degraded state for over 60 seconds without recovering, which exceeds the 60-second SLO threshold."
+  - alert: TrafficProtectionPolicyApplyLagSLOViolation
+    expr: |
+      max by (cluster, name, exported_namespace) (nso_extension_tpp_cache_generation)
+        >
+      max by (cluster, name, exported_namespace) (nso_extension_tpp_applied_generation)
+    for: 30s
+    labels:
+      severity: critical
+      slo_violation: "true"
+    annotations:
+      summary: "TrafficProtectionPolicy {{ $labels.name }} apply lag on {{ $labels.cluster }} exceeds 30s"
+      description: "Edge {{ $labels.cluster }} has TrafficProtectionPolicy {{ $labels.exported_namespace }}/{{ $labels.name }} cached at a generation ahead of the last applied generation for over 30 seconds. The edge may be serving stale WAF config for this policy."

--- a/test/prometheus-rules/gateways/nso-slo-tests.yaml
+++ b/test/prometheus-rules/gateways/nso-slo-tests.yaml
@@ -99,3 +99,51 @@ tests:
       - eval_time: 1m
         alertname: GatewayNotReadySLOViolation
         exp_alerts: []
+  # TrafficProtectionPolicyApplyLagSLOViolation — cache ahead of applied for >30s
+  - interval: 30s
+    input_series:
+      - series: 'nso_extension_tpp_cache_generation{cluster="edge-a", name="waf-pol", exported_namespace="ns-tenant", pod="ext-0"}'
+        values: '5+0x4'
+      - series: 'nso_extension_tpp_cache_generation{cluster="edge-a", name="waf-pol", exported_namespace="ns-tenant", pod="ext-1"}'
+        values: '5+0x4'
+      - series: 'nso_extension_tpp_applied_generation{cluster="edge-a", name="waf-pol", exported_namespace="ns-tenant", pod="ext-0"}'
+        values: '4+0x4'
+      - series: 'nso_extension_tpp_applied_generation{cluster="edge-a", name="waf-pol", exported_namespace="ns-tenant", pod="ext-1"}'
+        values: '4+0x4'
+    alert_rule_test:
+      - eval_time: 1m
+        alertname: TrafficProtectionPolicyApplyLagSLOViolation
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              slo_violation: "true"
+              cluster: edge-a
+              name: waf-pol
+              exported_namespace: ns-tenant
+            exp_annotations:
+              summary: "TrafficProtectionPolicy waf-pol apply lag on edge-a exceeds 30s"
+              description: "Edge edge-a has TrafficProtectionPolicy ns-tenant/waf-pol cached at a generation ahead of the last applied generation for over 30 seconds. The edge may be serving stale WAF config for this policy."
+
+  # TrafficProtectionPolicyApplyLagSLOViolation — in sync (should NOT alert)
+  - interval: 30s
+    input_series:
+      - series: 'nso_extension_tpp_cache_generation{cluster="edge-a", name="waf-pol", exported_namespace="ns-tenant", pod="ext-0"}'
+        values: '5+0x4'
+      - series: 'nso_extension_tpp_applied_generation{cluster="edge-a", name="waf-pol", exported_namespace="ns-tenant", pod="ext-0"}'
+        values: '5+0x4'
+    alert_rule_test:
+      - eval_time: 1m
+        alertname: TrafficProtectionPolicyApplyLagSLOViolation
+        exp_alerts: []
+
+  # TrafficProtectionPolicyApplyLagSLOViolation — brief skew clears before 30s (should NOT alert)
+  - interval: 15s
+    input_series:
+      - series: 'nso_extension_tpp_cache_generation{cluster="edge-a", name="waf-pol", exported_namespace="ns-tenant", pod="ext-0"}'
+        values: '5 5 5 5'
+      - series: 'nso_extension_tpp_applied_generation{cluster="edge-a", name="waf-pol", exported_namespace="ns-tenant", pod="ext-0"}'
+        values: '4 4 5 5'
+    alert_rule_test:
+      - eval_time: 45s
+        alertname: TrafficProtectionPolicyApplyLagSLOViolation
+        exp_alerts: []


### PR DESCRIPTION
## Summary

Second point on #266 asked us to measure upstream→edge TrafficProtectionPolicy propagation and decide whether it needs an SLO. Generation-bump samples converge in ~1.5s on staging and ~3.3s on prod — well under a 30s budget — so this adopts that SLO and pages when an edge stays behind.

The alert watches the existing extension-server gauges (`nso_extension_tpp_cache_generation` vs `nso_extension_tpp_applied_generation`), aggregated per edge/policy so replica noise does not flap.

| Env | Sample | Converged |
|---|---|---|
| staging | `nowaf-test` | ~1.2s |
| staging | `help-d9c5g5` | ~1.6s |
| prod | `portfolio-lmpn0u` | ~3.3s |
| prod | `waf-test-3gsu2v` | ~2.1s |

## Test plan

- [x] `promtool test rules` on `test/prometheus-rules/gateways/nso-slo-tests.yaml` (lag / in-sync / brief-skew)
- [ ] Confirm rule lands in the cluster that scrapes edge `envoy-gateway-extension-server` metrics (same path as TLS extension alerts)
- [ ] After deploy, verify no standing firings while the fleet is converged (`cache > applied` is empty today)

Related to #266.