### PR TITLE
feat: label projected namespaces with their project

### DIFF
--- a/internal/downstreamclient/mappednamespace.go
+++ b/internal/downstreamclient/mappednamespace.go
@@ -5,12 +5,15 @@ import (
 	"fmt"
 	"strings"
 
+	resourcemanagerv1alpha1 "go.miloapis.com/milo/pkg/apis/resourcemanager/v1alpha1"
+	multiclusterproviders "go.miloapis.com/milo/pkg/multicluster-runtime"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/validation"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -82,7 +85,7 @@ func (c *mappedNamespaceResourceStrategy) GetDownstreamNamespaceNameForUpstreamN
 	return fmt.Sprintf("ns-%s", namespace.UID), nil
 }
 
-func (c *mappedNamespaceResourceStrategy) ensureDownstreamNamespace(ctx context.Context, obj metav1.Object) (*corev1.Namespace, error) {
+func (c *mappedNamespaceResourceStrategy) ensureDownstreamNamespace(ctx context.Context, obj metav1.Object) error {
 	downstreamNamespace := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: obj.GetNamespace(),
@@ -106,6 +109,10 @@ func (c *mappedNamespaceResourceStrategy) ensureDownstreamNamespace(ctx context.
 			downstreamNamespace.Labels[UpstreamOwnerClusterNameLabel] = fmt.Sprintf("cluster-%s", strings.ReplaceAll(c.upstreamClusterName, "/", "_"))
 		}
 
+		if project := ProjectNameFromClusterName(c.upstreamClusterName); project != "" {
+			downstreamNamespace.Labels[resourcemanagerv1alpha1.ProjectNameLabel] = project
+		}
+
 		labels := obj.GetLabels()
 		if v, ok := labels[UpstreamOwnerNamespaceLabel]; ok {
 			downstreamNamespace.Labels[UpstreamOwnerNamespaceLabel] = v
@@ -114,10 +121,10 @@ func (c *mappedNamespaceResourceStrategy) ensureDownstreamNamespace(ctx context.
 		return nil
 	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to ensure downstream namespace: %w", err)
+		return fmt.Errorf("failed to ensure downstream namespace: %w", err)
 	}
 
-	return downstreamNamespace, nil
+	return nil
 }
 
 const (
@@ -127,6 +134,31 @@ const (
 	UpstreamOwnerNameLabel        = "meta.datumapis.com/upstream-name"
 	UpstreamOwnerNamespaceLabel   = "meta.datumapis.com/upstream-namespace"
 )
+
+// singleClusterName is the cluster name the single-cluster provider engages
+// with (see initializeClusterDiscovery in internal/cmd/manager). It names a
+// deployment cluster rather than a project.
+const singleClusterName = string(multiclusterproviders.ProviderSingle)
+
+// ProjectNameFromClusterName returns the project that owns an upstream cluster
+// name, or "" when the name does not identify a project or would not be a valid
+// label value.
+//
+// Under the Milo provider the cluster name is the project name, so downstream
+// resources can record the owning project without observing anything inside the
+// project control plane.
+func ProjectNameFromClusterName(clusterName string) string {
+	if clusterName == "" || clusterName == singleClusterName {
+		return ""
+	}
+
+	name := strings.TrimPrefix(clusterName, "/")
+	if len(validation.IsValidLabelValue(name)) > 0 {
+		return ""
+	}
+
+	return name
+}
 
 // UpstreamClusterNameFromLabel decodes the upstream cluster name from the value
 // of UpstreamOwnerClusterNameLabel, reversing the encoding applied when the
@@ -248,9 +280,8 @@ func (c *mappedNamespaceClient) Apply(ctx context.Context, obj runtime.ApplyConf
 }
 
 func (c *mappedNamespaceClient) Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
-	_, err := c.resourceStrategy.ensureDownstreamNamespace(ctx, obj)
-	if err != nil {
-		return fmt.Errorf("failed to ensure downstream namespace: %w", err)
+	if err := c.resourceStrategy.ensureDownstreamNamespace(ctx, obj); err != nil {
+		return err
 	}
 
 	return c.client.Create(ctx, obj, opts...)
@@ -273,10 +304,18 @@ func (c *mappedNamespaceClient) List(ctx context.Context, list client.ObjectList
 }
 
 func (c *mappedNamespaceClient) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+	if err := c.resourceStrategy.ensureDownstreamNamespace(ctx, obj); err != nil {
+		return err
+	}
+
 	return c.client.Patch(ctx, obj, patch, opts...)
 }
 
 func (c *mappedNamespaceClient) Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+	if err := c.resourceStrategy.ensureDownstreamNamespace(ctx, obj); err != nil {
+		return err
+	}
+
 	return c.client.Update(ctx, obj, opts...)
 }
 

--- a/internal/downstreamclient/mappednamespace_test.go
+++ b/internal/downstreamclient/mappednamespace_test.go
@@ -1,0 +1,124 @@
+package downstreamclient
+
+import (
+	"context"
+	"testing"
+
+	resourcemanagerv1alpha1 "go.miloapis.com/milo/pkg/apis/resourcemanager/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestProjectNameFromClusterName(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		clusterName string
+		want        string
+	}{
+		{"project", "my-project", "my-project"},
+		{"legacy leading slash", "/my-project", "my-project"},
+		{"single cluster provider", "single", ""},
+		{"empty", "", ""},
+		{"invalid label value", "org/my-project", ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ProjectNameFromClusterName(tc.clusterName); got != tc.want {
+				t.Errorf("ProjectNameFromClusterName(%q) = %q, want %q", tc.clusterName, got, tc.want)
+			}
+		})
+	}
+}
+
+func newTestStrategy(t *testing.T, upstreamClusterName string, downstreamObjects ...client.Object) (ResourceStrategy, client.Client) {
+	t.Helper()
+
+	testScheme := runtime.NewScheme()
+	if err := scheme.AddToScheme(testScheme); err != nil {
+		t.Fatalf("failed to build scheme: %v", err)
+	}
+
+	downstreamClient := fake.NewClientBuilder().
+		WithScheme(testScheme).
+		WithObjects(downstreamObjects...).
+		Build()
+
+	upstreamClient := fake.NewClientBuilder().WithScheme(testScheme).Build()
+
+	return NewMappedNamespaceResourceStrategy(upstreamClusterName, upstreamClient, downstreamClient), downstreamClient
+}
+
+func downstreamNamespaceLabels(t *testing.T, c client.Client, name string) map[string]string {
+	t.Helper()
+
+	var namespace corev1.Namespace
+	if err := c.Get(context.Background(), client.ObjectKey{Name: name}, &namespace); err != nil {
+		t.Fatalf("failed to get downstream namespace %q: %v", name, err)
+	}
+
+	return namespace.Labels
+}
+
+func TestEnsureDownstreamNamespaceLabelsProject(t *testing.T) {
+	strategy, downstreamClient := newTestStrategy(t, "my-project")
+
+	configMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "anchor", Namespace: "ns-1234"},
+	}
+	if err := strategy.GetClient().Create(context.Background(), configMap); err != nil {
+		t.Fatalf("failed to create downstream object: %v", err)
+	}
+
+	labels := downstreamNamespaceLabels(t, downstreamClient, "ns-1234")
+	if got := labels[resourcemanagerv1alpha1.ProjectNameLabel]; got != "my-project" {
+		t.Errorf("project label = %q, want %q", got, "my-project")
+	}
+	if got := labels[UpstreamOwnerClusterNameLabel]; got != "cluster-my-project" {
+		t.Errorf("cluster label = %q, want %q", got, "cluster-my-project")
+	}
+}
+
+func TestEnsureDownstreamNamespaceSkipsProjectForSingleCluster(t *testing.T) {
+	strategy, downstreamClient := newTestStrategy(t, "single")
+
+	configMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "anchor", Namespace: "ns-1234"},
+	}
+	if err := strategy.GetClient().Create(context.Background(), configMap); err != nil {
+		t.Fatalf("failed to create downstream object: %v", err)
+	}
+
+	labels := downstreamNamespaceLabels(t, downstreamClient, "ns-1234")
+	if _, ok := labels[resourcemanagerv1alpha1.ProjectNameLabel]; ok {
+		t.Errorf("project label present for single cluster provider: %v", labels)
+	}
+}
+
+func TestUpdateBackfillsProjectLabel(t *testing.T) {
+	existing := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "ns-1234",
+			Labels: map[string]string{
+				UpstreamOwnerClusterNameLabel: "cluster-my-project",
+			},
+		},
+	}
+	configMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "anchor", Namespace: "ns-1234"},
+	}
+
+	strategy, downstreamClient := newTestStrategy(t, "my-project", existing, configMap)
+
+	configMap.Data = map[string]string{"key": "value"}
+	if err := strategy.GetClient().Update(context.Background(), configMap); err != nil {
+		t.Fatalf("failed to update downstream object: %v", err)
+	}
+
+	labels := downstreamNamespaceLabels(t, downstreamClient, "ns-1234")
+	if got := labels[resourcemanagerv1alpha1.ProjectNameLabel]; got != "my-project" {
+		t.Errorf("project label = %q, want %q", got, "my-project")
+	}
+}


### PR DESCRIPTION
## Summary

Alerts from edge clusters name the affected namespace as `ns-<uuid>`, so a responder cannot tell which project or customer is broken without a manual lookup. The uuid is the UID of a namespace inside a project control plane, and nothing scrapes those, so the join cannot be completed on the monitoring side.

The operator already knows the answer when it creates that namespace. Under the Milo provider the upstream cluster name *is* the project name — it is recorded today only as `meta.datumapis.com/upstream-cluster-name`, whose value is prefixed and slash-encoded and whose key does not say "project", so every consumer has to encode the cluster-name-is-project coupling itself. This stamps `resourcemanager.miloapis.com/project-name` alongside it, the same label Milo already puts on project resources, which is what [`milo_projects_info`](https://github.com/datum-cloud/infra/pull/3867#pullrequestreview-611194980) keys on as `resource_name`.

Scoping the issue narrower than it was filed: the project is not absent from these namespaces today, it is only encoded in a label that means something else. The gap this closes is a clean key, not a missing fact.

- `ProjectNameFromClusterName` returns `""` for the single-cluster provider name (`single` names a deployment cluster, not a project) and for anything that is not a valid label value (e.g. a multi-segment `org/my-project`), so the namespace write cannot be broken by a bad value — the failure mode the existing defensive guard in this function documents.
- The downstream namespace is now ensured on the update and patch paths, not only create. Namespaces projected before this change pick up the label on their next reconcile instead of needing a manual backfill, which is the third acceptance criterion. Cost is a cached namespace GET per downstream write and no write once labels match; downstream RBAC already grants the verbs.
- Project **UID** is deliberately not stamped: the multicluster key carries the name only. Display name stays out of scope, per the [decision on the consumer issue](https://github.com/datum-cloud/infra/issues/3840#issuecomment-5221301477).

Closes #339. Consumer side: [datum-cloud/infra#3840](https://github.com/datum-cloud/infra/issues/3840).

## Test plan

- [x] `make test`, `make lint`
- [x] New unit tests in `internal/downstreamclient` cover the helper, the stamped labels, the single-cluster skip, and the backfill-on-update path
- [ ] Not covered by e2e: the test env runs the single-cluster provider, where this label is intentionally absent. Verification is a `kubectl get ns -L resourcemanager.miloapis.com/project-name` on an edge cluster after rollout.