### PR TITLE
docs: record what the upstream cluster name refers to

### DIFF
--- a/internal/downstreamclient/mappednamespace.go
+++ b/internal/downstreamclient/mappednamespace.go
@@ -120,6 +120,18 @@ func (c *mappedNamespaceResourceStrategy) ensureDownstreamNamespace(ctx context.
 	return downstreamNamespace, nil
 }
 
+// UpstreamOwnerClusterNameLabel carries the multicluster provider's name for
+// the upstream cluster, encoded as UpstreamClusterNameFromLabel's inverse.
+//
+// What that name refers to depends on the discovery mode (see
+// initializeClusterDiscovery in internal/cmd/manager):
+//
+//   - Milo provider: the project name. The provider keys clusters by the name of
+//     the cluster-scoped Project it discovered them from, so this label already
+//     records the project that owns a downstream resource. Nothing else in the
+//     operator needs to be consulted, and no project UID is available.
+//   - Single-cluster provider: the literal "single", which names a deployment
+//     cluster and no project.
 const (
 	UpstreamOwnerClusterNameLabel = "meta.datumapis.com/upstream-cluster-name"
 	UpstreamOwnerGroupLabel       = "meta.datumapis.com/upstream-group"
@@ -130,7 +142,8 @@ const (
 
 // UpstreamClusterNameFromLabel decodes the upstream cluster name from the value
 // of UpstreamOwnerClusterNameLabel, reversing the encoding applied when the
-// label is written ("cluster-" prefix, slashes encoded as underscores).
+// label is written ("cluster-" prefix, slashes encoded as underscores). What the
+// decoded name refers to is documented on UpstreamOwnerClusterNameLabel.
 //
 // It also tolerates labels written before the cluster name format changed in
 // #196: those carried a leading slash (e.g. "/project", encoded as

--- a/internal/extensionserver/cache/types.go
+++ b/internal/extensionserver/cache/types.go
@@ -36,14 +36,12 @@ type PolicyIndex struct {
 	// Values are upstream namespace names; they key into TPPs and Connectors.
 	DStoUS map[string]string
 
-	// ProjectNames maps downstream namespace names to the human-readable
-	// project name for that namespace. Derived from
-	// meta.datumapis.com/upstream-cluster-name on replica namespaces (value
-	// format: "cluster-<projectName>"). Empty string when the label is absent
-	// (e.g. single-cluster dev with no cluster name configured).
-	//
-	// TODO: replace with resourcemanager.miloapis.com/project-name once that
-	// label is available on project namespaces.
+	// ProjectNames maps downstream namespace names to the project name for that
+	// namespace, read from meta.datumapis.com/upstream-cluster-name on replica
+	// namespaces (value format: "cluster-<projectName>"). That label is the
+	// operator's record of the owning project; see UpstreamOwnerClusterNameLabel
+	// in internal/downstreamclient. Empty string when the label is absent (e.g.
+	// single-cluster dev with no cluster name configured).
 	ProjectNames map[string]string
 
 	// TPPs maps upstream namespace names to the list of


### PR DESCRIPTION
## Summary

`meta.datumapis.com/upstream-cluster-name` is the operator's record of the owning project, and nothing in this repo said so. Under the Milo provider the multicluster key is the name of the `Project` the cluster was discovered from — a fact that lives in the milo module, so reading NSO alone leaves the label looking like cluster plumbing with no project in it.

That gap produced #339, which proposed adding a project label the operator already writes, and #340, which implemented it. Both closed. The belief was also already in tree: `extensionserver/cache` derives project names from exactly this label while carrying a TODO saying the project label is not available yet, which reads as a gap where there is none.

- `UpstreamOwnerClusterNameLabel` now documents what the name refers to per discovery mode — project name under Milo, the literal `single` otherwise — and that no project UID is available from the key.
- `UpstreamClusterNameFromLabel` points at that description. It documented the `cluster-` prefix, the slash encoding and the legacy leading-slash form in detail, and never the referent.
- The stale `ProjectNames` TODO is dropped.

Comments only, no behaviour change.

## Test plan

- [x] `go build ./...`, `gofmt`, package tests for the two touched packages