### PR TITLE
fix: clean up edge configuration when a project's namespace is purged

### DIFF
--- a/internal/downstreamclient/mappednamespace.go
+++ b/internal/downstreamclient/mappednamespace.go
@@ -75,11 +75,65 @@ func (c *mappedNamespaceResourceStrategy) getUpstreamNamespace(ctx context.Conte
 
 func (c *mappedNamespaceResourceStrategy) GetDownstreamNamespaceNameForUpstreamNamespace(ctx context.Context, name string) (string, error) {
 	namespace, err := c.getUpstreamNamespace(ctx, name)
-	if err != nil {
+	if err == nil {
+		return fmt.Sprintf("ns-%s", namespace.UID), nil
+	}
+
+	// The downstream namespace is named after the upstream namespace's UID, so
+	// normally we read that UID from the namespace itself. A project purge
+	// force-finalizes the upstream namespace out from under us, though, and it
+	// does so without waiting for the objects inside it to be cleaned up. If we
+	// insisted on the upstream namespace we would never be able to finalize
+	// those objects, and everything we created downstream would be left behind
+	// serving traffic. So when the upstream namespace is gone, find the
+	// downstream namespace by the labels it was stamped with when we created it.
+	if !apierrors.IsNotFound(err) {
 		return "", fmt.Errorf("failed to get downstream namespace: %w", err)
 	}
 
-	return fmt.Sprintf("ns-%s", namespace.UID), nil
+	downstreamNamespaceName, resolveErr := c.findDownstreamNamespaceByLabels(ctx, name)
+	if resolveErr != nil {
+		return "", fmt.Errorf("failed to get downstream namespace: %w: %w", err, resolveErr)
+	}
+
+	return downstreamNamespaceName, nil
+}
+
+// findDownstreamNamespaceByLabels locates the downstream namespace belonging to
+// an upstream namespace without reading that namespace, by matching the labels
+// written in ensureDownstreamNamespace. The cluster name and upstream namespace
+// name together identify exactly one downstream namespace.
+func (c *mappedNamespaceResourceStrategy) findDownstreamNamespaceByLabels(ctx context.Context, upstreamNamespace string) (string, error) {
+	selector := client.MatchingLabels{
+		UpstreamOwnerNamespaceLabel: upstreamNamespace,
+	}
+	// Single-cluster mode leaves the cluster name empty, and ensureDownstreamNamespace
+	// skips the label rather than writing an invalid value, so only match on it
+	// when there is one to match. There is a single upstream cluster in that
+	// mode, so the namespace name alone is still unambiguous.
+	if c.upstreamClusterName != "" {
+		selector[UpstreamOwnerClusterNameLabel] = fmt.Sprintf("cluster-%s", strings.ReplaceAll(c.upstreamClusterName, "/", "_"))
+	}
+
+	var namespaces corev1.NamespaceList
+	if err := c.downstreamClient.List(ctx, &namespaces, selector); err != nil {
+		return "", fmt.Errorf("failed to list downstream namespaces: %w", err)
+	}
+
+	switch len(namespaces.Items) {
+	case 1:
+		return namespaces.Items[0].Name, nil
+	case 0:
+		// Nothing was ever created downstream for this upstream namespace, so
+		// there is no name to resolve and nothing to clean up either.
+		return "", fmt.Errorf("no downstream namespace is labelled for upstream namespace %q", upstreamNamespace)
+	default:
+		names := make([]string, 0, len(namespaces.Items))
+		for _, ns := range namespaces.Items {
+			names = append(names, ns.Name)
+		}
+		return "", fmt.Errorf("upstream namespace %q resolves to more than one downstream namespace: %s", upstreamNamespace, strings.Join(names, ", "))
+	}
 }
 
 func (c *mappedNamespaceResourceStrategy) ensureDownstreamNamespace(ctx context.Context, obj metav1.Object) (*corev1.Namespace, error) {

--- a/internal/downstreamclient/mappednamespace_test.go
+++ b/internal/downstreamclient/mappednamespace_test.go
@@ -1,0 +1,157 @@
+package downstreamclient
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func testScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	if err := corev1.AddToScheme(s); err != nil {
+		t.Fatalf("failed building scheme: %v", err)
+	}
+	return s
+}
+
+// downstreamNamespace is what ensureDownstreamNamespace leaves behind: a
+// namespace named after the upstream namespace UID, labelled with the cluster
+// and the upstream namespace it belongs to.
+func downstreamNamespace(name, cluster, upstreamNamespace string) *corev1.Namespace {
+	labels := map[string]string{
+		UpstreamOwnerNamespaceLabel: upstreamNamespace,
+	}
+	if cluster != "" {
+		labels[UpstreamOwnerClusterNameLabel] = "cluster-" + cluster
+	}
+	return &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   name,
+			Labels: labels,
+		},
+	}
+}
+
+func TestGetDownstreamNamespaceNameForUpstreamNamespace(t *testing.T) {
+	scheme := testScheme(t)
+
+	upstreamNamespace := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "demo",
+			UID:  types.UID("11111111-2222-3333-4444-555555555555"),
+		},
+	}
+
+	t.Run("resolves from the upstream namespace when it exists", func(t *testing.T) {
+		strategy := NewMappedNamespaceResourceStrategy(
+			"project-a",
+			fake.NewClientBuilder().WithScheme(scheme).WithObjects(upstreamNamespace).Build(),
+			fake.NewClientBuilder().WithScheme(scheme).Build(),
+		)
+
+		got, err := strategy.GetDownstreamNamespaceNameForUpstreamNamespace(context.Background(), "demo")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if want := "ns-11111111-2222-3333-4444-555555555555"; got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+
+	// The case a project purge creates: the upstream namespace is force-finalized
+	// away while objects that still need cleaning up remain behind it.
+	t.Run("falls back to the downstream namespace labels when the upstream namespace is gone", func(t *testing.T) {
+		strategy := NewMappedNamespaceResourceStrategy(
+			"project-a",
+			fake.NewClientBuilder().WithScheme(scheme).Build(),
+			fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+				downstreamNamespace("ns-11111111-2222-3333-4444-555555555555", "project-a", "demo"),
+				// Same upstream namespace name in a different project, and a
+				// different namespace in the same project: neither may be picked.
+				downstreamNamespace("ns-99999999-9999-9999-9999-999999999999", "project-b", "demo"),
+				downstreamNamespace("ns-88888888-8888-8888-8888-888888888888", "project-a", "other"),
+			).Build(),
+		)
+
+		got, err := strategy.GetDownstreamNamespaceNameForUpstreamNamespace(context.Background(), "demo")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if want := "ns-11111111-2222-3333-4444-555555555555"; got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("falls back on the namespace name alone in single-cluster mode", func(t *testing.T) {
+		strategy := NewMappedNamespaceResourceStrategy(
+			"",
+			fake.NewClientBuilder().WithScheme(scheme).Build(),
+			fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+				downstreamNamespace("ns-11111111-2222-3333-4444-555555555555", "", "demo"),
+			).Build(),
+		)
+
+		got, err := strategy.GetDownstreamNamespaceNameForUpstreamNamespace(context.Background(), "demo")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if want := "ns-11111111-2222-3333-4444-555555555555"; got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+
+	// Nothing was ever created downstream, so there is no name to resolve. The
+	// error names both halves so the cause is not hidden behind the fallback.
+	t.Run("reports both failures when neither the upstream nor a downstream namespace exists", func(t *testing.T) {
+		strategy := NewMappedNamespaceResourceStrategy(
+			"project-a",
+			fake.NewClientBuilder().WithScheme(scheme).Build(),
+			fake.NewClientBuilder().WithScheme(scheme).Build(),
+		)
+
+		_, err := strategy.GetDownstreamNamespaceNameForUpstreamNamespace(context.Background(), "demo")
+		if err == nil {
+			t.Fatal("expected an error")
+		}
+		for _, want := range []string{"failed to get upstream namespace", "no downstream namespace is labelled"} {
+			if !strings.Contains(err.Error(), want) {
+				t.Errorf("error %q does not mention %q", err, want)
+			}
+		}
+	})
+}
+
+func TestObjectMetaFromUpstreamObjectAfterNamespaceIsPurged(t *testing.T) {
+	scheme := testScheme(t)
+
+	strategy := NewMappedNamespaceResourceStrategy(
+		"project-a",
+		fake.NewClientBuilder().WithScheme(scheme).Build(),
+		fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+			downstreamNamespace("ns-11111111-2222-3333-4444-555555555555", "project-a", "demo"),
+		).Build(),
+	)
+
+	meta, err := strategy.ObjectMetaFromUpstreamObject(context.Background(), &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "some-gateway", Namespace: "demo"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if want := "ns-11111111-2222-3333-4444-555555555555"; meta.Namespace != want {
+		t.Errorf("got namespace %q, want %q", meta.Namespace, want)
+	}
+	if meta.Name != "some-gateway" {
+		t.Errorf("got name %q, want %q", meta.Name, "some-gateway")
+	}
+	if got := meta.Labels[UpstreamOwnerNamespaceLabel]; got != "demo" {
+		t.Errorf("got upstream namespace label %q, want %q", got, "demo")
+	}
+}

--- a/test/e2e-edge/project-purge-object-stranding/chainsaw-test.yaml
+++ b/test/e2e-edge/project-purge-object-stranding/chainsaw-test.yaml
@@ -1,0 +1,662 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+#
+# A purged project's edge configuration is stranded and keeps serving traffic.
+#
+# This test asserts the CORRECT behavior: when a customer's gateway goes away,
+# everything NSO put on the edge for it goes away too. It fails until the
+# stranding bug is fixed, and it is expected to keep passing afterwards. There
+# is nothing to flip.
+#
+# What goes wrong. Every downstream cleanup path in NSO resolves the edge
+# namespace by reading the *upstream* namespace and deriving ns-<uid> from its
+# metadata.uid. Milo's project purge force-finalizes that upstream namespace
+# (it clears spec.finalizers directly, so the namespace disappears whether or
+# not anything is still cleaning up inside it — see
+# milo-os/milo#750 and config/e2e-milo/purge-project.sh, which replays the same
+# ordering). From that moment NSO can no longer answer "which edge namespace
+# does this object belong to", so its finalizer fails on every attempt:
+#
+#   ERROR Reconciler error {"controller": "gateway", "error":
+#     "failed to get downstream namespace name: failed to get downstream namespace:
+#      failed to get upstream namespace: Namespace \"strand-ns\" not found"}
+#
+# The finalizer never completes, so the upstream Gateway is stuck terminating
+# forever and the anchor ConfigMap, the mirrored Gateway and the DNSEndpoint all
+# stay on the edge. In production those objects are propagated on to every edge
+# cluster by Karmada, so a deleted project's listener and DNS records go on
+# serving real traffic with no upstream object left to explain them or to
+# delete them through.
+#
+# The same failure is not specific to gateways: the trafficprotectionpolicy
+# controller resolves the edge namespace the same way and logs the same error at
+# the same moment, which is why the fix belongs in the shared downstream-client
+# layer rather than in one controller.
+#
+# Why the namespace is force-finalized rather than the whole project deleted.
+# The trigger is the upstream namespace vanishing while NSO still has work to
+# do in it, and that is exactly what a project purge does. Removing only the
+# namespace isolates that trigger: the project and its control plane stay up, so
+# the test can still ask the API server about the Gateway afterwards and watch
+# the finalizer fail in place. Deleting the whole project would destroy the
+# evidence along with the bug.
+#
+# Not the same bug as project-deletion-namespace-leak. That test is about the
+# empty edge *namespace* surviving after a clean teardown. This one is about the
+# *objects* inside it surviving because teardown cannot run at all. Both are
+# open; they fail in different places and are fixed by different changes.
+#
+# Talking to the project control plane. The upstream Gateway does not live in
+# the nso-upstream cluster; it lives in a Milo project control plane, reached at
+# https://127.0.0.1:16443/apis/resourcemanager.miloapis.com/v1alpha1/projects/<project>/control-plane
+# through a port-forward to svc/milo-apiserver in milo-system on nso-upstream.
+# Chainsaw cannot address that control plane natively, so every project-side
+# operation runs inside a script: block on cluster nso-upstream that backgrounds
+# its own port-forward, traps it closed on exit, waits for it to actually serve,
+# and then drives kubectl --kubeconfig, authenticating with the static
+# ($miloToken) the environment ships. Each script is self-contained because the
+# trap fires when that script's own shell exits.
+#
+# Naming the edge namespace. Chainsaw outputs are step-scoped, so a binding
+# captured in one step is not visible in the next; every step that needs the edge
+# namespace re-derives it at the top of its own try:. Only the second step reads
+# the upstream namespace UID, because that identity is destroyed in the step
+# after it. Every later step looks the namespace up on the downstream cluster by
+# its meta.datumapis.com/upstream-cluster-name=cluster-<project> label, which
+# still works once the upstream namespace is gone.
+#
+# Prerequisites (the Milo layer is opt-in on top of the standard env):
+#   task test-infra:up
+#   task test-infra:milo-up
+# The project, its namespace, and all its contents are created by this test.
+#
+# Not in DEFAULT_SCENARIOS in Taskfile.test-infra.yml; run it explicitly:
+#   task test-infra:e2e -- project-purge-object-stranding
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: project-purge-object-stranding
+spec:
+  concurrent: false
+  bindings:
+    # The Milo project this test creates. Derived from the chainsaw namespace so
+    # concurrent runs never collide, and short enough that the derived label
+    # value cluster-<project> stays under 63 characters.
+    - name: projectName
+      value: (join('-', ['strand', $namespace]))
+    # The namespace inside the project control plane. It is force-finalized
+    # mid-test, which is the trigger for the whole failure.
+    - name: projectNamespace
+      value: strand-ns
+    - name: gatewayClassName
+      value: strand-gc
+    - name: gatewayName
+      value: strand-gateway
+    # Per-run unique. Hostnames are claimed exclusively by an anchor ConfigMap in
+    # the downstream accounting namespace, keyed by hostname and owned by one
+    # gateway. A fixed hostname would be claimed by the first run's project and
+    # then refused to every later run, whose listener would be silently dropped
+    # and whose downstream Gateway would be rejected as having no listeners.
+    - name: gatewayHostname
+      value: (join('.', [$projectName, 'e2e.env.datum.net']))
+    # Milo runs inside the upstream cluster with no host port mapping, so the
+    # host reaches it on this local port through a port-forward.
+    - name: miloLocalPort
+      value: "16443"
+    # The static credential Milo's own test-infra overlay ships in its published
+    # bundle. It is a fixed test value, not a secret, and the scripts mint their
+    # kubeconfigs from it rather than depending on a task having been run.
+    - name: miloToken
+      value: test-admin-token
+    # How long cleanup is given after the Gateway is deleted. Cleanup on the
+    # healthy path completes in a couple of seconds, so this is generous enough
+    # that a failure means cleanup is not happening rather than that it is slow.
+    - name: cleanupWindowSeconds
+      value: "120"
+  cluster: nso-upstream
+  # A run that fails partway through would otherwise leave a project behind, and
+  # NSO would keep reconciling a gateway nobody is watching. Delete it on any
+  # failure; the edge namespace and the hostname claim go with it in the last
+  # step's finally:, which runs on both outcomes.
+  catch:
+    - script:
+        timeout: 180s
+        cluster: nso-upstream
+        env:
+          - name: PROJECT
+            value: ($projectName)
+          - name: MILO_PORT
+            value: ($miloLocalPort)
+          - name: MILO_TOKEN
+            value: ($miloToken)
+        content: |
+          kubectl -n milo-system port-forward svc/milo-apiserver "${MILO_PORT}:6443" >/dev/null 2>&1 &
+          PF_PID=$!
+          trap 'kill ${PF_PID} 2>/dev/null || true' EXIT
+          for i in $(seq 1 60); do
+            curl -sk -m 2 -H "Authorization: Bearer ${MILO_TOKEN}" \
+              "https://127.0.0.1:${MILO_PORT}/healthz" 2>/dev/null | grep -q '^ok' && break
+            sleep 1
+          done
+          WORK="${TMPDIR:-/tmp}/strand-${PROJECT}"
+          kubectl --kubeconfig "${WORK}/root.yaml" delete project "${PROJECT}" --ignore-not-found --timeout=120s || true
+          exit 0
+  steps:
+    - name: A project with a verified domain and a gateway comes up in its own control plane
+      description: |
+        Everything here happens inside the Milo project control plane, which
+        chainsaw cannot address directly, so it runs as one self-contained
+        script: port-forward, wait for it to serve, mint the root and
+        project-scoped kubeconfigs, then create the project, wait for it to be
+        Ready (NSO only engages Ready projects), and create the namespace,
+        GatewayClass, verified Domain, and Gateway. The Domain must exist in the
+        same namespace and be Verified on its status subresource, or the Gateway
+        never programs downstream and there is nothing for the deletion to
+        clean up.
+      try:
+        - script:
+            timeout: 300s
+            cluster: nso-upstream
+            env:
+              - name: PROJECT
+                value: ($projectName)
+              - name: PROJECT_NS
+                value: ($projectNamespace)
+              - name: GATEWAY_CLASS
+                value: ($gatewayClassName)
+              - name: GATEWAY_NAME
+                value: ($gatewayName)
+              - name: GATEWAY_HOSTNAME
+                value: ($gatewayHostname)
+              - name: MILO_PORT
+                value: ($miloLocalPort)
+              - name: MILO_TOKEN
+                value: ($miloToken)
+            content: |
+              set -eu
+              WORK="${TMPDIR:-/tmp}/strand-${PROJECT}"
+              mkdir -p "${WORK}"
+
+              # Background the port-forward and make sure it dies with this
+              # shell. If a forward is already running on this port this one
+              # simply loses the bind and exits; the readiness poll below still
+              # succeeds through the existing tunnel.
+              kubectl -n milo-system port-forward svc/milo-apiserver "${MILO_PORT}:6443" >/dev/null 2>&1 &
+              PF_PID=$!
+              trap 'kill ${PF_PID} 2>/dev/null || true' EXIT
+
+              TOKEN="${MILO_TOKEN}"
+              # The listener binds before the tunnel carries traffic, so wait on
+              # a real request rather than on the port being open.
+              ready=""
+              for i in $(seq 1 60); do
+                if curl -sk -m 2 -H "Authorization: Bearer ${TOKEN}" \
+                     "https://127.0.0.1:${MILO_PORT}/healthz" 2>/dev/null | grep -q '^ok'; then
+                  ready="yes"; break
+                fi
+                sleep 1
+              done
+              [ -n "${ready}" ] || { echo "ERROR: Milo API server never served through the port-forward (is 'task test-infra:milo-up' done?)"; exit 1; }
+
+              printf 'apiVersion: v1\nkind: Config\nclusters:\n- name: milo\n  cluster:\n    server: https://127.0.0.1:%s\n    insecure-skip-tls-verify: true\nusers:\n- name: nso\n  user:\n    token: %s\ncontexts:\n- name: milo\n  context:\n    cluster: milo\n    user: nso\ncurrent-context: milo\n' \
+                "${MILO_PORT}" "${TOKEN}" > "${WORK}/root.yaml"
+              sed 's|server: https://127.0.0.1:'"${MILO_PORT}"'|&/apis/resourcemanager.miloapis.com/v1alpha1/projects/'"${PROJECT}"'/control-plane|' \
+                "${WORK}/root.yaml" > "${WORK}/project.yaml"
+
+              ROOT="kubectl --kubeconfig ${WORK}/root.yaml"
+              PROJ="kubectl --kubeconfig ${WORK}/project.yaml"
+
+              ${ROOT} apply -f - <<'EOF'
+              apiVersion: resourcemanager.miloapis.com/v1alpha1
+              kind: Organization
+              metadata:
+                name: e2e-org
+              spec:
+                type: Personal
+              EOF
+              ${ROOT} apply -f - <<EOF
+              apiVersion: resourcemanager.miloapis.com/v1alpha1
+              kind: Project
+              metadata:
+                name: ${PROJECT}
+              spec:
+                ownerRef:
+                  kind: Organization
+                  name: e2e-org
+              EOF
+              # NSO only engages a project whose Ready condition is True. Milo's
+              # controller manager sets that, so wait for it rather than forcing
+              # it — a timeout here means the controller is not doing its job.
+              ${ROOT} wait project "${PROJECT}" --for=condition=Ready --timeout=180s
+
+              # The project control plane is served lazily; wait until it answers.
+              served=""
+              for i in $(seq 1 60); do
+                if ${PROJ} get ns >/dev/null 2>&1; then served="yes"; break; fi
+                echo "waiting for the ${PROJECT} control plane to serve... ${i}"
+                sleep 2
+              done
+              [ -n "${served}" ] || { echo "ERROR: project control plane for ${PROJECT} never served"; exit 1; }
+
+              ${PROJ} create namespace "${PROJECT_NS}" --dry-run=client -o yaml | ${PROJ} apply -f -
+              ${PROJ} apply -f - <<EOF
+              apiVersion: gateway.networking.k8s.io/v1
+              kind: GatewayClass
+              metadata:
+                name: ${GATEWAY_CLASS}
+              spec:
+                controllerName: gateway.networking.datumapis.com/external-global-proxy-controller
+              EOF
+              ${PROJ} apply -f - <<EOF
+              apiVersion: networking.datumapis.com/v1alpha
+              kind: Domain
+              metadata:
+                name: test-domain
+                namespace: ${PROJECT_NS}
+              spec:
+                domainName: e2e.env.datum.net
+              EOF
+              # Stand in for the Domain controller's HTTP/DNS verification; an
+              # unverified Domain means the Gateway never programs downstream.
+              ${PROJ} -n "${PROJECT_NS}" patch domain test-domain \
+                --subresource=status --type=merge \
+                -p '{"status":{"conditions":[{"type":"Verified","status":"True","reason":"Test","message":"test","lastTransitionTime":"2025-02-24T23:59:09Z"}]}}'
+              ${PROJ} apply -f - <<EOF
+              apiVersion: gateway.networking.k8s.io/v1
+              kind: Gateway
+              metadata:
+                name: ${GATEWAY_NAME}
+                namespace: ${PROJECT_NS}
+              spec:
+                gatewayClassName: ${GATEWAY_CLASS}
+                listeners:
+                  - name: http
+                    protocol: HTTP
+                    port: 80
+                    hostname: ${GATEWAY_HOSTNAME}
+                    allowedRoutes:
+                      namespaces:
+                        from: Same
+              EOF
+              echo "OK: project ${PROJECT} is Ready and carries a verified Domain and a Gateway"
+      catch:
+        - script:
+            cluster: nso-upstream
+            content: |
+              kubectl -n milo-system get pods -o wide || true
+              kubectl -n milo-system logs deploy/milo-apiserver --tail=100 || true
+              kubectl -n network-services-operator-system logs -l app.kubernetes.io/name=network-services-operator --tail=200 || true
+
+    - name: NSO mirrors the gateway onto the edge in a namespace named after the upstream namespace UID
+      description: |
+        The baseline the stranding is measured against, and the reason the
+        stranding happens. The edge namespace is ns-<uid>, where uid is the
+        *upstream* namespace's metadata.uid — an identity that exists only for as
+        long as that namespace does. This step reads the UID while it is still
+        readable and requires the edge namespace, the mirrored Gateway, the
+        DNSEndpoint and the anchor ConfigMap that owns them to be in place. If
+        any of this is missing, the rest of the test would be asserting cleanup
+        of something that was never created.
+      try:
+        - description: Read the upstream namespace UID. stdout is kept to the bare UID so the binding is exact.
+          script:
+            timeout: 120s
+            cluster: nso-upstream
+            skipCommandOutput: true
+            skipLogOutput: true
+            env:
+              - name: PROJECT
+                value: ($projectName)
+              - name: PROJECT_NS
+                value: ($projectNamespace)
+              - name: MILO_PORT
+                value: ($miloLocalPort)
+              - name: MILO_TOKEN
+                value: ($miloToken)
+            content: |
+              set -eu
+              WORK="${TMPDIR:-/tmp}/strand-${PROJECT}"
+              kubectl -n milo-system port-forward svc/milo-apiserver "${MILO_PORT}:6443" >/dev/null 2>&1 &
+              PF_PID=$!
+              trap 'kill ${PF_PID} 2>/dev/null || true' EXIT
+              for i in $(seq 1 60); do
+                curl -sk -m 2 -H "Authorization: Bearer ${MILO_TOKEN}" \
+                  "https://127.0.0.1:${MILO_PORT}/healthz" 2>/dev/null | grep -q '^ok' && break
+                sleep 1
+              done
+              UID_VALUE="$(kubectl --kubeconfig "${WORK}/project.yaml" get ns "${PROJECT_NS}" \
+                -o jsonpath='{.metadata.uid}')"
+              [ -n "${UID_VALUE}" ] || { echo "ERROR: upstream namespace ${PROJECT_NS} has no UID" >&2; exit 1; }
+              # printf (no trailing newline) so $stdout is exactly the UID.
+              printf '%s' "${UID_VALUE}"
+            outputs:
+              - name: downstreamNamespaceName
+                value: (join('-', ['ns', $stdout]))
+        - description: The mirrored Gateway is Accepted and Programmed in that namespace.
+          assert:
+            timeout: 240s
+            cluster: nso-downstream
+            resource:
+              apiVersion: gateway.networking.k8s.io/v1
+              kind: Gateway
+              metadata:
+                name: ($gatewayName)
+                namespace: ($downstreamNamespaceName)
+              status:
+                (conditions[?type == 'Accepted']):
+                  - status: "True"
+                (conditions[?type == 'Programmed']):
+                  - status: "True"
+        - description: The DNSEndpoint and the anchor ConfigMap that owns the mirrored objects both exist.
+          script:
+            timeout: 120s
+            cluster: nso-downstream
+            env:
+              - name: DS_NS
+                value: ($downstreamNamespaceName)
+              - name: GATEWAY_NAME
+                value: ($gatewayName)
+            content: |
+              set -eu
+              kubectl -n "${DS_NS}" get dnsendpoint "${GATEWAY_NAME}" >/dev/null
+              ANCHORS="$(kubectl -n "${DS_NS}" get configmap \
+                -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' | grep '^anchor-' || true)"
+              [ -n "${ANCHORS}" ] || { echo "ERROR: no anchor ConfigMap in ${DS_NS}; nothing owns the mirrored objects"; exit 1; }
+              echo "--- edge namespace ${DS_NS} as created ---"
+              kubectl -n "${DS_NS}" get gateway,dnsendpoint,configmap
+      catch:
+        - script:
+            cluster: nso-downstream
+            env:
+              - name: PROJECT
+                value: ($projectName)
+            content: |
+              DS_NS="$(kubectl get ns -l meta.datumapis.com/upstream-cluster-name=cluster-${PROJECT} -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)"
+              echo "edge namespace: ${DS_NS:-<none found>}"
+              kubectl -n "${DS_NS}" get gateway,dnsendpoint,configmap -o yaml || true
+        - script:
+            cluster: nso-upstream
+            content: |
+              kubectl -n network-services-operator-system logs -l app.kubernetes.io/name=network-services-operator --tail=200 || true
+
+    - name: The project purge force-finalizes the namespace out from under NSO
+      description: |
+        This is the trigger, reproduced exactly as Milo's purge performs it:
+        delete the namespace without waiting, then clear spec.finalizers through
+        the finalize subresource so the namespace is removed regardless of what
+        is still inside it.
+
+        The Gateway survives the namespace as an etcd ghost — still listed by the
+        API server, still carrying NSO's finalizer, but with no namespace object
+        behind it. That combination is the whole bug: NSO is about to be asked to
+        clean the Gateway up, and the only route it has to the edge namespace
+        runs through a namespace that no longer exists.
+      try:
+        - script:
+            timeout: 180s
+            cluster: nso-upstream
+            env:
+              - name: PROJECT
+                value: ($projectName)
+              - name: PROJECT_NS
+                value: ($projectNamespace)
+              - name: GATEWAY_NAME
+                value: ($gatewayName)
+              - name: MILO_PORT
+                value: ($miloLocalPort)
+              - name: MILO_TOKEN
+                value: ($miloToken)
+            content: |
+              set -eu
+              WORK="${TMPDIR:-/tmp}/strand-${PROJECT}"
+              kubectl -n milo-system port-forward svc/milo-apiserver "${MILO_PORT}:6443" >/dev/null 2>&1 &
+              PF_PID=$!
+              trap 'kill ${PF_PID} 2>/dev/null || true' EXIT
+              for i in $(seq 1 60); do
+                curl -sk -m 2 -H "Authorization: Bearer ${MILO_TOKEN}" \
+                  "https://127.0.0.1:${MILO_PORT}/healthz" 2>/dev/null | grep -q '^ok' && break
+                sleep 1
+              done
+              PROJ="kubectl --kubeconfig ${WORK}/project.yaml"
+
+              ${PROJ} delete namespace "${PROJECT_NS}" --wait=false
+              ${PROJ} get namespace "${PROJECT_NS}" -o json \
+                | jq '.spec.finalizers = []' \
+                | ${PROJ} replace --raw "/api/v1/namespaces/${PROJECT_NS}/finalize" -f - >/dev/null
+
+              gone=""
+              for i in $(seq 1 30); do
+                if ! ${PROJ} get namespace "${PROJECT_NS}" >/dev/null 2>&1; then gone="yes"; break; fi
+                echo "waiting for namespace ${PROJECT_NS} to disappear... ${i}"
+                sleep 2
+              done
+              [ -n "${gone}" ] || { echo "ERROR: namespace ${PROJECT_NS} survived the force-finalize; the trigger did not fire and the rest of this test proves nothing"; exit 1; }
+
+              # The Gateway must outlive its namespace, otherwise there is no
+              # object left for NSO's finalizer to fail on.
+              FINALIZERS="$(${PROJ} -n "${PROJECT_NS}" get gateway "${GATEWAY_NAME}" \
+                -o jsonpath='{.metadata.finalizers}' 2>/dev/null || true)"
+              case "${FINALIZERS}" in
+                *gateway.networking.datumapis.com/gateway-controller*) ;;
+                *) echo "ERROR: gateway ${GATEWAY_NAME} did not survive as a ghost (finalizers=${FINALIZERS:-<none>}); the reproduction is not set up"; exit 1 ;;
+              esac
+              echo "OK: namespace ${PROJECT_NS} is gone and gateway ${GATEWAY_NAME} survives it holding ${FINALIZERS}"
+      catch:
+        - script:
+            cluster: nso-upstream
+            content: |
+              kubectl -n network-services-operator-system logs -l app.kubernetes.io/name=network-services-operator --tail=200 || true
+
+    - name: Deleting the gateway must remove everything NSO created on the edge
+      description: |
+        The guarantee. The customer deletes the Gateway; within
+        ($cleanupWindowSeconds) the mirrored Gateway, the DNSEndpoint and the
+        anchor ConfigMap must all be gone from the edge, and the upstream Gateway
+        must have lost its finalizer and been removed. Whether or not the
+        upstream namespace still exists is NSO's problem, not the customer's.
+
+        This step fails today. NSO's finalizer cannot resolve the edge namespace
+        without the upstream namespace, so it errors on every attempt, the
+        upstream Gateway stays terminating forever, and the edge objects stay
+        exactly where they are — in production, still serving. On failure the
+        step prints the surviving objects and the NSO log lines that explain
+        them, so the diagnosis is in the output rather than somewhere else.
+
+        The edge namespace is re-derived here from its label rather than from the
+        UID captured earlier: chainsaw outputs are step-scoped, and the upstream
+        namespace that held the UID no longer exists.
+      try:
+        - description: Re-derive the edge namespace for this step, by a label that survives the upstream namespace.
+          script:
+            timeout: 120s
+            cluster: nso-downstream
+            skipCommandOutput: true
+            skipLogOutput: true
+            env:
+              - name: PROJECT
+                value: ($projectName)
+            content: |
+              set -eu
+              printf '%s' "$(kubectl get ns -l meta.datumapis.com/upstream-cluster-name=cluster-${PROJECT} \
+                -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)"
+            outputs:
+              - name: downstreamNamespaceName
+                value: ($stdout)
+        - description: The customer deletes the Gateway. --wait=false because the finalizer is what is under test; waiting here would only move the timeout into kubectl.
+          script:
+            timeout: 120s
+            cluster: nso-upstream
+            env:
+              - name: PROJECT
+                value: ($projectName)
+              - name: PROJECT_NS
+                value: ($projectNamespace)
+              - name: GATEWAY_NAME
+                value: ($gatewayName)
+              - name: MILO_PORT
+                value: ($miloLocalPort)
+              - name: MILO_TOKEN
+                value: ($miloToken)
+            content: |
+              set -eu
+              WORK="${TMPDIR:-/tmp}/strand-${PROJECT}"
+              kubectl -n milo-system port-forward svc/milo-apiserver "${MILO_PORT}:6443" >/dev/null 2>&1 &
+              PF_PID=$!
+              trap 'kill ${PF_PID} 2>/dev/null || true' EXIT
+              for i in $(seq 1 60); do
+                curl -sk -m 2 -H "Authorization: Bearer ${MILO_TOKEN}" \
+                  "https://127.0.0.1:${MILO_PORT}/healthz" 2>/dev/null | grep -q '^ok' && break
+                sleep 1
+              done
+              kubectl --kubeconfig "${WORK}/project.yaml" -n "${PROJECT_NS}" \
+                delete gateway "${GATEWAY_NAME}" --wait=false
+              echo "OK: deletion of gateway ${GATEWAY_NAME} requested"
+        - description: THE GUARANTEE - nothing NSO created is left on the edge.
+          script:
+            timeout: 300s
+            cluster: nso-downstream
+            env:
+              - name: PROJECT
+                value: ($projectName)
+              - name: DS_NS
+                value: ($downstreamNamespaceName)
+              - name: WINDOW
+                value: ($cleanupWindowSeconds)
+            content: |
+              set -eu
+              [ -n "${DS_NS}" ] || { echo "ERROR: no edge namespace labelled cluster-${PROJECT} was found; the earlier steps did not leave the state this one needs"; exit 1; }
+
+              deadline=$(( $(date +%s) + WINDOW ))
+              clean=""
+              while [ "$(date +%s)" -lt "${deadline}" ]; do
+                GW="$(kubectl -n "${DS_NS}" get gateway -o name 2>/dev/null | wc -l | tr -d ' ')"
+                DE="$(kubectl -n "${DS_NS}" get dnsendpoint -o name 2>/dev/null | wc -l | tr -d ' ')"
+                AN="$(kubectl -n "${DS_NS}" get configmap -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' 2>/dev/null | grep -c '^anchor-' || true)"
+                echo "edge gateways=${GW} dnsendpoints=${DE} anchors=${AN}"
+                if [ "${GW}" = "0" ] && [ "${DE}" = "0" ] && [ "${AN}" = "0" ]; then clean="yes"; break; fi
+                sleep 5
+              done
+
+              if [ -n "${clean}" ]; then
+                echo "OK: the edge is clean even though the upstream namespace was already gone"
+                exit 0
+              fi
+
+              echo
+              echo "STRANDED: ${WINDOW}s after the gateway was deleted, configuration NSO created is still"
+              echo "on the edge with nothing upstream left to delete it through. In production Karmada"
+              echo "propagates these objects to every edge cluster, so this listener keeps serving."
+              echo
+              echo "--- surviving objects in ${DS_NS} ---"
+              kubectl -n "${DS_NS}" get gateway,dnsendpoint,configmap || true
+              exit 1
+        - description: And the upstream Gateway itself is released rather than stuck terminating behind a finalizer that can never complete.
+          script:
+            timeout: 300s
+            cluster: nso-upstream
+            env:
+              - name: PROJECT
+                value: ($projectName)
+              - name: PROJECT_NS
+                value: ($projectNamespace)
+              - name: GATEWAY_NAME
+                value: ($gatewayName)
+              - name: WINDOW
+                value: ($cleanupWindowSeconds)
+              - name: MILO_PORT
+                value: ($miloLocalPort)
+              - name: MILO_TOKEN
+                value: ($miloToken)
+            content: |
+              set -eu
+              WORK="${TMPDIR:-/tmp}/strand-${PROJECT}"
+              kubectl -n milo-system port-forward svc/milo-apiserver "${MILO_PORT}:6443" >/dev/null 2>&1 &
+              PF_PID=$!
+              trap 'kill ${PF_PID} 2>/dev/null || true' EXIT
+              for i in $(seq 1 60); do
+                curl -sk -m 2 -H "Authorization: Bearer ${MILO_TOKEN}" \
+                  "https://127.0.0.1:${MILO_PORT}/healthz" 2>/dev/null | grep -q '^ok' && break
+                sleep 1
+              done
+              PROJ="kubectl --kubeconfig ${WORK}/project.yaml"
+
+              deadline=$(( $(date +%s) + WINDOW ))
+              released=""
+              while [ "$(date +%s)" -lt "${deadline}" ]; do
+                if ! ${PROJ} -n "${PROJECT_NS}" get gateway "${GATEWAY_NAME}" >/dev/null 2>&1; then
+                  released="yes"; break
+                fi
+                echo "upstream gateway ${GATEWAY_NAME} still present"
+                sleep 5
+              done
+
+              if [ -n "${released}" ]; then
+                echo "OK: the upstream gateway was released and removed"
+                exit 0
+              fi
+
+              echo
+              echo "STUCK: the upstream gateway is still terminating; NSO's finalizer never completed."
+              ${PROJ} -n "${PROJECT_NS}" get gateway "${GATEWAY_NAME}" \
+                -o jsonpath='deletionTimestamp={.metadata.deletionTimestamp}{"\n"}finalizers={.metadata.finalizers}{"\n"}' || true
+              echo
+              echo "--- why: NSO cannot resolve the edge namespace without the upstream namespace ---"
+              kubectl -n network-services-operator-system logs -l app.kubernetes.io/name=network-services-operator --tail=400 2>/dev/null \
+                | grep 'failed to get upstream namespace' | tail -5 || true
+              exit 1
+      catch:
+        - script:
+            cluster: nso-downstream
+            env:
+              - name: PROJECT
+                value: ($projectName)
+            content: |
+              DS_NS="$(kubectl get ns -l meta.datumapis.com/upstream-cluster-name=cluster-${PROJECT} -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)"
+              echo "edge namespace: ${DS_NS:-<none found>}"
+              kubectl -n "${DS_NS}" get gateway,dnsendpoint,configmap -o yaml || true
+        - script:
+            cluster: nso-upstream
+            content: |
+              kubectl -n network-services-operator-system logs -l app.kubernetes.io/name=network-services-operator --tail=300 || true
+      finally:
+        # Delete the project on both outcomes. On a failing run this also stops
+        # NSO reconciling a gateway that will never finalize.
+        - script:
+            timeout: 180s
+            cluster: nso-upstream
+            env:
+              - name: PROJECT
+                value: ($projectName)
+              - name: MILO_PORT
+                value: ($miloLocalPort)
+              - name: MILO_TOKEN
+                value: ($miloToken)
+            content: |
+              kubectl -n milo-system port-forward svc/milo-apiserver "${MILO_PORT}:6443" >/dev/null 2>&1 &
+              PF_PID=$!
+              trap 'kill ${PF_PID} 2>/dev/null || true' EXIT
+              for i in $(seq 1 60); do
+                curl -sk -m 2 -H "Authorization: Bearer ${MILO_TOKEN}" \
+                  "https://127.0.0.1:${MILO_PORT}/healthz" 2>/dev/null | grep -q '^ok' && break
+                sleep 1
+              done
+              WORK="${TMPDIR:-/tmp}/strand-${PROJECT}"
+              kubectl --kubeconfig "${WORK}/root.yaml" delete project "${PROJECT}" --ignore-not-found --timeout=120s || true
+              exit 0
+        # The edge namespace is not reaped by the product (see
+        # project-deletion-namespace-leak), and on a failing run it still holds
+        # the stranded objects, so remove it and the hostname claim here.
+        # Otherwise every run leaves a live listener behind on the edge cluster.
+        - script:
+            timeout: 180s
+            cluster: nso-downstream
+            env:
+              - name: PROJECT
+                value: ($projectName)
+            content: |
+              kubectl delete configmap -A -l "meta.datumapis.com/upstream-cluster-name=cluster-${PROJECT}" \
+                --ignore-not-found --wait=false || true
+              # --wait=false: the delete only has to be requested, and waiting on
+              # namespace termination here would outlast the step.
+              kubectl delete ns -l "meta.datumapis.com/upstream-cluster-name=cluster-${PROJECT}" \
+                --ignore-not-found --wait=false || true
+              exit 0

--- a/test/e2e-edge/project-purge-object-stranding/chainsaw-test.yaml
+++ b/test/e2e-edge/project-purge-object-stranding/chainsaw-test.yaml
@@ -20,17 +20,26 @@
 #     "failed to get downstream namespace name: failed to get downstream namespace:
 #      failed to get upstream namespace: Namespace \"strand-ns\" not found"}
 #
-# The finalizer never completes, so the upstream Gateway is stuck terminating
-# forever and the anchor ConfigMap, the mirrored Gateway and the DNSEndpoint all
-# stay on the edge. In production those objects are propagated on to every edge
-# cluster by Karmada, so a deleted project's listener and DNS records go on
-# serving real traffic with no upstream object left to explain them or to
-# delete them through.
+# The finalizer never completes, so the anchor ConfigMap, the mirrored Gateway
+# and the DNSEndpoint all stay on the edge. In production those objects are
+# propagated on to every edge cluster by Karmada, so a deleted project's listener
+# and DNS records go on serving real traffic with no upstream object left to
+# explain them or to delete them through. That is what this test requires to
+# stop happening.
 #
 # The same failure is not specific to gateways: the trafficprotectionpolicy
 # controller resolves the edge namespace the same way and logs the same error at
 # the same moment, which is why the fix belongs in the shared downstream-client
 # layer rather than in one controller.
+#
+# What this test does NOT require, and why. The upstream Gateway itself stays
+# terminating forever, because NamespaceLifecycle admission refuses every write
+# except DELETE in a namespace that does not exist — so once the namespace is
+# force-finalized, nobody, not even a cluster admin, can remove the finalizer.
+# No change to NSO can close that; it is the upstream half of the problem,
+# milo-os/milo#750. The last step documents the gap and proves it is the API
+# server refusing the write rather than NSO failing to try, instead of quietly
+# asserting a guarantee this side of the system cannot keep.
 #
 # Why the namespace is force-finalized rather than the whole project deleted.
 # The trigger is the upstream namespace vanishing while NSO still has work to
@@ -346,9 +355,9 @@ spec:
                   - status: "True"
                 (conditions[?type == 'Programmed']):
                   - status: "True"
-        - description: The DNSEndpoint and the anchor ConfigMap that owns the mirrored objects both exist.
+        - description: The DNSEndpoint and the anchor ConfigMap that owns the mirrored objects both exist. Polled, because they are written by a separate pass that can land shortly after the Gateway is Programmed.
           script:
-            timeout: 120s
+            timeout: 180s
             cluster: nso-downstream
             env:
               - name: DS_NS
@@ -357,10 +366,16 @@ spec:
                 value: ($gatewayName)
             content: |
               set -eu
-              kubectl -n "${DS_NS}" get dnsendpoint "${GATEWAY_NAME}" >/dev/null
-              ANCHORS="$(kubectl -n "${DS_NS}" get configmap \
-                -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' | grep '^anchor-' || true)"
-              [ -n "${ANCHORS}" ] || { echo "ERROR: no anchor ConfigMap in ${DS_NS}; nothing owns the mirrored objects"; exit 1; }
+              ready=""
+              for i in $(seq 1 30); do
+                ANCHORS="$(kubectl -n "${DS_NS}" get configmap \
+                  -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' 2>/dev/null | grep '^anchor-' || true)"
+                if kubectl -n "${DS_NS}" get dnsendpoint "${GATEWAY_NAME}" >/dev/null 2>&1 && [ -n "${ANCHORS}" ]; then
+                  ready="yes"; break
+                fi
+                sleep 4
+              done
+              [ -n "${ready}" ] || { echo "ERROR: ${DS_NS} never gained both a DNSEndpoint and an anchor ConfigMap; there is nothing for the rest of this test to require the cleanup of"; kubectl -n "${DS_NS}" get gateway,dnsendpoint,configmap || true; exit 1; }
               echo "--- edge namespace ${DS_NS} as created ---"
               kubectl -n "${DS_NS}" get gateway,dnsendpoint,configmap
       catch:
@@ -450,16 +465,18 @@ spec:
       description: |
         The guarantee. The customer deletes the Gateway; within
         ($cleanupWindowSeconds) the mirrored Gateway, the DNSEndpoint and the
-        anchor ConfigMap must all be gone from the edge, and the upstream Gateway
-        must have lost its finalizer and been removed. Whether or not the
+        anchor ConfigMap must all be gone from the edge. Whether or not the
         upstream namespace still exists is NSO's problem, not the customer's.
 
-        This step fails today. NSO's finalizer cannot resolve the edge namespace
-        without the upstream namespace, so it errors on every attempt, the
-        upstream Gateway stays terminating forever, and the edge objects stay
-        exactly where they are — in production, still serving. On failure the
-        step prints the surviving objects and the NSO log lines that explain
-        them, so the diagnosis is in the output rather than somewhere else.
+        Before the fix this failed: NSO's finalizer could not resolve the edge
+        namespace without the upstream namespace, so it errored on every attempt
+        and the edge objects stayed exactly where they were — in production,
+        still serving. On failure the step prints the surviving objects, so the
+        diagnosis is in the output rather than somewhere else.
+
+        The last op is not part of the guarantee. It records the half of this
+        that NSO cannot fix: the upstream Gateway can never be written again, so
+        its finalizer can never be removed. See the header.
 
         The edge namespace is re-derived here from its label rather than from the
         UID captured earlier: chainsaw outputs are step-scoped, and the upstream
@@ -549,9 +566,9 @@ spec:
               echo "--- surviving objects in ${DS_NS} ---"
               kubectl -n "${DS_NS}" get gateway,dnsendpoint,configmap || true
               exit 1
-        - description: And the upstream Gateway itself is released rather than stuck terminating behind a finalizer that can never complete.
+        - description: THE GAP - the upstream Gateway stays terminating, and nothing on this side of the system can change that.
           script:
-            timeout: 300s
+            timeout: 180s
             cluster: nso-upstream
             env:
               - name: PROJECT
@@ -560,8 +577,6 @@ spec:
                 value: ($projectNamespace)
               - name: GATEWAY_NAME
                 value: ($gatewayName)
-              - name: WINDOW
-                value: ($cleanupWindowSeconds)
               - name: MILO_PORT
                 value: ($miloLocalPort)
               - name: MILO_TOKEN
@@ -579,30 +594,35 @@ spec:
               done
               PROJ="kubectl --kubeconfig ${WORK}/project.yaml"
 
-              deadline=$(( $(date +%s) + WINDOW ))
-              released=""
-              while [ "$(date +%s)" -lt "${deadline}" ]; do
-                if ! ${PROJ} -n "${PROJECT_NS}" get gateway "${GATEWAY_NAME}" >/dev/null 2>&1; then
-                  released="yes"; break
-                fi
-                echo "upstream gateway ${GATEWAY_NAME} still present"
-                sleep 5
-              done
-
-              if [ -n "${released}" ]; then
-                echo "OK: the upstream gateway was released and removed"
+              if ! ${PROJ} -n "${PROJECT_NS}" get gateway "${GATEWAY_NAME}" >/dev/null 2>&1; then
+                echo "OK: the upstream gateway is gone. The API server now allows objects in a"
+                echo "    force-finalized namespace to be updated, so the gap this step documents"
+                echo "    has closed. Fold this into the guarantee above and update the header."
                 exit 0
               fi
 
-              echo
-              echo "STUCK: the upstream gateway is still terminating; NSO's finalizer never completed."
+              echo "the upstream gateway is still terminating:"
               ${PROJ} -n "${PROJECT_NS}" get gateway "${GATEWAY_NAME}" \
-                -o jsonpath='deletionTimestamp={.metadata.deletionTimestamp}{"\n"}finalizers={.metadata.finalizers}{"\n"}' || true
+                -o jsonpath='  deletionTimestamp={.metadata.deletionTimestamp}{"\n"}  finalizers={.metadata.finalizers}{"\n"}'
+
+              # Prove this is the API server and not NSO, by trying the same write
+              # as a cluster admin. NamespaceLifecycle admission rejects every
+              # operation except DELETE in a namespace that does not exist, so the
+              # finalizer cannot be removed by anyone.
+              OUT="$(${PROJ} -n "${PROJECT_NS}" patch gateway "${GATEWAY_NAME}" \
+                --type=json -p '[{"op":"remove","path":"/metadata/finalizers"}]' 2>&1 || true)"
+              echo "a cluster admin removing the finalizer by hand gets: ${OUT}"
+              case "${OUT}" in
+                *"namespaces \"${PROJECT_NS}\" not found"*) ;;
+                *) echo "ERROR: expected the API server to refuse the write because the namespace is gone, but it said: ${OUT}"; exit 1 ;;
+              esac
+
               echo
-              echo "--- why: NSO cannot resolve the edge namespace without the upstream namespace ---"
-              kubectl -n network-services-operator-system logs -l app.kubernetes.io/name=network-services-operator --tail=400 2>/dev/null \
-                | grep 'failed to get upstream namespace' | tail -5 || true
-              exit 1
+              echo "GAP (not NSO's to close): an object whose namespace was force-finalized can never"
+              echo "be written again, so its finalizer can never be removed and the object stays in"
+              echo "etcd until the whole project control plane is torn down. The fix belongs upstream"
+              echo "in the purge ordering — milo-os/milo#750. What matters for customers is the edge,"
+              echo "and the step above requires that to be clean regardless."
       catch:
         - script:
             cluster: nso-downstream


### PR DESCRIPTION
When a customer's project is deleted, the configuration we put on the edge for it can be left behind permanently — the mirrored Gateway, its DNS records, and the anchor that owns them. Karmada propagates those objects out to every edge cluster, so a deleted project's listener keeps serving real traffic with nothing upstream left to explain it or to delete it through. Operators cannot clean it up through the product; it has to be removed by hand on each edge.

The cause is an ordering assumption. NSO works out which edge namespace an object belongs to by reading the customer's namespace in the project control plane. A project purge removes that namespace immediately, without waiting for anything still cleaning up inside it (milo-os/milo#750), so from that moment NSO can no longer answer the question and its cleanup fails on every retry, forever.

This makes cleanup independent of that namespace: when it is gone, the edge namespace is found instead from labels written when it was created. The normal path is unchanged, and because the change is in the shared layer every controller that mirrors resources to the edge is covered, not just gateways.

One half of this stays open and is not ours to close. Once a namespace has been force-finalized, the API server refuses every write to the objects left inside it, so their finalizers can never be removed by anyone — the customer's Gateway object stays in a terminating state until the whole project control plane is torn down. That is the purge-ordering problem in milo-os/milo#750. What reaches customers is the edge, and that is now cleaned up regardless.

## Verification

A new end-to-end scenario reproduces the trigger the way a purge performs it: mirror a gateway to the edge, force-finalize the upstream namespace out from under NSO while the gateway is live, delete the gateway, and require the edge to end up clean. It fails against current `main` with the objects still present and passes with this change. Its last step deliberately records the gap above rather than asserting a guarantee this side of the system cannot keep. The existing project-deletion scenario still passes unchanged.

## Note for reviewers

The scenario depends on the Milo layer of the prod-fidelity test environment, which is still in flight on a separate branch and not included here. Until that lands the scenario cannot run in CI; the unit tests covering the resolution logic run today.